### PR TITLE
Do not run build if the manual trigger is not set

### DIFF
--- a/features/project/project_controller.rb
+++ b/features/project/project_controller.rb
@@ -18,6 +18,13 @@ module FastlaneCI
 
       repo = FastlaneCI::GitRepo.new(git_config: project.repo_config, provider_credential: current_github_provider_credential)
       current_sha = repo.most_recent_commit.sha
+      manual_triggers_allowed = project.job_triggers.any? { |trigger| trigger.type == FastlaneCI::JobTrigger::TRIGGER_TYPE[:manual] }
+
+      unless manual_triggers_allowed
+        status(403) # Forbidden
+        body("Cannot build. There is no manual build trigger, for this branch, associated with this project.")
+        return
+      end
 
       # TODO: not the best approach to spawn a thread
       Thread.new do


### PR DESCRIPTION
Note: The "Trigger Job Now" button in the view has this request as the href. So if we return an error, it will just display it. The button needs to be fixed.