### PR TITLE
#52 - re-run pending builds on server initialization.

### DIFF
--- a/launch.rb
+++ b/launch.rb
@@ -1,3 +1,5 @@
+require_relative "taskqueue/task_queue"
+
 module FastlaneCI
   # Launch is responsible for spawning up the whole
   # fastlane.ci server, this includes all needed classes
@@ -14,6 +16,7 @@ module FastlaneCI
       check_for_existing_setup
       prepare_server
       launch_workers
+      run_pending_builds
     end
 
     def self.require_fastlane_ci
@@ -133,26 +136,42 @@ module FastlaneCI
       FastlaneCI::RefreshConfigDataSourcesWorker.new
     end
 
+    # In the event of a server crash, we want to run pending builds on server
+    # initialization for all projects for the provider credentials
+    #
+    # @return [nil]
+    def self.run_pending_builds
+      task_queue = TaskQueue::TaskQueue.new(name: "run_pending_builds")
+      projects = Services.config_service.projects(provider_credential: self.provider_credential)
+      github_service = FastlaneCI::GitHubService.new(provider_credential: self.provider_credential)
+
+      # For each project, rerun all builds with the status of "pending"
+      projects.each do |project|
+        pending_builds = Services.build_service.pending_builds(project: project)
+        repo = FastlaneCI::GitRepo.new(git_config: project.repo_config, provider_credential: self.provider_credential)
+        current_sha = repo.most_recent_commit.sha
+        runner_service = FastlaneCI::TestRunnerService.new(project: project, sha: current_sha, github_service: github_service)
+
+        # Enqueue each pending build rerun in an asynchronous task queue
+        pending_builds.each do |build|
+          task = TaskQueue::Task.new(work_block: proc { runner_service.rerun(build) })
+          task_queue.add_task_async(task: task)
+        end
+      end
+    end
+
     # Verify that fastlane.ci is already set up on this machine.
     # If that's not the case, we have to make sure to trigger the initial clone
     def self.trigger_initial_ci_setup
       puts("No config repo cloned yet, doing that now") # TODO: use logger if possible
 
