### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,16 @@
+container:
+  image: ruby:2.5
+
+task:
+  bundle_cache:
+    folder: /usr/local/bundle
+    fingerprint_script: cat Gemfile.lock
+    populate_script: bundle install
+  git_script:
+    - git submodule init
+    - git submodule update
+  matrix:
+    - name: rspec
+      rspec_script: bundle exec rspec
+    - name: rubocop
+      rspec_script: bundle exec rubocop -a


### PR DESCRIPTION
Until Fastlane CI can't run CI builds for itself it's reasonable to setup another CI to run `rspec` and `rubocop`.

Cirrus CI and Fastlane CI has a common idea to built the best in the industry experience for backend and mobile projects respectively. They both started in late 2017 and 2018 with modern ideas in mind.

This PR adds Cirrus CI config to run `rspec` and `rubocop` in the official Ruby Docker containers. Since a container has everything pre-installed for running Ruby a Cirrus CI build finishes in a few seconds:

![image](https://user-images.githubusercontent.com/989066/36206922-266d5e56-1162-11e8-8fb5-7fdcd08a318d.png)

This change helped me to find and fix Rubocop violations: https://github.com/fastlane/ci/pull/131

In case of merging this PR don't forget to install [Cirrus CI Github Application](https://github.com/apps/cirrus-ci).