### PR TITLE
Add Nightly Build Worker

### DIFF
--- a/services/worker_service.rb
+++ b/services/worker_service.rb
@@ -1,4 +1,5 @@
 require_relative "../workers/check_for_new_commits_on_github_worker"
+require_relative "../workers/nightly_build_github_worker"
 require_relative "../shared/logging_module"
 require_relative "../shared/models/provider_credential"
 
@@ -27,15 +28,18 @@ module FastlaneCI
       raise "incompatible repo_config and provider_credential" if provider_credential.type != repo_config.provider_credential_type_needed
 
       logger.debug("Starting worker for #{project.project_name}, on behalf of #{user_responsible.email}")
-      new_worker = nil
+      new_workers = []
       case provider_credential.type
       when FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]
-        new_worker = FastlaneCI::CheckForNewCommitsOnGithubWorker.new(provider_credential: provider_credential, project: project)
+        new_workers.push(FastlaneCI::CheckForNewCommitsOnGithubWorker.new(provider_credential: provider_credential, project: project))
+        new_workers.push(FastlaneCI::NightlyBuildGithubWorker.new(provider_credential: provider_credential, project: project))
       else
         raise "unrecognized provider_type: #{provider_credential.type}"
       end
 
-      self.resource_workers_dictionary[worker_key] = new_worker
+      new_workers.each do |new_worker|
+        self.resource_workers_dictionary[worker_key] = new_worker
+      end
     end
 
     def stop_worker(project: nil, user_responsible: nil)

--- a/workers/check_for_new_commits_on_github_worker.rb
+++ b/workers/check_for_new_commits_on_github_worker.rb
@@ -16,12 +16,11 @@ module FastlaneCI
 
     attr_accessor :provider_credential
     attr_accessor :project
-
     attr_accessor :user_config_service
     attr_accessor :github_service
-
     attr_accessor :serial_task_queue
     attr_accessor :current_tasks
+    attr_accessor :scheduler
 
     attr_writer :git_repo
 
@@ -33,6 +32,7 @@ module FastlaneCI
       self.provider_credential = provider_credential
       self.github_service = FastlaneCI::GitHubService.new(provider_credential: provider_credential)
       self.project = project
+      self.scheduler = WorkerScheduler.new(sleep_interval: 10)
 
       project_full_name = project.repo_config.git_url
 
@@ -138,10 +138,6 @@ module FastlaneCI
         logger.debug("Adding task for #{project_full_name}: #{credential.ci_user.email}: #{current_sha[-6..-1]}")
         self.serial_task_queue.add_task_async(task: check_for_commit_task)
       end
-    end
-
-    def scheduler
-      WorkerScheduler.new(sleep_interval: 10)
     end
   end
 end

--- a/workers/nightly_build_github_worker.rb
+++ b/workers/nightly_build_github_worker.rb
@@ -1,0 +1,113 @@
+require_relative "worker_base"
+require_relative "../services/build_service"
+require_relative "../shared/models/job_trigger"
+require_relative "../shared/models/provider_credential"
+require_relative "../shared/logging_module"
+require_relative "../services/test_runner_service"
+require_relative "../services/code_hosting/git_hub_service"
+
+module FastlaneCI
+  # Responsible for starting off builds nightly
+  # TODO: determine what timezone to use
+  class NightlyBuildGithubWorker < WorkerBase
+    include FastlaneCI::Logging
+    NIGHTLY_CRON_TIME = "0 0 * * *"
+
+    attr_accessor :provider_credential
+    attr_accessor :project
+    attr_accessor :user_config_service
+    attr_accessor :github_service
+    attr_accessor :serial_task_queue
+    attr_accessor :project_full_name
+    attr_accessor :scheduler
+    attr_accessor :target_branches_set
+
+    attr_writer :git_repo
+
+    def provider_type
+      return FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]
+    end
+
+    def initialize(provider_credential: nil, project: nil)
+      self.provider_credential = provider_credential
+      self.github_service = FastlaneCI::GitHubService.new(provider_credential: provider_credential)
+      self.project = project
+      self.scheduler = WorkerScheduler.new(cron_schedule: NIGHTLY_CRON_TIME)
+
+      self.target_branches_set = Set.new
+      project.job_triggers.each do |trigger|
+        if trigger.type == FastlaneCI::JobTrigger::TRIGGER_TYPE[:nightly]
+          self.target_branches_set.add(trigger.branch)
+        end
+      end
+
+      self.project_full_name = project.repo_config.git_url
+
+      if project.repo_config.kind_of?(FastlaneCI::GitRepoConfig)
+        self.project_full_name = project.repo_config.full_name unless project.repo_config.full_name.nil?
+      end
+
+      self.serial_task_queue = TaskQueue::TaskQueue.new(name: "#{self.project_full_name}:#{provider_credential.ci_user.email}")
+
+      super() # This starts the work by calling `work`
+    end
+
+    def thread_id
+      if @thread_id
+        return @thread_id
+      end
+
+      time_nano = Time.now.nsec
+      @thread_id = "GithubWorker:#{time_nano}: #{self.serial_task_queue.name}"
+      return @thread_id
+    end
+
+    # This is a separate method, so it's lazy loaded
+    # since it will be run on the "main" thread if it were
+    # part of the #initialize method
+    def git_repo
+      @git_repo ||= GitRepo.new(
+        git_config: project.repo_config,
+        provider_credential: provider_credential
+      )
+    end
+
+    def work
+      logger.debug("Running nightly builds on GitHub")
+      repo = self.git_repo
+
+      # is needed to see if there are new branches (called async)
+      repo.fetch
+
+      repo.git_and_remote_branches_each do |git, branch|
+        next if branch.name.start_with?("HEAD ->") # not sure what this is for
+
+        # Only need to look at branches that have associated nightly build triggers
+        next unless self.target_branches_set.include?(branch.name)
+
+        # There might be un-committed changes in there, so ignore
+        git.reset_hard
+
+        # Check out the specific branch, this will detach our current head
+        branch.checkout
+
+        current_sha = repo.most_recent_commit.sha
+        logger.debug("Running Nightly build on branch #{branch.name} with sha #{current_sha}")
+
+        credential = self.provider_credential
+        current_project = self.project
+
+        nightly_build_task = TaskQueue::Task.new(work_block: proc {
+          FastlaneCI::TestRunnerService.new(
+            project: current_project,
+            sha: current_sha,
+            github_service: self.github_service
+          ).run
+        })
+
+        logger.debug("Adding task for #{self.project_full_name}: #{credential.ci_user.email}: #{current_sha[-6..-1]}")
+        self.serial_task_queue.add_task_async(task: nightly_build_task)
+      end
+    end
+  end
+end