-      # This happens on the first launch of CI
-      # We don't have access to the config directory yet
-      # So we'll use ENV variables that are used for the initial clone only
-      #
-      # Long term, we'll have a nice onboarding flow, where you can enter those credentials
-      # as part of a web UI. But for containers (e.g. Google Cloud App Engine)
-      # we'll have to support ENV variables also, for the initial clone, so that's the code below
-      # Clone the repo, and login the user
-      provider_credential = GitHubProviderCredential.new(email: ENV["FASTLANE_CI_INITIAL_CLONE_EMAIL"],
-                                                       api_token: ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"])
       # Trigger the initial clone
       FastlaneCI::ProjectService.new(
-        project_data_source: FastlaneCI::JSONProjectDataSource.create(ci_config_repo,
-                                                                      git_repo_config: ci_config_repo,
-                                                                      provider_credential: provider_credential)
+        project_data_source: FastlaneCI::JSONProjectDataSource.create(
+          ci_config_repo,
+          git_repo_config: ci_config_repo,
+          provider_credential: self.provider_credential
+        )
       )
       puts("Successfully did the initial clone on this machine")
     rescue StandardError => ex
@@ -163,6 +182,23 @@ module FastlaneCI
       end
 
       raise ex
+    end
+
+    # This happens on the first launch of CI
+    # We don't have access to the config directory yet
+    # So we'll use ENV variables that are used for the initial clone only
+    #
+    # Long term, we'll have a nice onboarding flow, where you can enter those credentials
+    # as part of a web UI. But for containers (e.g. Google Cloud App Engine)
+    # we'll have to support ENV variables also, for the initial clone, so that's the code below
+    # Clone the repo, and login the user
+    #
+    # @return [GitHubProviderCredential]
+    def self.provider_credential
+      @provider_credential ||= GitHubProviderCredential.new(
+        email: ENV["FASTLANE_CI_INITIAL_CLONE_EMAIL"],
+        api_token: ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"]
+      )
     end
   end
 end

--- a/services/build_service.rb
+++ b/services/build_service.rb
@@ -17,6 +17,10 @@ module FastlaneCI
       self.build_data_source.list_builds(project: project)
     end
 
+    def pending_builds(project: nil)
+      self.build_data_source.pending_builds(project: project)
+    end
+
     def add_build!(project: nil, build: nil)
       self.build_data_source.add_build!(project: project, build: build)
 

--- a/services/code_hosting/git_hub_service.rb
+++ b/services/code_hosting/git_hub_service.rb
@@ -44,7 +44,7 @@ module FastlaneCI
     # Does the client with the associated credentials have access to the specified repo?
     # @repo [String] Repo URL as string
     def access_to_repo?(repo_url: nil)
-      client.repository?(repo_url.sub("https://github.com/",""))
+      client.repository?(repo_url.sub("https://github.com/", ""))
     end
 
     # The `target_url`, `description` and `context` parameters are optional

--- a/services/config_service.rb
+++ b/services/config_service.rb
@@ -51,10 +51,10 @@ module FastlaneCI
 
     def octokit_projects(provider_credential: nil)
       # Get a list of all the repos `provider` has access to
-      logger.debug("Getting code host for #{provider_credential.ci_user.email}, #{provider_credential.type}")
+      logger.debug("Getting code host for #{provider_credential.ci_user.email}, #{provider_credential.type}") if provider_credential.ci_user
       current_code_hosting_service = self.code_hosting_service(provider_credential: provider_credential)
 
-      logger.debug("Finding projects we have access to with #{provider_credential.ci_user.email}, #{provider_credential.type}")
+      logger.debug("Finding projects we have access to with #{provider_credential.ci_user.email}, #{provider_credential.type}") if provider_credential.ci_user
       projects = self.project_service.projects.select do |project|
         current_code_hosting_service.access_to_repo?(repo_url: project.repo_config.git_url)
       end

--- a/services/data_sources/build_data_source.rb
+++ b/services/data_sources/build_data_source.rb
@@ -6,6 +6,11 @@ module FastlaneCI
       not_implemented(__method__)
     end
 
+    # Array of all builds for the given project that have the status `pending`
+    def pending_builds(project: nil)
+      not_implemented(__method__)
+    end
+
     # Add or update a build
     def add_build!(project: nil, build: nil)
       not_implemented(__method__)

--- a/services/data_sources/json_user_data_source.rb
+++ b/services/data_sources/json_user_data_source.rb
@@ -88,7 +88,7 @@ module FastlaneCI
       user_password = BCrypt::Password.new(user.password_hash)
 
       # sweet, it matches, return the user
-      if user_password == password
+      if user_password.to_s == password
         logger.debug("user #{email} authenticated")
         return user
       end

--- a/services/services.rb
+++ b/services/services.rb
@@ -70,7 +70,7 @@ module FastlaneCI
     # Start up the BuildService
     def self.build_service
       @_build_service ||= FastlaneCI::BuildService.new(
-        build_data_source: JSONBuildDataSource.new(json_folder_path: ci_config_git_repo_path)
+        build_data_source: JSONBuildDataSource.create(ci_config_git_repo_path)
       )
     end
 

--- a/services/test_runner_service.rb
+++ b/services/test_runner_service.rb
@@ -21,6 +21,10 @@ module FastlaneCI
       self.code_hosting_service = github_service
     end
 
+    # Runs a new build, incrementing the build number from the number of builds
+    # for a given project
+    #
+    # @return [nil]
     def run
       start_time = Time.now
       builds = build_service.list_builds(project: self.project)
@@ -39,6 +43,38 @@ module FastlaneCI
         duration: -1,
         sha: self.sha
       )
+      update_build_status!
+
+      # TODO: Replace with fastlane runner here
+      command = "rubocop #{project.repo_config.local_repo_path}"
+      logger.info("Running #{command}")
+
+      cmd = TTY::Command.new
+      cmd.run(command)
+
+      duration = Time.now - start_time
+
+      current_build.duration = duration
+      current_build.status = :success
+
+      self.update_build_status!
+    rescue StandardError => ex
+      # TODO: better error handling, don't catch all Exception
+      puts(ex)
+      duration = Time.now - start_time
+      current_build.duration = duration
+      current_build.status = :failure # TODO: also handle failure
+      self.update_build_status!
+    end
+
+    # Re-runs a build passed in, does not modify the build number
+    #
+    # @param  [Build] build
+    # @return [nil]
+    def rerun(build = nil)
+      start_time = Time.now
+
+      self.current_build = build
       update_build_status!
 
       # TODO: Replace with fastlane runner here

