### PR TITLE
ProjectService setup.

### DIFF
--- a/features/project/views/project.erb
+++ b/features/project/views/project.erb
@@ -40,7 +40,7 @@
               <% end %>
             </td>
             <td style="text-align: center;"><%= build.number %></td>
-            <td><%= build.timestamp %></td>
+            <td><%= build.timestamp.strftime("%Y%m%dT%H%M%S%z") %></td>
           </tr>
         <% end %>
       </tbody>

--- a/features/project/views/project.erb
+++ b/features/project/views/project.erb
@@ -40,6 +40,7 @@
               <% end %>
             </td>
             <td style="text-align: center;"><%= build.number %></td>
+            <!-- TODO: Use whichever format for the timestamp desired. -->
             <td><%= build.timestamp.strftime("%Y%m%dT%H%M%S%z") %></td>
           </tr>
         <% end %>

--- a/launch.rb
+++ b/launch.rb
@@ -149,10 +149,6 @@ module FastlaneCI
       provider_credential = GitHubProviderCredential.new(email: ENV["FASTLANE_CI_INITIAL_CLONE_EMAIL"],
                                                        api_token: ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"])
       # Trigger the initial clone
-      # FastlaneCI::JSONProjectDataSource.new(
-      #  git_repo_config: ci_config_repo,
-      #  provider_credential: provider_credential
-      # )
       FastlaneCI::ProjectService.new(
         project_data_source: FastlaneCI::JSONProjectDataSource.create(ci_config_repo,
                                                                       git_repo_config: ci_config_repo,

--- a/launch.rb
+++ b/launch.rb
@@ -149,9 +149,14 @@ module FastlaneCI
       provider_credential = GitHubProviderCredential.new(email: ENV["FASTLANE_CI_INITIAL_CLONE_EMAIL"],
                                                        api_token: ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"])
       # Trigger the initial clone
-      FastlaneCI::JSONProjectDataSource.new(
-        git_repo_config: ci_config_repo,
-        provider_credential: provider_credential
+      # FastlaneCI::JSONProjectDataSource.new(
+      #  git_repo_config: ci_config_repo,
+      #  provider_credential: provider_credential
+      # )
+      FastlaneCI::ProjectService.new(
+        project_data_source: FastlaneCI::JSONProjectDataSource.create(ci_config_repo,
+                                                                      git_repo_config: ci_config_repo,
+                                                                      provider_credential: provider_credential)
       )
       puts("Successfully did the initial clone on this machine")
     rescue StandardError => ex

--- a/services/config_data_sources/json_project_data_source.rb
+++ b/services/config_data_sources/json_project_data_source.rb
@@ -40,8 +40,12 @@ module FastlaneCI
     attr_accessor :git_repo
 
     def after_creation(**params)
-      unless params.nil?
-        if params[:user] or params[:provider_credential]
+      if params.nil?
+        raise "Either user or a provider credential is mandatory."
+      else
+        if !params[:user] && !params[:provider_credential]
+          raise "Either user or a provider credential is mandatory."
+        else
           params[:provider_credential] ||= params[:user].provider_credential(type: ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github])
           @git_repo = FastlaneCI::GitRepo.new(git_config: self.json_folder_path, provider_credential: params[:provider_credential])
         end

--- a/services/config_data_sources/json_project_data_source.rb
+++ b/services/config_data_sources/json_project_data_source.rb
@@ -52,9 +52,6 @@ module FastlaneCI
       end
     end
 
-    def after_creation(params)
-    end
-
     def refresh_repo
       self.git_repo.pull
     end

--- a/services/config_data_sources/json_project_data_source.rb
+++ b/services/config_data_sources/json_project_data_source.rb
@@ -32,6 +32,20 @@ module FastlaneCI
       attr_accessor :projects_file_semaphore
       attr_accessor :repos_file_semaphore
     end
+<<<<<<< refs/remotes/fastlane/master
+=======
+
+    JSONProjectDataSource.projects_file_semaphore = Mutex.new
+    JSONProjectDataSource.repos_file_semaphore = Mutex.new
+
+    # Reference to FastlaneCI::GitRepo
+    attr_accessor :git_repo
+
+    # You can provide either a `user` or `provider_credential`
+    # TODO: should it be just `provider_credential`?
+    def initialize(git_repo_config: nil, user: nil, provider_credential: nil)
+      raise "No git_repo_config provided" if git_repo_config.nil?
+>>>>>>> minuscorp-ProjectService~12
 
     JSONProjectDataSource.projects_file_semaphore = Mutex.new
     JSONProjectDataSource.repos_file_semaphore = Mutex.new
@@ -79,7 +93,11 @@ module FastlaneCI
         path = self.git_repo.file_path("repos.json")
         return [] unless File.exist?(path)
 
+<<<<<<< refs/remotes/fastlane/master
         saved_git_repos = JSON.parse(File.read(path)).map(&GitRepoConfig.method(:from_json!))
+=======
+        saved_git_repos = JSON.parse(File.read(path)).map { |repo_config_hash| GitRepoConfig.from_json!(repo_config_hash) }
+>>>>>>> minuscorp-ProjectService~12
         return saved_git_repos
       end
     end
@@ -89,6 +107,7 @@ module FastlaneCI
         path = self.git_repo.file_path("repos.json")
         File.write(path, JSON.pretty_generate(git_repo_configs.map(&:to_object_dictionary)))
       end
+<<<<<<< refs/remotes/fastlane/master
     end
 
     def create_project!(name: nil, repo_config: nil, enabled: nil, lane: nil)
@@ -135,6 +154,8 @@ module FastlaneCI
         logger.debug("Updating project #{existing_project.project_name}, writing out to projects.json to #{json_folder_path}")
         @projects[project_index] = project
       end
+=======
+>>>>>>> minuscorp-ProjectService~12
     end
   end
 end

--- a/services/config_data_sources/json_project_data_source.rb
+++ b/services/config_data_sources/json_project_data_source.rb
@@ -52,6 +52,9 @@ module FastlaneCI
       end
     end
 
+    def after_creation(params)
+    end
+
     def refresh_repo
       self.git_repo.pull
     end
@@ -135,29 +138,6 @@ module FastlaneCI
         logger.debug("Updating project #{existing_project.project_name}, writing out to projects.json to #{json_folder_path}")
         @projects[project_index] = project
       end
-    end
-
-    def create_project!(name: nil, repo_config: nil, enabled: nil, lane: nil)
-      projects = self.projects
-      new_project = Project.new(repo_config: repo_config,
-                                enabled: enabled,
-                                project_name: name,
-                                lane: lane)
-      if self.project_exist?(new_project.project_name)
-        projects.push(new_project)
-        self.projects = projects
-        logger.debug("Added project #{new_project.project_name} to projets.json in #{self.json_folder_path}")
-        return new_project
-      else
-        logger.debug("Couldn't add project #{new_project.project_name} because it already exists")
-        return nil
-      end
-    end
-
-    # Define that the name of the project must be unique
-    def project_exist?(name: nil)
-      project = self.projects.select { |existing_project| existing_project.project_name.casecmp(name.downcase).zero? }.first
-      return !project.nil?
     end
   end
 end

--- a/services/config_data_sources/json_project_data_source.rb
+++ b/services/config_data_sources/json_project_data_source.rb
@@ -1,4 +1,5 @@
 require_relative "project_data_source"
+require_relative "../data_sources/json_data_source"
 require_relative "../../shared/json_convertible"
 require_relative "../../shared/models/git_repo"
 require_relative "../../shared/models/git_repo_config"
@@ -19,6 +20,7 @@ module FastlaneCI
 
   # (default) Store configuration in git
   class JSONProjectDataSource < ProjectDataSource
+    include FastlaneCI::JSONDataSource
     include FastlaneCI::Logging
 
     # Reference to FastlaneCI::GitRepo

--- a/services/config_data_sources/json_project_data_source.rb
+++ b/services/config_data_sources/json_project_data_source.rb
@@ -32,20 +32,6 @@ module FastlaneCI
       attr_accessor :projects_file_semaphore
       attr_accessor :repos_file_semaphore
     end
-<<<<<<< refs/remotes/fastlane/master
-=======
-
-    JSONProjectDataSource.projects_file_semaphore = Mutex.new
-    JSONProjectDataSource.repos_file_semaphore = Mutex.new
-
-    # Reference to FastlaneCI::GitRepo
-    attr_accessor :git_repo
-
-    # You can provide either a `user` or `provider_credential`
-    # TODO: should it be just `provider_credential`?
-    def initialize(git_repo_config: nil, user: nil, provider_credential: nil)
-      raise "No git_repo_config provided" if git_repo_config.nil?
->>>>>>> minuscorp-ProjectService~12
 
     JSONProjectDataSource.projects_file_semaphore = Mutex.new
     JSONProjectDataSource.repos_file_semaphore = Mutex.new
@@ -93,11 +79,7 @@ module FastlaneCI
         path = self.git_repo.file_path("repos.json")
         return [] unless File.exist?(path)
 
-<<<<<<< refs/remotes/fastlane/master
         saved_git_repos = JSON.parse(File.read(path)).map(&GitRepoConfig.method(:from_json!))
-=======
-        saved_git_repos = JSON.parse(File.read(path)).map { |repo_config_hash| GitRepoConfig.from_json!(repo_config_hash) }
->>>>>>> minuscorp-ProjectService~12
         return saved_git_repos
       end
     end
@@ -107,7 +89,6 @@ module FastlaneCI
         path = self.git_repo.file_path("repos.json")
         File.write(path, JSON.pretty_generate(git_repo_configs.map(&:to_object_dictionary)))
       end
-<<<<<<< refs/remotes/fastlane/master
     end
 
     def create_project!(name: nil, repo_config: nil, enabled: nil, lane: nil)
@@ -154,8 +135,17 @@ module FastlaneCI
         logger.debug("Updating project #{existing_project.project_name}, writing out to projects.json to #{json_folder_path}")
         @projects[project_index] = project
       end
-=======
->>>>>>> minuscorp-ProjectService~12
+    end
+
+    def create_project!(name: nil, repo_config: nil, enabled: nil, lane: nil)
+      projects = self.projects
+      new_project = Project.new(repo_config: repo_config,
+                                enabled: enabled,
+                                project_name: name,
+                                lane: lane)
+      projects.push(new_project)
+      self.projects = projects
+      return new_project
     end
   end
 end

--- a/services/config_data_sources/json_project_data_source.rb
+++ b/services/config_data_sources/json_project_data_source.rb
@@ -88,5 +88,16 @@ module FastlaneCI
         File.write(path, JSON.pretty_generate(git_repo_configs.map(&:to_object_dictionary)))
       end
     end
+
+    def create_project!(name: nil, repo_config: nil, enabled: nil, lane: nil)
+      projects = self.projects
+      new_project = Project.new(repo_config: repo_config,
+                                enabled: enabled,
+                                project_name: name,
+                                lane: lane)
+      projects.push(new_project)
+      self.projects = projects
+      return new_project
+    end
   end
 end

--- a/services/config_data_sources/json_project_data_source.rb
+++ b/services/config_data_sources/json_project_data_source.rb
@@ -143,9 +143,21 @@ module FastlaneCI
                                 enabled: enabled,
                                 project_name: name,
                                 lane: lane)
-      projects.push(new_project)
-      self.projects = projects
-      return new_project
+      if self.project_exist?(new_project.project_name)
+        projects.push(new_project)
+        self.projects = projects
+        logger.debug("Added project #{new_project.project_name} to projets.json in #{self.json_folder_path}")
+        return new_project
+      else
+        logger.debug("Couldn't add project #{new_project.project_name} because it already exists")
+        return nil
+      end
+    end
+
+    # Define that the name of the project must be unique
+    def project_exist?(name: nil)
+      project = self.projects.select { |existing_project| existing_project.project_name.casecmp(name.downcase).zero? }.first
+      return !project.nil?
     end
   end
 end

--- a/services/config_data_sources/project_data_source.rb
+++ b/services/config_data_sources/project_data_source.rb
@@ -16,5 +16,9 @@ module FastlaneCI
     def save_git_repo_configs!(git_repo_configs: nil)
       not_implemented(__method__)
     end
+
+    def create_project!(name: nil, repo_config: nil, enabled: nil, lane: nil)
+      not_implemented(__method__)
+    end
   end
 end

--- a/services/config_data_sources/project_data_source.rb
+++ b/services/config_data_sources/project_data_source.rb
@@ -9,7 +9,7 @@ module FastlaneCI
       not_implemented(__method__)
     end
 
-    def refresh_repo(project: nil)
+    def refresh_repo
       not_implemented(__method__)
     end
 

--- a/services/config_data_sources/project_data_source.rb
+++ b/services/config_data_sources/project_data_source.rb
@@ -9,7 +9,7 @@ module FastlaneCI
       not_implemented(__method__)
     end
 
-    def refresh_repo
+    def refresh_repo(project: nil)
       not_implemented(__method__)
     end
 

--- a/services/config_data_sources/project_data_source.rb
+++ b/services/config_data_sources/project_data_source.rb
@@ -20,5 +20,9 @@ module FastlaneCI
     def create_project!(name: nil, repo_config: nil, enabled: nil, lane: nil)
       not_implemented(__method__)
     end
+
+    def update_project!(project: nil)
+      not_implemented(__method__)
+    end
   end
 end

--- a/services/config_service.rb
+++ b/services/config_service.rb
@@ -8,12 +8,12 @@ module FastlaneCI
   class ConfigService
     include FastlaneCI::Logging
 
-    attr_accessor :project_data_source
+    attr_accessor :project_service
     attr_accessor :ci_user
     attr_accessor :active_code_hosting_services # dictionary of active_code_hosting_service_key to CodeHosting
 
-    def initialize(project_data_source: FastlaneCI::Services.project_data_source, ci_user: nil)
-      self.project_data_source = project_data_source
+    def initialize(project_service: FastlaneCI::Services.project_service, ci_user: nil)
+      self.project_service = project_service
       self.ci_user = ci_user
       self.active_code_hosting_services = {}
     end
@@ -67,7 +67,7 @@ module FastlaneCI
       if ENV["FASTLANE_CI_SUPER_VERBOSE"]
         logger.debug("Finding projects we have access to with #{provider_credential.ci_user.email}, #{provider_credential.type}")
       end
-      projects = self.project_data_source.projects.select do |project|
+      projects = self.project_service.projects.select do |project|
         current_repo_git_url_set.include?(project.repo_config.git_url)
       end
 

--- a/services/data_sources/json_build_data_source.rb
+++ b/services/data_sources/json_build_data_source.rb
@@ -18,7 +18,7 @@ module FastlaneCI
 
     def self.json_to_attribute_name_proc_map
       seconds_to_datetime_proc = proc { |seconds|
-        DateTime.parse(Time.at(seconds).to_s)
+        Time.at(seconds.to_i)
       }
       return { :@timestamp => seconds_to_datetime_proc }
     end

--- a/services/data_sources/json_data_source.rb
+++ b/services/data_sources/json_data_source.rb
@@ -1,7 +1,6 @@
 module FastlaneCI
   # define a simple initialization of instances which rely on a JSON file
   module JSONDataSource
-
     def self.included(base)
       base.send(:include, InstanceMethods)
       base.extend(ClassMethods)

--- a/services/data_sources/json_data_source.rb
+++ b/services/data_sources/json_data_source.rb
@@ -1,0 +1,14 @@
+module FastlaneCI
+  # define a simple initialization of instances which rely on a JSON file
+  module JSONDataSource
+    attr_accessor :json_folder_path
+
+    # add these as class methods
+    module ClassMethods
+      def create(json_folder_path)
+        instance = self.new
+        instance.json_folder_path = json_folder_path
+      end
+    end
+  end
+end

--- a/services/data_sources/json_data_source.rb
+++ b/services/data_sources/json_data_source.rb
@@ -1,14 +1,27 @@
 module FastlaneCI
   # define a simple initialization of instances which rely on a JSON file
   module JSONDataSource
+
+    def self.included(base)
+      base.send(:include, InstanceMethods)
+      base.extend(ClassMethods)
+    end
+
     attr_accessor :json_folder_path
 
     # add these as class methods
     module ClassMethods
-      def create(json_folder_path)
+      def create(json_folder_path: nil, params: nil)
         instance = self.new
         instance.json_folder_path = json_folder_path
+        instance.after_creation(params)
         return instance
+      end
+    end
+
+    # add this as instance methods
+    module InstanceMethods
+      def after_creation(params)
       end
     end
   end

--- a/services/data_sources/json_data_source.rb
+++ b/services/data_sources/json_data_source.rb
@@ -8,6 +8,7 @@ module FastlaneCI
       def create(json_folder_path)
         instance = self.new
         instance.json_folder_path = json_folder_path
+        return instance
       end
     end
   end

--- a/services/data_sources/json_data_source.rb
+++ b/services/data_sources/json_data_source.rb
@@ -11,7 +11,7 @@ module FastlaneCI
 
     # add these as class methods
     module ClassMethods
-      def create(json_folder_path: nil, params: nil)
+      def create(json_folder_path, **params)
         instance = self.new
         instance.json_folder_path = json_folder_path
         instance.after_creation(params)
@@ -21,7 +21,7 @@ module FastlaneCI
 
     # add this as instance methods
     module InstanceMethods
-      def after_creation(params)
+      def after_creation(**params)
       end
     end
   end

--- a/services/data_sources/json_data_source.rb
+++ b/services/data_sources/json_data_source.rb
@@ -11,6 +11,12 @@ module FastlaneCI
 
     # add these as class methods
     module ClassMethods
+      # Factory method, all JSON-based data sources rely on different
+      # JSON files stored in the `json_folder_path` directory.
+      #
+      # @param [String] json_folder_path
+      # @param [any] **params
+      # @return [JSONDataSource]
       def create(json_folder_path, **params)
         instance = self.new
         instance.json_folder_path = json_folder_path
@@ -21,6 +27,9 @@ module FastlaneCI
 
     # add this as instance methods
     module InstanceMethods
+      # Post-initialization method. This method is optionally
+      # overridden by `JSONDataSource`s in order to get injected
+      # different parameters that are mandatory for its initialization.
       def after_creation(**params)
       end
     end

--- a/services/data_sources/json_user_data_source.rb
+++ b/services/data_sources/json_user_data_source.rb
@@ -31,13 +31,11 @@ module FastlaneCI
     # can't have us reading and writing to a file at the same time
     JSONUserDataSource.file_semaphore = Mutex.new
 
-    def initialize(json_folder_path: nil)
-      instance = self.class.create(json_folder_path: json_folder_path)
+    def after_creation(params)
       logger.debug("Using folder path for user data: #{json_folder_path}")
       # load up the json file here
       # parse all data into objects so we can fail fast on error
-      instance.reload_users
-      return instance
+      self.reload_users
     end
 
     def user_file_path(path: "users.json")

--- a/services/data_sources/json_user_data_source.rb
+++ b/services/data_sources/json_user_data_source.rb
@@ -31,7 +31,7 @@ module FastlaneCI
     # can't have us reading and writing to a file at the same time
     JSONUserDataSource.file_semaphore = Mutex.new
 
-    def after_creation(params)
+    def after_creation(*params)
       logger.debug("Using folder path for user data: #{json_folder_path}")
       # load up the json file here
       # parse all data into objects so we can fail fast on error

--- a/services/data_sources/json_user_data_source.rb
+++ b/services/data_sources/json_user_data_source.rb
@@ -1,5 +1,6 @@
 require "bcrypt"
 require "securerandom"
+require_relative "json_data_source"
 require_relative "user_data_source"
 require_relative "../../shared/logging_module"
 require_relative "../../shared/json_convertible"
@@ -20,9 +21,8 @@ module FastlaneCI
 
   # Data source for users backed by JSON
   class JSONUserDataSource < UserDataSource
+    include FastlaneCI::JSONDataSource
     include FastlaneCI::Logging
-
-    attr_accessor :json_folder_path
 
     class << self
       attr_accessor :file_semaphore
@@ -32,11 +32,12 @@ module FastlaneCI
     JSONUserDataSource.file_semaphore = Mutex.new
 
     def initialize(json_folder_path: nil)
-      @json_folder_path = json_folder_path
+      instance = self.class.create(json_folder_path: json_folder_path)
       logger.debug("Using folder path for user data: #{json_folder_path}")
       # load up the json file here
       # parse all data into objects so we can fail fast on error
-      reload_users
+      instance.reload_users
+      return instance
     end
 
     def user_file_path(path: "users.json")

--- a/services/project_service.rb
+++ b/services/project_service.rb
@@ -3,6 +3,7 @@ require_relative "../shared/../shared/models/repo_config"
 require_relative "../shared/logging_module"
 
 module FastlaneCI
+  # Provides access to projects
   class ProjectService
     include FastlaneCI::Logging
     attr_accessor :project_data_source

--- a/services/project_service.rb
+++ b/services/project_service.rb
@@ -1,0 +1,23 @@
+require_relative "config_data_sources/json_project_data_source"
+require_relative "../shared/logging_module"
+
+module FastlaneCI
+  class ProjectService
+    include FastlaneCI::Logging
+    attr_accessor :project_data_source
+
+    def initialize(project_data_source: nil)
+      unless project_data_source.nil?
+        raise "project_data_source must be descendant of #{ProjectDataSource.name}" unless project_data_source.class <= ProjectDataSource
+      end
+
+      if project_data_source.nil?
+        # Default to JSONProjectDataSource
+        logger.debug("project_data_source is new, using `ENV[\"data_store_folder\"]` if available, or `sample_data` folder")
+        data_store_folder = ENV["data_store_folder"]
+        data_store_folder ||= File.join(FastlaneCI::FastlaneApp.settings.root, "sample_data")
+      end
+
+    end
+  end
+end

--- a/services/services.rb
+++ b/services/services.rb
@@ -2,6 +2,7 @@ require_relative "./config_data_sources/json_project_data_source"
 require_relative "./config_service"
 require_relative "./worker_service"
 require_relative "./user_service"
+require_relative "./project_service"
 require_relative "./data_sources/json_user_data_source"
 require_relative "./data_sources/json_build_data_source"
 require_relative "./code_hosting/git_hub_service"
@@ -20,7 +21,7 @@ module FastlaneCI
         # TODO: Verify that we actually need to do this
         @_user_service = nil
         @_build_service = nil
-        @_project_data_source = nil
+        @_project_service = nil
         @_ci_user = nil
         @_config_service = nil
         @_worker_service = nil
@@ -47,23 +48,22 @@ module FastlaneCI
       )
     end
 
-    # Start our project data source
-    # TODO: this should be accessed through a ProjectDataService
-    def self.project_data_source
-      @_project_data_source ||= FastlaneCI::JSONProjectDataSource.new(
-        git_repo_config: ci_config_repo,
-        user: ci_user
-      )
-    end
-
     ########################################################
     # Services that we provide
     ########################################################
 
+    # Start up a ProjectService from our JSONProjectDataSource
+    def self.project_service
+      @_project_service ||= FastlaneCI::ProjectService.new(
+        project_data_source: FastlaneCI::JSONProjectDataSource.create(ci_config_repo,
+                                                                      user: ci_user)
+      )
+    end
+
     # Start up a UserService from our JSONUserDataSource
     def self.user_service
       @_user_service ||= FastlaneCI::UserService.new(
-        user_data_source: JSONUserDataSource.create(json_folder_path: ci_config_git_repo_path)
+        user_data_source: FastlaneCI::JSONUserDataSource.create(ci_config_git_repo_path)
       )
     end
 

--- a/services/services.rb
+++ b/services/services.rb
@@ -63,7 +63,7 @@ module FastlaneCI
     # Start up a UserService from our JSONUserDataSource
     def self.user_service
       @_user_service ||= FastlaneCI::UserService.new(
-        user_data_source: JSONUserDataSource.new(json_folder_path: ci_config_git_repo_path)
+        user_data_source: JSONUserDataSource.create(json_folder_path: ci_config_git_repo_path)
       )
     end
 

--- a/services/test_runner_service.rb
+++ b/services/test_runner_service.rb
@@ -79,7 +79,7 @@ module FastlaneCI
       )
 
       # Commit & Push the changes to git remote
-      FastlaneCI::Services.project_data_source.git_repo.commit_changes!
+      FastlaneCI::Services.project_service.git_repo.commit_changes!
     rescue StandardError => ex
       logger.error("Error setting the build status as part of the config repo")
       logger.error(ex.to_s)

--- a/services/user_service.rb
+++ b/services/user_service.rb
@@ -18,7 +18,7 @@ module FastlaneCI
         logger.debug("user_data_source is new, using `ENV[\"data_store_folder\"]` if available, or `sample_data` folder")
         data_store_folder = ENV["data_store_folder"] # you can set it at runtime!
         data_store_folder ||= File.join(FastlaneCI::FastlaneApp.settings.root, "sample_data")
-        user_data_source = JSONUserDataSource.new(json_folder_path: data_store_folder)
+        user_data_source = JSONUserDataSource.create(json_folder_path: data_store_folder)
       end
 
       self.user_data_source = user_data_source

--- a/shared/json_convertible.rb
+++ b/shared/json_convertible.rb
@@ -50,8 +50,8 @@ module FastlaneCI
           else
             var_name = "@#{var}".to_sym
           end
-          if self.json_to_attribute_name_proc_map.key?(var)
-            var_value = self.json_to_attribute_name_proc_map[var].call(val)
+          if self.json_to_attribute_name_proc_map.key?(var_name)
+            var_value = self.json_to_attribute_name_proc_map[var_name].call(val)
           else
             var_value = val
           end

--- a/spec/shared/json_convertible_spec.rb
+++ b/spec/shared/json_convertible_spec.rb
@@ -70,7 +70,7 @@ module FastlaneCI
     end
 
     it "Allows to decode from a dictionary object using custom value mapping" do
-      allow(MockJSONConvertible).to receive(:json_to_attribute_name_proc_map).and_return({ :@other_attribute => proc { |timestamp| Time.parse(timestamp) } })
+      allow(MockJSONConvertible).to receive(:json_to_attribute_name_proc_map).and_return({ :@other_attribute => proc { |timestamp| Time.at(timestamp) } })
       object = MockJSONConvertible.from_json!({ "one_attribute" => "Hello", "other_attribute" => Time.at(0) })
       expect(object.one_attribute).to eql("Hello")
       expect(object.other_attribute).to eql(Time.at(0))
@@ -78,7 +78,7 @@ module FastlaneCI
 
     it "Allows to decode from a dictionary object using both custom value mapping and custom porperty mapping" do
       allow(MockJSONConvertible).to receive(:attribute_key_name_map).and_return({ :@one_attribute => "json_one_attribute", :@other_attribute => "json_other_attribute" })
-      allow(MockJSONConvertible).to receive(:json_to_attribute_name_proc_map).and_return({ :@other_attribute => proc { |timestamp| Time.parse(timestamp) } })
+      allow(MockJSONConvertible).to receive(:json_to_attribute_name_proc_map).and_return({ :@other_attribute => proc { |timestamp| Time.at(timestamp) } })
       object = MockJSONConvertible.from_json!({ "json_one_attribute" => "Hello", "json_other_attribute" => Time.at(0) })
       expect(object.one_attribute).to eql("Hello")
       expect(object.other_attribute).to eql(Time.at(0))

--- a/workers/refresh_config_data_sources_worker.rb
+++ b/workers/refresh_config_data_sources_worker.rb
@@ -5,7 +5,7 @@ module FastlaneCI
   # in the background, every x seconds
   class RefreshConfigDataSourcesWorker < WorkerBase
     def work
-      FastlaneCI::Services.project_data_source.refresh_repo
+      FastlaneCI::Services.project_service.refresh_repo
     end
 
     def sleep_interval


### PR DESCRIPTION
So this PR tries to cover the following objectives:

- Generalize the `JSONDataSource` using a mixin that can be included by any `SomeModelJSONDataSource`.

- Using this pattern, all models that have a `JSONDataSource`, should include the mixin.

- At the end of this, we can achieve that `ProjectService` is created, using `ProjectJSONDataSource`. 

I have some questions regarding how this can be achieved but we can break this in little pieces so it’s easier to work on.