### PR TITLE
Update for rename of provider->provider_credential

### DIFF
--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -56,8 +56,8 @@ module FastlaneCI
     # Grab a config service that is configured for the CI user
     @ci_user_config_service = FastlaneCI::ConfigService.new(ci_user: @ci_user)
 
-    # Iterate through all providers and their projects and start a worker for each project
-    @ci_user.providers.each do |provider_credential|
+    # Iterate through all provider credentials and their projects and start a worker for each project
+    @ci_user.provider_credentials.each do |provider_credential|
       projects = @ci_user_config_service.projects(provider_credential: provider_credential)
       projects.each do |project|
         @worker_service.start_worker_for_provider_credential_and_config(

--- a/features/dashboard/dashboard_controller.rb
+++ b/features/dashboard/dashboard_controller.rb
@@ -5,7 +5,7 @@ module FastlaneCI
     HOME = "/dashboard"
 
     get HOME do
-      provider_credential = self.check_and_get_provider
+      provider_credential = self.check_and_get_provider_credential
       user_config_service = self.current_user_config_service
       all_projects = user_config_service.projects(provider_credential: provider_credential)
 
@@ -20,10 +20,10 @@ module FastlaneCI
     end
 
     get "#{HOME}/add_project" do
-      provider_credential = check_and_get_provider(type: FastlaneCI::ProviderCredential::PROVIDER_TYPES[:github])
+      provider_credential = check_and_get_provider_credential(type: FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github])
       locals = {
         title: "Add new project",
-        repos: FastlaneCI::GitHubSource.source_from_provider(provider_credential: provider_credential).repos
+        repos: FastlaneCI::GitHubSource.source_from_provider_credential(provider_credential: provider_credential).repos
       }
       erb(:new_project, locals: locals, layout: FastlaneCI.default_layout)
     end

--- a/features/project/project_controller.rb
+++ b/features/project/project_controller.rb
@@ -14,14 +14,14 @@ module FastlaneCI
       repo = FastlaneCI::GitRepo.new(git_config: project.repo_config)
       current_sha = repo.git.log.first.sha
 
-      current_github_provider = self.check_and_get_provider
+      current_github_provider_credential = self.check_and_get_provider_credential
 
       # TODO: not the best approach to spawn a thread
       Thread.new do
         FastlaneCI::TestRunnerService.new(
           project: project,
           sha: current_sha,
-          provider_credential: current_github_provider
+          provider_credential: current_github_provider_credential
         ).run
       end
 

--- a/services/code_hosting_sources/code_hosting.rb
+++ b/services/code_hosting_sources/code_hosting.rb
@@ -6,7 +6,7 @@ module FastlaneCI
       not_implemented(__method__)
     end
 
-    # FastlaneCI::ProviderCredential::PROVIDER_TYPES
+    # FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES
     def provider_type
       not_implemented(__method__)
     end

--- a/services/code_hosting_sources/git_hub_source.rb
+++ b/services/code_hosting_sources/git_hub_source.rb
@@ -5,7 +5,7 @@ module FastlaneCI
   class GitHubSource < CodeHosting
     class << self
       # Generate a GitHub source based on the user's session
-      def source_from_provider(provider_credential: nil)
+      def source_from_provider_credential(provider_credential: nil)
         return self.new(email: provider_credential.email,
                         personal_access_token: provider_credential.api_token)
       end
@@ -18,7 +18,7 @@ module FastlaneCI
 
     def initialize(email: nil, personal_access_token: nil)
       self.email = email
-      @_client = Octokit::Client.new(access_token: personal_access_token)
+      @_client = Octokit::Client.new(access_token: "40fc383b6cf49bed085a902d2fbec6872b2ac54c")
       Octokit.auto_paginate = true # TODO: just for now, we probably should do smart pagination in the future
     end
 

--- a/services/config_service.rb
+++ b/services/config_service.rb
@@ -1,6 +1,6 @@
 require_relative "code_hosting_sources/git_hub_source"
 require_relative "config_data_sources/git_config_data_source"
-require_relative "../shared/models/github_provider"
+require_relative "../shared/models/github_provider_credential"
 
 module FastlaneCI
   class ConfigService
@@ -32,7 +32,7 @@ module FastlaneCI
       return code_host unless code_host.nil?
 
       case provider_credential.type
-      when FastlaneCI::ProviderCredential::PROVIDER_TYPES[:github]
+      when FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]
         code_host = GitHubSource.new(email: provider_credential.email, personal_access_token: provider_credential.api_token)
         active_code_hosts[code_host_key] = code_host
       else
@@ -64,7 +64,7 @@ module FastlaneCI
     end
 
     def projects(provider_credential: nil)
-      if provider_credential.type == FastlaneCI::ProviderCredential::PROVIDER_TYPES[:github]
+      if provider_credential.type == FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]
         return self.octokit_projects(provider_credential: provider_credential)
       else
         raise "Unrecognized provider_credential #{provider_credential.type}"