--- a/spec/helper_functions.rb
+++ b/spec/helper_functions.rb
@@ -1,0 +1,27 @@
+module HelperFunctions
+  def provider_credential
+    FastlaneCI::GitHubProviderCredential.new(email: "test_user", api_token: nil)
+  end
+
+  def git_repo
+    FastlaneCI::GitRepoConfig.new(
+      id: "fastlane-ci-config",
+      git_url: "https://github.com/fake_user/fake_config",
+      description: "Contains the fastlane.ci configuration",
+      name: "fastlane ci",
+      hidden: true
+    )
+  end
+
+  def git_repo_path
+    git_repo.local_repo_path
+  end
+
+  def ci_user
+    FastlaneCI::User.new(
+      email: "test_user",
+      password_hash: "password_hash",
+      provider_credentials: [provider_credential]
+    )
+  end
+end

--- a/spec/services/test_runner_service_spec.rb
+++ b/spec/services/test_runner_service_spec.rb
@@ -1,0 +1,127 @@
+require File.expand_path("../../spec_helper.rb", __FILE__)
+require File.expand_path("../../../services/test_runner_service.rb", __FILE__)
+
+describe FastlaneCI::TestRunnerService do
+  # Will not cause an exception to be raised in `subject.run` because the project
+  # constructor is given a 'repo_config' attribute
+  let (:good_project) do
+    FastlaneCI::Project.new(
+      repo_config: git_repo,
+      enabled: true,
+      project_name: "fake_project",
+      lane: "fake_lane",
+    )
+  end
+
+  # Will cause an exception to be raised in `subject.run` because the project
+  # constructor it wasn't given a 'repo_config' attribute
+  let (:bad_project) do
+    FastlaneCI::Project.new
+  end
+
+  subject do
+    FastlaneCI::TestRunnerService.new(
+      project: good_project,
+      sha: SecureRandom.uuid,
+      github_service: double("GithubService", :set_build_status! => nil)
+    )
+  end
+
+  before(:each) do
+    stub_git_repos
+    stub_services
+  end
+
+  describe "#run" do
+    let (:builds) do
+      (1..3).map do |index|
+        FastlaneCI::Build.new(
+          project: good_project,
+          number: index,
+          status: :pending,
+          timestamp: Time.now,
+          duration: -1,
+          sha: SecureRandom.uuid
+        )
+      end
+    end
+
+    before(:each) do
+      FastlaneCI::BuildService.any_instance.stub(:list_builds).and_return(builds)
+      subject.should_receive(:update_build_status!).twice
+
+      # Don't execute build command
+      TTY::Command.any_instance.stub(:run)
+    end
+
+    context "success" do
+      before(:each) { allow(subject).to receive(:project).and_return(good_project) }
+
+      it "Updates the current build and sets the status to 'success' when a build passes" do
+        expect { subject.run }.to change { subject.current_build }.from(nil)
+      end
+
+      after(:each) do
+        expect(subject.current_build.status).to eq(:success)
+
+        # Build should be incremented by 1
+        expect(subject.current_build.number).to eq(4)
+      end
+    end
+
+    context "failure" do
+      before(:each) { allow(subject).to receive(:project).and_return(bad_project) }
+
+      it "Updates the current build and sets the status to 'failure' when a build fails" do
+        expect { subject.run }.to change { subject.current_build }.from(nil)
+      end
+
+      after(:each) { expect(subject.current_build.status).to eq(:failure) }
+    end
+  end
+
+  describe "#rerun" do
+    let (:build) do
+      FastlaneCI::Build.new(
+        project: good_project,
+        number: 1,
+        status: :pending,
+        timestamp: Time.now,
+        duration: -1,
+        sha: SecureRandom.uuid
+      )
+    end
+
+    before (:each) do
+      subject.should_receive(:update_build_status!).twice
+
+      # Don't execute build command
+      TTY::Command.any_instance.stub(:run)
+    end
+
+    context "success" do
+      before(:each) { allow(subject).to receive(:project).and_return(good_project) }
+
+      it "Updates the current build and sets the status to 'success' when a build passes" do
+        expect { subject.run }.to change { subject.current_build }.from(nil)
+      end
+
+      after(:each) do
+        expect(subject.current_build.status).to eq(:success)
+
+        # Build should not be incremented by 1
+        expect(subject.current_build.number).to eq(build.number)
+      end
+    end
+
+    context "failure" do
+      before(:each) { allow(subject).to receive(:project).and_return(bad_project) }
+
+      it "Updates the current build and sets the status to 'failure' when a build fails" do
+        expect { subject.run }.to change { subject.current_build }.from(nil)
+      end
+
+      after(:each) { expect(subject.current_build.status).to eq(:failure) }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 $LOAD_PATH << "shared"
 require "rack/test"
 require "rspec"
