### PR TITLE
Real-time build log stream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "sinatra-contrib", ">= 2.0.0", "< 3.0.0" # TODO: document why we have this h
 gem "faye-websocket", ">= 0.10.7", "< 1.0.0" # web socket connection for Sinatra
 
 # web server that we need to support web socket connections with sinatra
-gem "thin"
+gem "thin", ">= 1.7.2", "< 2.0.0"
 
 # Best password hashing to-date
 gem "bcrypt", ">= 3.1.11", "< 4.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source("https://rubygems.org")
 
 # Sinatra
-gem "sinatra", ">= 2.0.1", "< 3.0.0"
-gem "sinatra-contrib", ">= 2.0.0", "< 3.0.0" # TODO: document why we have this here @taquitos
 gem "faye-websocket", ">= 0.10.7", "< 1.0.0" # web socket connection for Sinatra
+gem "sinatra", ">= 2.0.1", "< 3.0.0" # Our web application library
+gem "sinatra-contrib", ">= 2.0.0", "< 3.0.0" # TODO: document why we have this here @taquitos
 
 # web server that we need to support web socket connections with sinatra
 gem "thin", ">= 1.7.2", "< 2.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source("https://rubygems.org")
 # Sinatra
 gem "sinatra", ">= 2.0.1", "< 3.0.0"
 gem "sinatra-contrib", ">= 2.0.0", "< 3.0.0" # TODO: document why we have this here @taquitos
+gem "faye-websocket", ">= 0.10.7", "< 1.0.0" # web socket connection for Sinatra
+
+# web server that we need to support web socket connections with sinatra
+gem "thin"
 
 # Best password hashing to-date
 gem "bcrypt", ">= 3.1.11", "< 4.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     concord (0.1.5)
       adamantium (~> 0.2.0)
       equalizer (~> 0.0.9)
+    daemons (1.2.6)
     declarative (0.0.10)
     declarative-option (0.1.0)
     diff-lcs (1.3)
@@ -72,6 +73,7 @@ GEM
     equatable (0.5.0)
     et-orbi (1.0.9)
       tzinfo
+    eventmachine (1.2.5)
     excon (0.60.0)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
@@ -81,6 +83,9 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.1)
+    faye-websocket (0.10.7)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
     gh_inspector (1.1.2)
     git (1.3.0)
     google-api-client (0.13.6)
@@ -203,6 +208,10 @@ GEM
     terminal-notifier (1.8.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tty-color (0.4.2)
@@ -227,6 +236,9 @@ GEM
       equalizer (~> 0.0.9)
       parser (>= 2.3.1.2, < 2.5)
       procto (~> 0.0.2)
+    websocket-driver (0.7.0)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.3)
     word_wrap (1.0.0)
     xcodeproj (1.5.6)
       CFPropertyList (~> 2.3.3)
@@ -246,6 +258,7 @@ DEPENDENCIES
   bcrypt (>= 3.1.11, < 4.0.0)
   dotenv (>= 2.2.1, < 3.0.0)
   fastlane!
+  faye-websocket (>= 0.10.7, < 1.0.0)
   git (>= 1.3.0, < 2.0.0)
   octokit (>= 4.8.0, < 5.0.0)
   parser (>= 2.4.0.2, < 2.5.0.0)
@@ -258,6 +271,7 @@ DEPENDENCIES
   rufus-scheduler
   sinatra (>= 2.0.1, < 3.0.0)
   sinatra-contrib (>= 2.0.0, < 3.0.0)