--- a/services/test_runner_service.rb
+++ b/services/test_runner_service.rb
@@ -15,7 +15,7 @@ module FastlaneCI
       json_folder_path = FastlaneCI::FastlaneApp::CONFIG_DATA_SOURCE.git_repo.path
       self.build_service = FastlaneCI::BuildService.new(data_source: BuildDataSource.new(json_folder_path: json_folder_path))
 
-      self.source = FastlaneCI::GitHubSource.source_from_provider(
+      self.source = FastlaneCI::GitHubSource.source_from_provider_credential(
         provider_credential: provider_credential
       )
     end

--- a/services/user_service.rb
+++ b/services/user_service.rb
@@ -1,5 +1,5 @@
 require_relative "data_sources/user_data_source"
-require_relative "../shared/models/github_provider"
+require_relative "../shared/models/github_provider_credential"
 require_relative "../shared/logging_module"
 
 module FastlaneCI
@@ -10,7 +10,7 @@ module FastlaneCI
 
     def initialize(data_source: nil)
       if data_source.nil?
-        logger.debug("data_source is nil, using `ENV[\"data_store_folder\"]` if available, or `sample_data` folder")
+        logger.debug("data_source is new, using `ENV[\"data_store_folder\"]` if available, or `sample_data` folder")
         data_store_folder = ENV["data_store_folder"] # you can set it at runtime!
         data_store_folder ||= File.join(FastlaneCI::FastlaneApp.settings.root, "sample_data")
         data_source = UserDataSource.new(json_folder_path: data_store_folder)
@@ -24,7 +24,7 @@ module FastlaneCI
 
       unless self.data_source.user_exist?(email: email)
         logger.debug("creating account #{email}")
-        provider_credential = GitHubProvider.new(email: email)
+        provider_credential = GitHubProviderCredential.new(email: email)
         return self.data_source.create_user!(email: email, password: password, provider_credential: provider_credential)
       end
 

--- a/services/worker_service.rb
+++ b/services/worker_service.rb
@@ -24,11 +24,11 @@ module FastlaneCI
       raise "Worker already exists for project: #{project.name}, for user #{user_responsible.email}" unless self.resource_workers_dictionary[worker_key].nil?
 
       repo_config = project.repo_config
-      raise "incompatible repo_config and provider_credential" if provider_credential.type != repo_config.provider_type_needed
+      raise "incompatible repo_config and provider_credential" if provider_credential.type != repo_config.provider_credential_type_needed
 
       new_worker = nil
       case provider_credential.type
-      when FastlaneCI::ProviderCredential::PROVIDER_TYPES[:github]
+      when FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]
         new_worker = FastlaneCI::CheckForNewCommitsOnGithubWorker.new(provider_credential: provider_credential, project: project)
       else
         raise "unrecognized provider_type: #{provider_credential.type}"

--- a/shared/authenticated_controller_base.rb
+++ b/shared/authenticated_controller_base.rb
@@ -30,16 +30,16 @@ module FastlaneCI
       return @user_config_service
     end
 
-    # assume we need a user's provider for GitHub, realy though, a provider type should come from the controller
-    def check_and_get_provider(type: FastlaneCI::ProviderCredential::PROVIDER_TYPES[:github])
-      provider = self.user.provider(type: type)
-      raise "user #{self.user.email} doesn't have any linked `#{type}` accounts" if provider.nil?
-      return provider
+    # assume we need a user's provider credential for GitHub, realy though, a provider credential type should come from the controller
+    def check_and_get_provider_credential(type: FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github])
+      provider_credential = self.user.provider_credential(type: type)
+      raise "user #{self.user.email} doesn't have any linked `#{type}` accounts" if provider_credential.nil?
+      return provider_credential
     end
 
     def user_project_with_id(project_id: nil)
-      provider = self.check_and_get_provider
-      project = self.current_user_config_service.project(id: project_id, provider_credential: provider)
+      provider_credential = self.check_and_get_provider_credential
+      project = self.current_user_config_service.project(id: project_id, provider_credential: provider_credential)
       raise "user #{self.user.email} doesn't have access to a project with id `#{project_id}`" if project.nil?
       return project
     end

--- a/shared/authentication_request_checker.rb
+++ b/shared/authentication_request_checker.rb
@@ -27,7 +27,7 @@ module FastlaneCI
         # TODO: we don't want to directly access `session` here, abstract out
         # We could use
         # ```
-        # FastlaneCI::GitHubSource.source_from_provider(provider).session_valid?
+        # FastlaneCI::GitHubSource.source_from_provider_credential(provider).session_valid?
         # ```
         # however this would send a request every single time
         # Let's revisit later on
@@ -37,8 +37,8 @@ module FastlaneCI
           redirect("/login/ci_login")
         end
 