+require "stub_helpers"
+require "helper_functions"
 
 ENV["RACK_ENV"] = "test"
 require File.expand_path("../../fastlane_app.rb", __FILE__)
@@ -14,6 +16,8 @@ end
 
 RSpec.configure do |config|
   config.include(RSpecMixin)
+  config.include(StubHelpers)
+  config.include(HelperFunctions)
 
   config.formatter = :documentation
   config.tty = true

--- a/spec/stub_helpers.rb
+++ b/spec/stub_helpers.rb
@@ -1,0 +1,36 @@
+require "helper_functions"
+
+module StubHelpers
+  include HelperFunctions
+
+  def stub_git_repos
+    FastlaneCI::GitRepo.any_instance.stub(:setup_repo)
+    FastlaneCI::GitRepo.any_instance.stub(:clone)
+  end
+
+  def stub_services
+    FastlaneCI::Services.stub(:ci_config_git_repo_path).and_return(git_repo_path)
+
+    FastlaneCI::Services.stub(:project_service).and_return(
+      FastlaneCI::ProjectService.new(
+        project_data_source: FastlaneCI::JSONProjectDataSource.create(
+          git_repo, user: ci_user
+        )
+      )
+    )
+
+    FastlaneCI::Services.stub(:user_service).and_return(
+      FastlaneCI::UserService.new(
+        user_data_source: FastlaneCI::JSONUserDataSource.create(git_repo_path)
+      )
+    )
+
+    FastlaneCI::Services.stub(:ci_user).and_return(ci_user)
+
+    FastlaneCI::Services.stub(:build_service).and_return(
+      FastlaneCI::BuildService.new(
+        build_data_source: FastlaneCI::JSONBuildDataSource.create(git_repo_path)
+      )
+    )
+  end
+end


### PR DESCRIPTION
The following is a PR for issue #52.

### Changes

**`launch.rb`**
- On [`Launch::take_off`](), pending builds will be run after all other configuration takes place
- [`Launch::run_pending_builds`](https://github.com/AndrewMcBurney/ci/blob/rerun_pending_builds/launch.rb#L143) iterates through all projects and appends a worker task dedicated to running pending builds corresponding to each project asynchronously
- `provider_credential` is now a [memoized class method](https://github.com/AndrewMcBurney/ci/blob/rerun_pending_builds/launch.rb#L191), since the `provider_credentials` are now being used in multiple class methods

**`json_build_data_source.rb`**
- I made the methods `JSONBuildDataSource::json_folder_path` and `JSONBuildDataSource::builds_path` [private](https://github.com/AndrewMcBurney/ci/blob/rerun_pending_builds/services/data_sources/json_build_data_source.rb#L57-L65), because I was worried about potential violation of the [dependency inversion principle](http://deviq.com/dependency-inversion-principle/) - since the abstract class doesn't have these public methods

### Use case

1. Have some builds with `pending` status in your Fastlane CI config repo:

<img width="1005" alt="screen shot 2018-02-25 at 1 36 18 pm" src="https://user-images.githubusercontent.com/8942499/36645072-5da0fc34-1a31-11e8-9fb4-d01330b5e11f.png">

> I updated `1.json` and `3.json` to be `pending` builds

2. Boot up the Fastlane CI server

<img width="715" alt="screen shot 2018-02-25 at 1 36 59 pm" src="https://user-images.githubusercontent.com/8942499/36645057-2ce4cabc-1a31-11e8-990e-8cfaeacc1823.png">

3. _Voila_, the builds are rerun!

<img width="1007" alt="screen shot 2018-02-25 at 1 37 29 pm" src="https://user-images.githubusercontent.com/8942499/36645060-3b5406c6-1a31-11e8-8cd5-4f392b4dfd84.png">
<img width="999" alt="screen shot 2018-02-25 at 1 37 40 pm" src="https://user-images.githubusercontent.com/8942499/36645061-3b5db9d2-1a31-11e8-9b5b-660bd191d150.png">

### Enhancements

- [x] Add tests
- [x] Show use case
- [x] Validate everything works :joy: