### PR TITLE
Update string_encrypter_spec to stub encryption key

### DIFF
--- a/spec/shared/string_encrypter_spec.rb
+++ b/spec/shared/string_encrypter_spec.rb
@@ -3,6 +3,11 @@ require "string_encrypter"
 
 module FastlaneCI
   describe StringEncrypter do
+    before do
+      encryption_key = "iUjsfjfiU"
+      allow(ENV).to receive(:[]).with("FASTLANE_CI_ENCRYPTION_KEY").and_return(encryption_key)
+    end
+
     describe "string encrypter example" do
       it "should encode, decode, and be the same as the start" do
         hi_string = StringEncrypter.encode("hi", key: "ThisIsAPassword")


### PR DESCRIPTION
Is that by design that the encryption key can be anything for the tests to be green?

If so, feel free to merge. If not, we need to investigate

Fixes https://github.com/fastlane/ci/issues/89