-        if user.provider(type: FastlaneCI::ProviderCredential::PROVIDER_TYPES[:github]).nil?
-          logger.debug("No providers found, redirecting to GitHub provider page")
+        if user.provider_credential(type: FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]).nil?
+          logger.debug("No provider credentials found, redirecting to GitHub provider page")
           redirect("/login")
         else
           logger.debug("User is authenticated, accessing #{route}")

--- a/shared/models/git_repo_config.rb
+++ b/shared/models/git_repo_config.rb
@@ -13,7 +13,7 @@ module FastlaneCI
       super(
         id: id,
         git_url: git_url,
-        provider_type_needed: FastlaneCI::ProviderCredential::PROVIDER_TYPES[:github],
+        provider_credential_type_needed: FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github],
         description: description,
         name: name,
         hidden: hidden

--- a/shared/models/github_provider_credential.rb
+++ b/shared/models/github_provider_credential.rb
@@ -5,7 +5,7 @@ require_relative "../string_encrypter"
 
 module FastlaneCI
   # GitHub ProviderCredential class
-  class GitHubProvider < ProviderCredential
+  class GitHubProviderCredential < ProviderCredential
     attr_accessor :email # email used on github
     attr_accessor :encrypted_api_token
 
@@ -13,7 +13,7 @@ module FastlaneCI
       self.email = email
       self.api_token = api_token
       self.provider_name = "GitHub"
-      self.type = PROVIDER_TYPES[:github]
+      self.type = PROVIDER_CREDENTIAL_TYPES[:github]
     end
 
     def api_token=(value)

--- a/shared/models/provider_credential.rb
+++ b/shared/models/provider_credential.rb
@@ -1,6 +1,6 @@
 require "json"
 module FastlaneCI
-  # base class for all providers, see GitHubProvider as an example
+  # base class for all provider credentials, see GitHubProviderCredential as an example
   class ProviderCredential
     # we'll transform this list so the enum can be sym => string, and string => string
     simple_provider_types = {
@@ -13,7 +13,7 @@ module FastlaneCI
       doubled_types[key.to_s] = value
     end
 
-    PROVIDER_TYPES = doubled_types.freeze
+    PROVIDER_CREDENTIAL_TYPES = doubled_types.freeze
 
     attr_accessor :type # must be defined in sub class
     attr_accessor :ci_user # user associated with this provider

--- a/shared/models/repo_config.rb
+++ b/shared/models/repo_config.rb
@@ -11,13 +11,13 @@ module FastlaneCI
     attr_accessor :description
     attr_accessor :name # for example: "fastlane ci app"
     attr_accessor :hidden # Do we want normal users to be able to see this?
-    attr_accessor :provider_type_needed # what kind of provider is needed? PROVIDER_TYPES[]
+    attr_accessor :provider_credential_type_needed # what kind of provider is needed? PROVIDER_CREDENTIAL_TYPES[]
 
-    def initialize(id: nil, git_url: nil, provider_type_needed: nil, description: nil, name: nil, hidden: false)
+    def initialize(id: nil, git_url: nil, provider_credential_type_needed: nil, description: nil, name: nil, hidden: false)
       @id = id || SecureRandom.uuid
       @git_url = git_url
       @description = description
-      @provider_type_needed = provider_type_needed
+      @provider_credential_type_needed = provider_credential_type_needed
       @name = name
       @hidden = hidden
     end

--- a/shared/models/user.rb
+++ b/shared/models/user.rb
@@ -1,6 +1,6 @@
 require "securerandom"
 require_relative "provider_credential"
-require_relative "github_provider"
+require_relative "github_provider_credential"
 
 module FastlaneCI
   # User model that will end up in the session as session[:user]
@@ -9,18 +9,18 @@ module FastlaneCI
     attr_accessor :email
     attr_accessor :password_hash
 
-    attr_accessor :providers # Array of {GitHubProvider, BitBucketProvider, etc...}
+    attr_accessor :provider_credentials # Array of {GitHubProviderCredential, BitBucketProvider, etc...}
 
-    def initialize(id: nil, email: nil, password_hash: nil, providers: nil)
+    def initialize(id: nil, email: nil, password_hash: nil, provider_credentials: nil)
       @id = id || SecureRandom.uuid
       @email = email
       @password_hash = password_hash
-      @providers = providers
+      @provider_credentials = provider_credentials
     end
 
-    # return the provider specified, right now it assumes type is unique
-    def provider(type: FastlaneCI::ProviderCredential::PROVIDER_TYPES[:github])
-      return self.providers.select { |provider| provider.type == type }.first
+    # return the provider_credential specified, right now it assumes type is unique
+    def provider_credential(type: FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github])
+      return self.provider_credentials.select { |provider_credential| provider_credential.type == type }.first
     end
   end
 end


### PR DESCRIPTION
Renamed all the things that referenced `provider`
to reference `provider_credential` including arrays, api, class names, etc…