### PR TITLE
Only look at branches that have associated commit triggers

### DIFF
--- a/features/project/project_controller.rb
+++ b/features/project/project_controller.rb
@@ -155,6 +155,7 @@ module FastlaneCI
       project_name = params["project_name"]
 
       # We now have enough information to create the new project.
+      # TODO: add job_triggers here
       project = Services.project_service.create_project!(
         name: project_name,
         repo_config: repo_config,

--- a/workers/check_for_new_commits_on_github_worker.rb
+++ b/workers/check_for_new_commits_on_github_worker.rb
@@ -37,7 +37,7 @@ module FastlaneCI
 
       self.target_branches_set = Set.new
       project.job_triggers.each do |trigger|
-        if trigger.kind_of?(FastlaneCI::CommitJobTrigger)
+        if trigger.type == FastlaneCI::JobTrigger::TRIGGER_TYPE[:commit]
           self.target_branches_set.add(trigger.branch)
         end
       end


### PR DESCRIPTION
Was originally thinking of making separate workers to track each branch, but thought that was overkill.

I tried saving a little time here by prepping the set of branches we're targeting on init. I fear that this list will be stale if the UI will ever allow for dynamic addition of triggers. But i don't believe we currently propagate runtime project modification to this worker anyways.