### PR TITLE
Add doc covering task execution

### DIFF
--- a/docs/TaskExecution.md
+++ b/docs/TaskExecution.md
@@ -1,3 +1,4 @@
+# Task Execution
 ## Background
 By nature fastlane.ci is a task executor service. It has a collection of `projects` that contain rules for when to run and what to run. Task executor services have unique synchronization challenges, here are just a few:
 
@@ -22,11 +23,11 @@ At the highest level, the solution must:
 - be general enough that it can apply to any task
 
 ### Solution
-Utilize a [GCD-like](https://developer.apple.com/documentation/dispatch) mechanism to provide a TaskQueue with a configurable number of workers. Currently implemented in [TaskQueue project](https://github.com/fastlane/TaskQueue). 
+Utilize a [GCD-like](https://developer.apple.com/documentation/dispatch) mechanism to provide a TaskQueue with a configurable number of workers. Currently implemented in [TaskQueue project](https://github.com/fastlane/TaskQueue). The typical GCD workflow consists of submitting blocks of works to a queue with either 1 single worker -which guarantees first in first out execution- or a configurable amount of workers, which constrains the maximum number of tasks that can be executed at once. There are many more use cases for having a work queue, but those two are the most common. In our implementation, we expect:
 
-- Each repo to be associated with a `serial` `TaskQueue`
+- Each repo to be associated with a `serial` `TaskQueue`, so that any task needing to execute can be guaranteed to be executed in the correct order and only after the preceeding task as completed
 - Any work that needs to take place on that repo can be submitted to the queue
 - Every datasource that reads/writes to a file can be associated with a filewriter/reader `serial` `TaskQueue`
-- Where we used threads on a timer to check status, we can now use a timer to submit a `task` to a concurrent queue with a set limit of workers. Before submitting another `task` the timer can check if the previous has been completed
+- Use a timer to submit a `task` to a concurrent queue with a set limit of workers. Before submitting another `task` the timer can check if the previous has been completed
 
 #WIP


### PR DESCRIPTION
We are going to move from task execution on new threads to using a queuing system. This doc covers specifically, what we are looking to solve, why, and the how.