--- a/workers/refresh_config_data_sources_worker.rb
+++ b/workers/refresh_config_data_sources_worker.rb
@@ -5,12 +5,14 @@ module FastlaneCI
   # Responsible for running `git pull` on the ci config repo
   # in the background, every x seconds
   class RefreshConfigDataSourcesWorker < WorkerBase
-    def work
-      FastlaneCI::Services.project_service.refresh_repo
+    attr_accessor :scheduler
+
+    def initialize
+      self.scheduler = WorkerScheduler.new(sleep_interval: 15)
     end
 
-    def scheduler
-      WorkerScheduler.new(sleep_interval: 15)
+    def work
+      FastlaneCI::Services.project_service.refresh_repo
     end
   end
 end

--- a/workers/worker_base.rb
+++ b/workers/worker_base.rb
@@ -25,7 +25,11 @@ module FastlaneCI
           # We have the `work` inside a `begin rescue`
           # so that if something fails, the thread still is alive
           begin
-            self.scheduler.schedule { self.work } unless self.should_stop
+            if self.should_stop
+              self.scheduler.shutdown
+            else
+              self.scheduler.schedule { self.work }
+            end
           rescue StandardError => ex
             puts("[#{self.class} Exception]: #{ex}: ")
             puts(ex.backtrace.join("\n"))

--- a/workers/worker_scheduler.rb
+++ b/workers/worker_scheduler.rb
@@ -7,6 +7,7 @@ module FastlaneCI
     attr_accessor :sleep_interval
     # Ex. '5 0 * * *' do something every day, five minutes after midnight
     # (see "man 5 crontab" in your terminal)
+<<<<<<< HEAD
     attr_accessor :cron_schedule
     attr_accessor :scheduler
 
@@ -21,6 +22,18 @@ module FastlaneCI
 
       if !self.sleep_interval.nil? && !self.cron_schedule.nil?
         raise "Only one of cron_schedule or a sleep_interval is allowed."
+=======
+    attr_accessor :cron_time
+    attr_accessor :scheduler
+
+    def initialize(sleep_interval: nil, cron_time: nil)
+      self.sleep_interval = sleep_interval
+      self.cron_time = cron_time
+      self.scheduler = Rufus::Scheduler.new
+
+      if self.sleep_interval.nil? && self.cron_time.nil?
+        raise "Either a cron_time or a sleep_interval is mandatory."
+>>>>>>> Add worker scheduler to handle the scheduling of the worker task. Scheduler can also handle cron jobs
       end
     end
 
@@ -28,8 +41,13 @@ module FastlaneCI
       if !self.sleep_interval.nil?
         block.call
         Kernel.sleep(self.sleep_interval)
+<<<<<<< HEAD
       elsif !self.cron_schedule.nil?
         self.scheduler.cron(self.cron_schedule) { block.call }
+=======
+      elsif !self.cron_time.nil?
+        self.scheduler.cron(self.cron_time) { block.call }
+>>>>>>> Add worker scheduler to handle the scheduling of the worker task. Scheduler can also handle cron jobs
       end
     end
   end


### PR DESCRIPTION
Added:

- Nightly Build Worker
- Scheduler being initialized on initialize for each worker
- shutdown scheduler if the thread is told to stop
- stop from scheduling the cron job again if the scheduler has already scheduled something
- only init scheduler if cron_schedule is provided

TESTED_LOCALLY with a closer time than midnight 😉 