### PR TITLE
Synchronize all git actions

### DIFF
--- a/services/data_sources/json_build_data_source.rb
+++ b/services/data_sources/json_build_data_source.rb
@@ -52,7 +52,7 @@ module FastlaneCI
       containing_path = builds_path(project: project)
       full_path = File.join(containing_path, "#{build.number}.json")
 
-      puts("Writing to '#{full_path}'")
+      logger.debug("Writing to '#{full_path}'")
       hash_to_store = build.to_object_dictionary(ignore_instance_variables: [:@project])
       FileUtils.mkdir_p(containing_path)
       File.write(full_path, JSON.pretty_generate(hash_to_store))

--- a/services/worker_service.rb
+++ b/services/worker_service.rb
@@ -26,6 +26,7 @@ module FastlaneCI
       repo_config = project.repo_config
       raise "incompatible repo_config and provider_credential" if provider_credential.type != repo_config.provider_credential_type_needed
 
+      logger.debug("Starting worker for #{project.project_name}, on behalf of #{user_responsible.email}")
       new_worker = nil
       case provider_credential.type
       when FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]
@@ -35,7 +36,6 @@ module FastlaneCI
       end
 
       self.resource_workers_dictionary[worker_key] = new_worker
-      logger.debug("Starting worker for #{project.project_name}, on behalf of #{user_responsible.email}")
     end
 
     def stop_worker(project: nil, user_responsible: nil)

--- a/workers/refresh_config_data_sources_worker.rb
+++ b/workers/refresh_config_data_sources_worker.rb
@@ -8,7 +8,7 @@ module FastlaneCI
       FastlaneCI::Services.project_data_source.refresh_repo
     end
 
-    def timeout
+    def sleep_interval
       15
     end
   end

--- a/workers/worker_base.rb
+++ b/workers/worker_base.rb
@@ -2,7 +2,7 @@ require_relative "../shared/logging_module"
 
 module FastlaneCI
   # super class for all fastlane.ci workers
-  # Subclass this class, and implement `work` and `timeout`
+  # Subclass this class, and implement `work` and `sleep_interval`
   class WorkerBase
     include FastlaneCI::Logging
 
@@ -19,13 +19,10 @@ module FastlaneCI
 
     def initialize
       self.should_stop = false
-      # TODO: investigate what `abort_on_exception` does
-      #   and what to use it for
-      # Thread.abort_on_exception = true
 
       @thread = Thread.new do
         until self.should_stop
-          Kernel.sleep(self.timeout)
+          Kernel.sleep(self.sleep_interval)
 
           # We have the `work` inside a `begin rescue`
           # so that if something fails, the thread still is alive
@@ -54,8 +51,8 @@ module FastlaneCI
       @should_stop = true
     end
 
-    # Timeout in seconds
-    def timeout
+    # Sleep in seconds
+    def sleep_interval
       not_implemented(__method__)
     end
   end


### PR DESCRIPTION
You can’t thread the git gem, so we need to make sure we only work with git one thread at a time.