+  thin
   tty-command (>= 0.7.0, < 1.0.0)
   unparser (>= 0.2.6, < 1.0.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/fastlane/fastlane
-  revision: d0998ae7acd3e8ed165186d55547a9d7e69abefd
+  revision: 5c8081c5eda17a0e1ca6d953ee6492992553308c
   specs:
-    fastlane (2.83.0)
+    fastlane (2.84.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -271,7 +271,7 @@ DEPENDENCIES
   rufus-scheduler
   sinatra (>= 2.0.1, < 3.0.0)
   sinatra-contrib (>= 2.0.0, < 3.0.0)
-  thin
+  thin (>= 1.7.2, < 2.0.0)
   tty-command (>= 0.7.0, < 1.0.0)
   unparser (>= 0.2.6, < 1.0.0)
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Base64.encode64(new_encrypted_api_token)
 bundle exec rackup -p 8080 --env development
 ```
 
-Visit [127.0.0.1:8080](http://127.0.0.1:8080/) to open the login
+Visit [localhost:8080](http://localhost:8080/) to open the login
 
 If you're having trouble and need to debug, you can add the following environment variables:
 `FASTLANE_CI_VERBOSE=1` and `DEBUG=1`

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,9 +5,9 @@ platform :ios do
   lane :beta do
     UI.message("It works, what kind of magic is this?")
     UI.message("Building now...")
-    sleep(3)
-    UI.error("One error in your project")
-    sleep(1)
+    sleep(5)
+    UI.error("One error in your project, trying to fix it for you...")
+    sleep(5)
     UI.success("Building complete")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,5 +4,10 @@ platform :ios do
   desc "Description of what the lane does"
   lane :beta do
     UI.message("It works, what kind of magic is this?")
+    UI.message("Building now...")
+    sleep(3)
+    UI.error("One error in your project")
+    sleep(1)
+    UI.success("Building complete")
   end
 end

--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -4,7 +4,7 @@ require "sinatra/base"
 # Switch from the default Sinatra web server to `thin`
 # which is required to support web socket streams for the
 # display of real-time output
-# set :server, "thin"
+set :server, "thin"
 
 require_relative "./fastfile-parser/fastfile_parser"
 

--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -4,7 +4,7 @@ require "sinatra/base"
 # Switch from the default Sinatra web server to `thin`
 # which is required to support web socket streams for the
 # display of real-time output
-set :server, "thin"
+set(:server, "thin")
 
 require_relative "./fastfile-parser/fastfile_parser"
 

--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -1,6 +1,11 @@
 # External
 require "sinatra/base"
 
+# Switch from the default Sinatra web server to `thin`
+# which is required to support web socket streams for the
+# display of real-time output
+# set :server, "thin"
+
 require_relative "./fastfile-parser/fastfile_parser"
 
 # Internal

--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -1,11 +1,6 @@
 # External
 require "sinatra/base"
 
-# Switch from the default Sinatra web server to `thin`
-# which is required to support web socket streams for the
-# display of real-time output
-set(:server, "thin")
-
 require_relative "./fastfile-parser/fastfile_parser"
 
 # Internal
@@ -27,6 +22,11 @@ module FastlaneCI
   class FastlaneApp < Sinatra::Base
     include FastlaneCI::Logging
     Thread.current[:thread_id] = "main"
+
+    # Switch from the default Sinatra web server to `thin`
+    # which is required to support web socket streams for the
+    # display of real-time output
+    set(:server, "thin")
 
     get "/" do
       if session[:user]

--- a/features/build/build_controller.rb
+++ b/features/build/build_controller.rb
@@ -9,7 +9,7 @@ module FastlaneCI
 
     use(FastlaneCI::BuildWebsocketBackend)
 
-    get "/projects/*/builds/*" do |project_id, build_id|
+    get "#{HOME}/*" do |project_id, build_id|
       project = self.user_project_with_id(project_id: project_id)
       build = project.builds.find { |b| b.sha == build_id } # TODO: We need a build ID, sha isn't enough
 

--- a/features/build/build_controller.rb
+++ b/features/build/build_controller.rb
@@ -13,7 +13,7 @@ module FastlaneCI
       project = self.user_project_with_id(project_id: project_id)
       build = project.builds.find { |b| b.sha == build_id } # TODO: We need a build ID, sha isn't enough
 
-      current_runner_service = TestRunnerService.test_runner_services.find do |t| 
+      current_runner_service = TestRunnerService.test_runner_services.find do |t|
         t.project.id == project_id && t.sha == build_id # TODO: just as above, use actual identification
       end
 

--- a/features/build/build_controller.rb
+++ b/features/build/build_controller.rb
@@ -13,6 +13,17 @@ module FastlaneCI
       project = self.user_project_with_id(project_id: project_id)
       build = project.builds.find { |b| b.sha == build_id } # TODO: We need a build ID, sha isn't enough
 
+      # TODO: currently we just trigger a build here
+      service = FastlaneCI::TestRunnerService.new(
+        project: project,
+        sha: build_id
+      )
+      BuildWebsocketBackend.test_runner_services ||= []
+      BuildWebsocketBackend.test_runner_services << service
+      Thread.new do
+        service.run
+      end
+
       locals = {
         project: project,
         build: build,

--- a/features/build/build_controller.rb
+++ b/features/build/build_controller.rb
@@ -21,7 +21,7 @@ module FastlaneCI
         project: project,
         build: build,
         title: "Project #{project.project_name}, Build #{build.sha}",
-        existing_rows: current_runner_service.all_lines.collect { |a| a[:html] }
+        existing_rows: current_runner_service.all_build_output_log_lines.collect { |a| a[:html] }
       }
       erb(:build, locals: locals, layout: FastlaneCI.default_layout)
     end

--- a/features/build/build_controller.rb
+++ b/features/build/build_controller.rb
@@ -1,0 +1,24 @@
+require_relative "../../shared/authenticated_controller_base"
+require_relative "./build_websocket_backend"
+require "pathname"
+
+module FastlaneCI
+  # Controller for a single project view. Responsible for updates, triggering builds, and displaying project info
+  class BuildController < AuthenticatedControllerBase
+    HOME = "/projects/*/builds"
+
+    use(FastlaneCI::BuildWebsocketBackend)
+
+    get "/projects/*/builds/*" do |project_id, build_id|
+      project = self.user_project_with_id(project_id: project_id)
+      build = project.builds.find { |b| b.sha == build_id } # TODO: We need a build ID, sha isn't enough
+
+      locals = {
+        project: project,
+        build: build,
+        title: "Project #{project.project_name}, Build #{build.sha}"
+      }
+      erb(:build, locals: locals, layout: FastlaneCI.default_layout)
+    end
+  end
+end

--- a/features/build/build_controller.rb
+++ b/features/build/build_controller.rb
@@ -13,21 +13,15 @@ module FastlaneCI
       project = self.user_project_with_id(project_id: project_id)
       build = project.builds.find { |b| b.sha == build_id } # TODO: We need a build ID, sha isn't enough
 
-      # TODO: currently we just trigger a build here
-      service = FastlaneCI::TestRunnerService.new(
-        project: project,
-        sha: build_id
-      )
-      BuildWebsocketBackend.test_runner_services ||= []
-      BuildWebsocketBackend.test_runner_services << service
-      Thread.new do
-        service.run
+      current_runner_service = TestRunnerService.test_runner_services.find do |t| 
+        t.project.id == project_id && t.sha == build_id # TODO: just as above, use actual identification
       end
 
       locals = {
         project: project,
         build: build,
-        title: "Project #{project.project_name}, Build #{build.sha}"
+        title: "Project #{project.project_name}, Build #{build.sha}",
+        existing_rows: current_runner_service.all_lines.collect { |a| a[:html] }
       }
       erb(:build, locals: locals, layout: FastlaneCI.default_layout)
     end

--- a/features/build/build_websocket_backend.rb
+++ b/features/build/build_websocket_backend.rb
@@ -1,0 +1,58 @@
+require "faye/websocket"
+require_relative "../../shared/logging_module"
+
+Faye::WebSocket.load_adapter('thin')
+
+module FastlaneCI
+  class BuildWebsocketBackend
+    include FastlaneCI::Logging
+
+    KEEPALIVE_TIME = 30 # in seconds
+    CHANNEL = "build-output"
+
+    def initialize(app)
+      @app = app
+
+      @clients = []
+    end
+
+    def call(env)
+      if Faye::WebSocket.websocket?(env)
+        ws = Faye::WebSocket.new(env, nil, {ping: KEEPALIVE_TIME })
+        ws.on :open do |event|
+          logger.debug([:open, ws.object_id])
+          @clients << ws
+
+
+          # TODO: Testing code only
+          FastlaneCI::FastlaneTestRunner.new.run(
+            lane: "beta",
+            platform: "ios"
+          ) do |row|
+            html_row = FastlaneOutputToHtml.convert_row(row)
+            puts html_row
+            @clients.each do
+              ws.send(html_row)
+            end
+          end
+        end
+
+        ws.on :message do |event|
+          # We don't use this right now
+          logger.debug([:message, event.data])
+        end
+
+        ws.on :close do |event|
+          logger.debug([:close, ws.object_id, event.code, event.reason])
+          @clients.delete(ws)
+          ws = nil
+        end
+
+        # Return async Rack response
+        ws.rack_response
+      else
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/features/build/build_websocket_backend.rb
+++ b/features/build/build_websocket_backend.rb
@@ -4,6 +4,8 @@ require_relative "../../shared/logging_module"
 Faye::WebSocket.load_adapter('thin')
 
 module FastlaneCI
+  # Responsible for the real-time streaming of the build output
+  # to the user's browser
   class BuildWebsocketBackend
     include FastlaneCI::Logging
 
@@ -11,48 +13,62 @@ module FastlaneCI
     CHANNEL = "build-output"
 
     def initialize(app)
+      logger.debug("Setting up new BuildWebsocketBackend")
       @app = app
 
       @clients = []
     end
 
     def call(env)
-      if Faye::WebSocket.websocket?(env)
-        ws = Faye::WebSocket.new(env, nil, {ping: KEEPALIVE_TIME })
-        ws.on :open do |event|
-          logger.debug([:open, ws.object_id])
-          @clients << ws
+      unless Faye::WebSocket.websocket?(env)
+        # This is a regular HTTP call (no socket connection)
+        # so just redirect to the user's app
+        return @app.call(env)
+      end
 
+      ws = Faye::WebSocket.new(env, nil, {ping: KEEPALIVE_TIME })
+      ws.on(:open) do |event|
+        logger.debug([:open, ws.object_id])
+        @clients << ws
 
-          # TODO: Testing code only
-          FastlaneCI::FastlaneTestRunner.new.run(
-            lane: "beta",
-            platform: "ios"
-          ) do |row|
-            html_row = FastlaneOutputToHtml.convert_row(row)
-            puts html_row
-            @clients.each do
-              ws.send(html_row)
-            end
+        # TODO: Testing code only
+        # We don't want to actually trigger the runner here
+        FastlaneCI::FastlaneTestRunner.new.run(
+          lane: "beta",
+          platform: "ios"
+        ) do |row|
+          # Additionally to transfering the original metadata of this message
+          # that look like this:
+          # 
+          # {:type=>:success, :message=>"Everything worked"}
+          # 
+          # we append the HTML code that should be used in the `html` key
+          # the result looks like this
+          #
+          # {"type":"success","message":"Driving the lane 'ios beta' 🚀","html":"<p class=\"success\">Driving the lane 'ios beta' 🚀</p>"}
+          #
+          
+          row[:html] = FastlaneOutputToHtml.convert_row(row)
+          logger.debug("Streaming #{row} to #{@clients.count} client(s)")
+          @clients.each do
+            ws.send(row.to_json)
           end
         end
-
-        ws.on :message do |event|
-          # We don't use this right now
-          logger.debug([:message, event.data])
-        end
-
-        ws.on :close do |event|
-          logger.debug([:close, ws.object_id, event.code, event.reason])
-          @clients.delete(ws)
-          ws = nil
-        end
-
-        # Return async Rack response
-        ws.rack_response
-      else
-        @app.call(env)
       end
+
+      ws.on(:message) do |event|
+        # We don't use this right now
+        logger.debug([:message, event.data])
+      end
+
+      ws.on(:close) do |event|
+        logger.debug([:close, ws.object_id, event.code, event.reason])
+        @clients.delete(ws)
+        ws = nil
+      end
+
+      # Return async Rack response
+      return ws.rack_response
     end
   end
 end

--- a/features/build/build_websocket_backend.rb
+++ b/features/build/build_websocket_backend.rb
@@ -1,11 +1,14 @@
 require "faye/websocket"
 require_relative "../../shared/logging_module"
 
-Faye::WebSocket.load_adapter('thin')
+Faye::WebSocket.load_adapter("thin")
 
 module FastlaneCI
   # Responsible for the real-time streaming of the build output
   # to the user's browser
+  # This is a Rack middleware, that is called before any of the Sinatra code is called
+  # it allows us to have the real time web socket connection. Inside the `.call` method
+  # we check if the current request is a socket connection or traditional HTTPs
   class BuildWebsocketBackend
     include FastlaneCI::Logging
 
@@ -34,7 +37,7 @@ module FastlaneCI
         return @app.call(env)
       end
 
-      ws = Faye::WebSocket.new(env, nil, {ping: KEEPALIVE_TIME })
+      ws = Faye::WebSocket.new(env, nil, { ping: KEEPALIVE_TIME })
       ws.on(:open) do |event|
         logger.debug([:open, ws.object_id])
 

--- a/features/build/build_websocket_backend.rb
+++ b/features/build/build_websocket_backend.rb
@@ -7,20 +7,17 @@ module FastlaneCI
   # Responsible for the real-time streaming of the build output
   # to the user's browser
   class BuildWebsocketBackend
-    class << self
-      attr_accessor :test_runner_services
-    end
-
     include FastlaneCI::Logging
 
     KEEPALIVE_TIME = 30 # in seconds
-    CHANNEL = "build-output" # TODO: we probably need this to distinguish between multiple builds
+
+    attr_accessor :websocket_clients
 
     def initialize(app)
       logger.debug("Setting up new BuildWebsocketBackend")
       @app = app
 
-      @clients = []
+      self.websocket_clients = []
     end
 
     def call(env)
@@ -33,13 +30,14 @@ module FastlaneCI
       ws = Faye::WebSocket.new(env, nil, {ping: KEEPALIVE_TIME })
       ws.on(:open) do |event|
         logger.debug([:open, ws.object_id])
-        @clients << ws
+        self.websocket_clients << ws
 
-        self.class.test_runner_services.each do |test_runner_service|
+        TestRunnerService.test_runner_services.each do |test_runner_service|
           logger.debug("Appending to runner service :)")
           test_runner_service.add_listener(proc do |row|
-            logger.debug("Streaming #{row} to #{@clients.count} client(s)")
-            @clients.each do
+            logger.debug("Streaming #{row} to #{self.websocket_clients.count} client(s)")
+
+            self.websocket_clients.each do
               ws.send(row.to_json)
             end
           end)
@@ -53,7 +51,7 @@ module FastlaneCI
 
       ws.on(:close) do |event|
         logger.debug([:close, ws.object_id, event.code, event.reason])
-        @clients.delete(ws)
+        self.websocket_clients.delete(ws)
         ws = nil
       end
 

--- a/features/build/views/build.erb
+++ b/features/build/views/build.erb
@@ -1,7 +1,11 @@
 <h1>Build Log <%= build.number %></h1>
 
 <code id="log">
-  Loading...
+  <% if existing_rows.count > 0 %>
+    <%= existing_rows.join("\n") %>
+  <% else %>
+    Loading...
+  <% end %>
 </code>
 
 <script type="text/javascript">
@@ -10,7 +14,7 @@
     var uri      = scheme + window.document.location.host + "/";
     var ws       = new WebSocket(uri);
     console.log("Listening to web socket connection now for URL " + uri + "...")
-    var firstMessageReceived = false;
+    var firstMessageReceived = <%= existing_rows.count == 0 ? false : true %>;
     ws.onmessage = function(message) {
       if (firstMessageReceived == false) {
         document.getElementById("log").innerHTML = ""

--- a/features/build/views/build.erb
+++ b/features/build/views/build.erb
@@ -1,7 +1,7 @@
 <h1>Build Log <%= build.number %></h1>
 
 <code id="log">
-  <p>Line 1</p>
+  Loading...
 </code>
 
 <script type="text/javascript">
@@ -9,11 +9,39 @@
     var scheme   = "ws://"
     var uri      = scheme + window.document.location.host + "/";
     var ws       = new WebSocket(uri);
+    console.log("Listening to web socket connection now for URL " + uri + "...")
+    var firstMessageReceived = false;
     ws.onmessage = function(message) {
+      if (firstMessageReceived == false) {
+        document.getElementById("log").innerHTML = ""
+        firstMessageReceived = true
+      }
       console.log(message)
-      var data = message.data
+      var data = JSON.parse(message.data)
       console.log(data)
-      document.getElementById("log").innerHTML << data // this piece doesn't work yet
+      document.getElementById("log").innerHTML += data["html"]
+    }
+    ws.onopen = function(something) {
+      console.log("Open")
+      console.log(something)
+    }
+    ws.onerror = function(error) {
+      console.log("error")
+      console.log(error)
+    }
+    ws.onclose = function(something) {
+      console.log("close")
+      console.log(something)
+      document.getElementById("log").innerHTML += "<p class='error'>Server disconnected</p>"
     }
   });
 </script>
+
+<style type="text/css">
+  .success {
+    color: green;
+  }
+  .error {
+    color: red;
+  }
+</style>

--- a/features/build/views/build.erb
+++ b/features/build/views/build.erb
@@ -10,9 +10,10 @@
 
 <script type="text/javascript">
   document.addEventListener("DOMContentLoaded", function(event) { 
-    var scheme   = "ws://"
-    var uri      = scheme + window.document.location.host + "/";
-    var ws       = new WebSocket(uri);
+    var scheme = "ws://"
+    var uri = scheme + window.document.location.host
+    uri += "/?&project=<%= project.id %>&build=<%= build.sha %>"; // we add that extra & to make the Ruby URI parser work
+    var ws = new WebSocket(uri);
     console.log("Listening to web socket connection now for URL " + uri + "...")
     var firstMessageReceived = <%= existing_rows.count == 0 ? false : true %>;
     ws.onmessage = function(message) {

--- a/features/build/views/build.erb
+++ b/features/build/views/build.erb
@@ -1,0 +1,19 @@
+<h1>Build Log <%= build.number %></h1>
+
+<code id="log">
+  <p>Line 1</p>
+</code>
+
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", function(event) { 
+    var scheme   = "ws://"
+    var uri      = scheme + window.document.location.host + "/";
+    var ws       = new WebSocket(uri);
+    ws.onmessage = function(message) {
+      console.log(message)
+      var data = message.data
+      console.log(data)
+      document.getElementById("log").innerHTML << data // this piece doesn't work yet
+    }
+  });
+</script>

--- a/features/project/project_controller.rb
+++ b/features/project/project_controller.rb
@@ -27,7 +27,7 @@ module FastlaneCI
         ).run
       end
 
-      redirect("#{HOME}/details/#{project_id}")
+      redirect("#{HOME}/#{project_id}/builds/#{current_sha}")
     end
 
     # Edit a project settings

--- a/features/project/views/project.erb
+++ b/features/project/views/project.erb
@@ -25,7 +25,8 @@
       </thead>
       <tbody>
         <% project.builds.each do |build| %>
-          <tr style="cursor: pointer;" onclick="location.href='/projects/'">
+          <% url = "/projects/#{project.id}/builds/#{build.sha}" %>
+          <tr style="cursor: pointer;" onclick="location.href='<%= url %>'">
             <td>
               <% if build.status == "success" %>
                 <%= "✅" %>

--- a/features/test_runner/fastlane_test_runner.rb
+++ b/features/test_runner/fastlane_test_runner.rb
@@ -10,7 +10,7 @@ module FastlaneCI
 
       ci_output = FastlaneCI::FastlaneCIOutput.new(
         file_path: "fastlane.log",
-        block: proc do |row|
+        each_line_block: proc do |row|
           puts "Current output from fastlane: #{row}"
 
           yield(row)

--- a/features/test_runner/fastlane_test_runner.rb
+++ b/features/test_runner/fastlane_test_runner.rb
@@ -48,8 +48,9 @@ module FastlaneCI
 
       begin
         # Execute the Fastfile here
+        puts("starting fastlane run")
         fast_file.runner.execute(self.lane, self.platform, self.parameters)
-        puts("Big success")
+        puts("fastlane run complete")
         # TODO: success handling here
         # this all will be implemented using a separate PR
         # once we have the web socket streaming implemented

--- a/features/test_runner/fastlane_test_runner.rb
+++ b/features/test_runner/fastlane_test_runner.rb
@@ -24,16 +24,15 @@ module FastlaneCI
         each_line_block: proc do |row|
           # Additionally to transfering the original metadata of this message
           # that look like this:
-          # 
+          #
           # {:type=>:success, :message=>"Everything worked"}
-          # 
+          #
           # we append the HTML code that should be used in the `html` key
           # the result looks like this
           #
-          # {"type":"success","message":"Driving the lane 'ios beta' 🚀","html":"<p class=\"success\">Driving the lane 'ios beta' 🚀</p>"}
+          # {"type":"success","message":"Driving the lane 'ios beta'","html":"<p class=\"success\">Driving the lane 'ios beta'</p>"}
           #
           row[:html] = FastlaneOutputToHtml.convert_row(row)
-
           yield(row)
         end
       )

--- a/features/test_runner/fastlane_test_runner.rb
+++ b/features/test_runner/fastlane_test_runner.rb
@@ -1,4 +1,5 @@
 require_relative "./fastlane_test_runner_helpers/fastlane_ci_output"
+require_relative "./fastlane_test_runner_helpers/fastlane_output_to_html"
 
 module FastlaneCI
   # Represents the test runner responsible for loading and running

--- a/features/test_runner/fastlane_test_runner_helpers/fastlane_ci_output.rb
+++ b/features/test_runner/fastlane_test_runner_helpers/fastlane_ci_output.rb
@@ -63,7 +63,7 @@ module FastlaneCI
     def message(message)
       log.info(message.to_s)
       self.each_line_block.call(
-        type: :error,
+        type: :message,
         message: message
       )
     end

--- a/features/test_runner/fastlane_test_runner_helpers/fastlane_output_to_html.rb
+++ b/features/test_runner/fastlane_test_runner_helpers/fastlane_output_to_html.rb
@@ -1,17 +1,17 @@
 module FastlaneCI
   # Responsible for converting JSON based message information, e.g.
-  # 
+  #
   # {
   #   type: success,
   #   message: "Step: default_platform"
   # }
-  # 
+  #
   # to HTML code, e.g.
-  # 
+  #
   # <p class="success">Step: default_platform</p>
-  # 
+  #
   # It does so for each row
-  # 
+  #
   # TODO: we decided to move this away long term, into the brower using JavaScript
   #
   class FastlaneOutputToHtml

--- a/features/test_runner/fastlane_test_runner_helpers/fastlane_output_to_html.rb
+++ b/features/test_runner/fastlane_test_runner_helpers/fastlane_output_to_html.rb
@@ -1,0 +1,34 @@
+module FastlaneCI
+  # Responsible for converting JSON based message information, e.g.
+  # 
+  # {
+  #   type: success,
+  #   message: "Step: default_platform"
+  # }
+  # 
+  # to HTML code, e.g.
+  # 
+  # <p class="success">Step: default_platform</p>
+  # 
+  # It does so for each row
+  class FastlaneOutputToHtml
+    class << self
+      def convert_row(row)
+        wrapping_type = "p"
+        wrapping_class = type_to_class(row[:type])
+
+        return "<#{wrapping_type} class=\"#{wrapping_class}\">#{row[:message]}</#{wrapping_type}>"
+      end
+
+      def type_to_class(type)
+        if [:crash, :shell_error, :build_failure, :test_failure, :abort].include?(type)
+          return "crash"
+        elsif type == :user_error
+          return "user_error"
+        else
+          return type.to_s
+        end
+      end
+    end
+  end
+end

--- a/features/test_runner/fastlane_test_runner_helpers/fastlane_output_to_html.rb
+++ b/features/test_runner/fastlane_test_runner_helpers/fastlane_output_to_html.rb
@@ -11,6 +11,9 @@ module FastlaneCI
   # <p class="success">Step: default_platform</p>
   # 
   # It does so for each row
+  # 
+  # TODO: we decided to move this away long term, into the brower using JavaScript
+  #
   class FastlaneOutputToHtml
     class << self
       def convert_row(row)

--- a/launch.rb
+++ b/launch.rb
@@ -119,12 +119,14 @@ module FastlaneCI
       require_relative "features/login/login_controller"
       require_relative "features/notifications/notifications_controller"
       require_relative "features/project/project_controller"
+      require_relative "features/build/build_controller"
 
       # Load up all the available controllers
       FastlaneCI::FastlaneApp.use(FastlaneCI::DashboardController)
       FastlaneCI::FastlaneApp.use(FastlaneCI::LoginController)
       FastlaneCI::FastlaneApp.use(FastlaneCI::NotificationsController)
       FastlaneCI::FastlaneApp.use(FastlaneCI::ProjectController)
+      FastlaneCI::FastlaneApp.use(FastlaneCI::BuildController)
     end
 
     def self.launch_workers

--- a/services/code_hosting/git_hub_service.rb
+++ b/services/code_hosting/git_hub_service.rb
@@ -51,7 +51,7 @@ module FastlaneCI
       return client.statuses(repo_full_name, sha)
     end
 
-    # updates the most current commit to "pending" on all open prs if they don't have a status.    
+    # updates the most current commit to "pending" on all open prs if they don't have a status.
     # returns a list of commits that have been updated to `pending` status
     def update_all_open_prs_without_status_to_pending_status!(repo_full_name: nil)
       open_pr_commits = self.last_commit_sha_for_all_open_pull_requests(repo_full_name: repo_full_name)

--- a/services/test_runner_service.rb
+++ b/services/test_runner_service.rb
@@ -1,5 +1,11 @@
 module FastlaneCI
-  # Service that will interact with fastlane to run tests/lanes
+  # Responsible for the life cycle of running tests as part of fastlane.ci
+  # In particular this takes care of all the overhead, like measuring the time and storing & reporting
+  # the build status
+  # - TestRunnerService owns a TestRunner
+  # - TestRunnerService is alive until it's finished running
+  # - TestRunnerService is created on the fly, either when "resuming" a build, or when a new build is triggered by a project trigger
+  # - TestRunner only runs tests. Stays alive as long as the TestRunnerService
   # TODO: move github specific stuff out into GitHubService (GitHubService right now)
   # TODO: maybe rename this to GitHubTestRunnerService
   class TestRunnerService
@@ -11,7 +17,18 @@ module FastlaneCI
     attr_accessor :current_build
     attr_accessor :sha
 
-    def initialize(project: nil, sha: nil, github_service: nil)
+    # All lines that were generated so far, this might not be a complete run
+    # This is an array of hashes
+    # TODO: have a class representing a Row (has to offer dynamic values though, as we might have non fastlane runners in the future)
+    attr_accessor :all_lines
+
+    # All blocks listening to changes for this build
+    attr_accessor :all_blocks
+
+    # The TestRunner object that is responsible for running the actual tests
+    attr_accessor :test_runner
+
+    def initialize(project: nil, sha: nil, github_service: nil, test_runner: nil)
       self.project = project
       self.sha = sha
 
@@ -19,6 +36,33 @@ module FastlaneCI
 
       # TODO: provider credential should determine what exact CodeHostingService gets instantiated
       self.code_hosting_service = github_service
+
+      self.all_lines = []
+      self.all_blocks = []
+
+      self.test_runner = FastlaneTestRunner.new(
+        platform: "ios", #nil, # TODO: is the platform gonna be part of the `project.lane`? Probably yes
+        lane: "beta", #project.lane, 
+        parameters: nil
+      )
+    end
+
+    def add_listener(block)
+      self.all_blocks << block
+    end
+
+    # Handle a new incoming row, and alert every stakeholder who is interested
+    def new_row(row)
+      logger.debug(row["message"])
+
+      # Report back the row
+      # 1) Store it in the history of logs (used to access half-built builds)
+      all_lines << row
+
+      # 2) Report back to all listeners, usually socket connections
+      self.all_blocks.each do |current_block|
+        current_block.call(row)
+      end
     end
 
     # Runs a new build, incrementing the build number from the number of builds
@@ -45,12 +89,10 @@ module FastlaneCI
       )
       update_build_status!
 
-      # TODO: Replace with fastlane runner here
-      command = "rubocop #{project.repo_config.local_repo_path}"
-      logger.info("Running #{command}")
-
-      cmd = TTY::Command.new
-      cmd.run(command)
+      logger.debug("Running runner now")
+      test_runner.run do |current_row|
+        new_row(current_row)
+      end
 
       duration = Time.now - start_time
 
@@ -77,12 +119,10 @@ module FastlaneCI
       self.current_build = build
       update_build_status!
 
-      # TODO: Replace with fastlane runner here
-      command = "rubocop #{project.repo_config.local_repo_path}"
-      logger.info("Running #{command}")
-
-      cmd = TTY::Command.new
-      cmd.run(command)
+      logger.debug("Running runner now")
+      test_runner.run do |row|
+        new_row(row)
+      end
 
       duration = Time.now - start_time
 

--- a/services/test_runner_service.rb
+++ b/services/test_runner_service.rb
@@ -14,8 +14,6 @@ module FastlaneCI
       # we need to hold all test runner services, to not destroy them with the garbage collector
       # and also to access them as part of our middle ware
       # it probably makes sense to have a single TestRunnerService, that holds multiple TestRunners instead
-      attr_accessor :test_runner_services
-
       def test_runner_services
         @test_runner_services ||= []
       end
@@ -53,14 +51,14 @@ module FastlaneCI
       self.all_blocks = []
 
       self.test_runner = FastlaneTestRunner.new(
-        platform: "ios", #nil, # TODO: is the platform gonna be part of the `project.lane`? Probably yes
-        lane: "beta", #project.lane, 
+        platform: "ios", # nil, # TODO: is the platform gonna be part of the `project.lane`? Probably yes
+        lane: "beta", # project.lane,
         parameters: nil
       )
 
       # Add yourself to the list of active workers so we can stream the output to the user
       # this might be nil, while the server still starts
-      puts "added myself to the backend list"
+      puts("added myself to the backend list")
       self.class.test_runner_services << self
     end
 

--- a/services/test_runner_service.rb
+++ b/services/test_runner_service.rb
@@ -30,10 +30,10 @@ module FastlaneCI
     # All lines that were generated so far, this might not be a complete run
     # This is an array of hashes
     # TODO: have a class representing a Row (has to offer dynamic values though, as we might have non fastlane runners in the future)
-    attr_accessor :all_lines
+    attr_accessor :all_build_output_log_lines
 
     # All blocks listening to changes for this build
-    attr_accessor :all_blocks
+    attr_accessor :build_change_observer_blocks
 
     # The TestRunner object that is responsible for running the actual tests
     attr_accessor :test_runner
@@ -47,8 +47,8 @@ module FastlaneCI
       # TODO: provider credential should determine what exact CodeHostingService gets instantiated
       self.code_hosting_service = github_service
 
-      self.all_lines = []
-      self.all_blocks = []
+      self.all_build_output_log_lines = []
+      self.build_change_observer_blocks = []
 
       self.test_runner = FastlaneTestRunner.new(
         platform: "ios", # nil, # TODO: is the platform gonna be part of the `project.lane`? Probably yes
@@ -63,7 +63,7 @@ module FastlaneCI
     end
 
     def add_listener(block)
-      self.all_blocks << block
+      self.build_change_observer_blocks << block
     end
 
     # Handle a new incoming row, and alert every stakeholder who is interested
@@ -72,10 +72,10 @@ module FastlaneCI
 
       # Report back the row
       # 1) Store it in the history of logs (used to access half-built builds)
-      all_lines << row
+      all_build_output_log_lines << row
 
       # 2) Report back to all listeners, usually socket connections
-      self.all_blocks.each do |current_block|
+      self.build_change_observer_blocks.each do |current_block|
         current_block.call(row)
       end
     end

--- a/services/test_runner_service.rb
+++ b/services/test_runner_service.rb
@@ -9,6 +9,18 @@ module FastlaneCI
   # TODO: move github specific stuff out into GitHubService (GitHubService right now)
   # TODO: maybe rename this to GitHubTestRunnerService
   class TestRunnerService
+    class << self
+      # TODO: move all the things below somewhere else
+      # we need to hold all test runner services, to not destroy them with the garbage collector
+      # and also to access them as part of our middle ware
+      # it probably makes sense to have a single TestRunnerService, that holds multiple TestRunners instead
+      attr_accessor :test_runner_services
+
+      def test_runner_services
+        @test_runner_services ||= []
+      end
+    end
+
     include FastlaneCI::Logging
 
     attr_accessor :project
@@ -45,6 +57,11 @@ module FastlaneCI
         lane: "beta", #project.lane, 
         parameters: nil
       )
+
+      # Add yourself to the list of active workers so we can stream the output to the user
+      # this might be nil, while the server still starts
+      puts "added myself to the backend list"
+      self.class.test_runner_services << self
     end
 
     def add_listener(block)


### PR DESCRIPTION
Fixes https://github.com/fastlane/ci/issues/201
Fixes https://github.com/fastlane/ci/issues/147

**To test this change:**
1. open a project view (e.g. `http://localhost:9292/projects/details/db799377-aaa3-4605-ba43-c91a13c8f83`)
1. Click on `Trigger job now`
1. See how half the build output is there instantly (shows that fastlane.ci "caches" the output)
1. See how more messages are being loaded as _fastlane_ runs the `Fastfile` (has a few sleeps in there to proof the real-time-ness)

**Notes**
1. Thin seems to require the use of `localhost` instead of `127.0.0.1`, I didn't look into this yet if we can support both
1. Main thing that's missing to get this in a rather solid state is the identification of a build. As raised the question in Slack (`I see the Build object doesn't have an ID like we have for all other objects. Is there a reason for that? Did we decide you can't run multiple builds for one sha? Is project + sha unique?)`). My proposal is to add a unique ID to builds also, so that this ID in combination with the project is unique (or even without the project?). Once that's done, multiple `# TODO` items from this PR can be resolved. (e.g. see https://github.com/fastlane/ci/pull/200/files#diff-40d0c75f55437cd62b7224bd7d90d275R14)
1. The custom middleware holds a reference to each web socket connection (https://github.com/fastlane/ci/pull/200/files#diff-7db6fa3652598445f8cb2adaed28ae88R40) grouped by the Build ID, so once the build ID is unique, without the project ideally, this will work nicely.
1. The frontend is just a basic proof of concept of course
1. We discussed that we don't want to generate the HTML on the backend long term. I'll change this with a follow-up PR
1. The `fastlane.log` file is hard coded for now, until we have the artifact system ready. 
1. I get those weird `lib/git/lib.rb:460: warning: conflicting chdir during another chdir block` warnings again. I assume this happens due to running _fastlane_ and we do some `Dir.chdir` in that code base also. I haven't verified yet if this PR adds this issue, or if that's already the case in `master`.
1. As seen in https://github.com/fastlane/ci/pull/200/files#diff-62e64a60028b7cd0fdf6248bbc3f9bfcR13, we currently have to store references to all active `test_runner_services` to keep them alive, and to be able to access them when the user wants to see their progress. I added a comment with a proposal on how we can properly architect it