### PR TITLE
Migrate from sha-based identification to build number, allow multiple builds per sha

### DIFF
--- a/features/build/build_controller.rb
+++ b/features/build/build_controller.rb
@@ -11,16 +11,16 @@ module FastlaneCI
 
     get "#{HOME}/*" do |project_id, build_id|
       project = self.user_project_with_id(project_id: project_id)
-      build = project.builds.find { |b| b.sha == build_id } # TODO: We need a build ID, sha isn't enough
+      build = project.builds.find { |b| b.id == build_id }
 
       current_runner_service = TestRunnerService.test_runner_services.find do |t|
-        t.project.id == project_id && t.sha == build_id # TODO: just as above, use actual identification
+        t.project.id == project_id && t.current_build.id == build_id 
       end
 
       locals = {
         project: project,
         build: build,
-        title: "Project #{project.project_name}, Build #{build.sha}",
+        title: "Project #{project.project_name}, Build #{build.id}",
         existing_rows: current_runner_service.all_build_output_log_lines.collect { |a| a[:html] }
       }
       erb(:build, locals: locals, layout: FastlaneCI.default_layout)

--- a/features/build/build_controller.rb
+++ b/features/build/build_controller.rb
@@ -9,18 +9,21 @@ module FastlaneCI
 
     use(FastlaneCI::BuildWebsocketBackend)
 
-    get "#{HOME}/*" do |project_id, build_id|
-      project = self.user_project_with_id(project_id: project_id)
-      build = project.builds.find { |b| b.id == build_id }
+    get "#{HOME}/*" do |project_id, build_number|
+      build_number = build_number.to_i
 
+      project = self.user_project_with_id(project_id: project_id)
+      build = project.builds.find { |b| b.number == build_number }
+
+      # Fetch all the active runners, and see if there is one WIP
       current_runner_service = TestRunnerService.test_runner_services.find do |t|
-        t.project.id == project_id && t.current_build.id == build_id 
+        t.project.id == project_id && t.current_build.number == build_number
       end
 
       locals = {
         project: project,
         build: build,
-        title: "Project #{project.project_name}, Build #{build.id}",
+        title: "Project #{project.project_name}, Build #{build.number}",
         existing_rows: current_runner_service.all_build_output_log_lines.collect { |a| a[:html] }
       }
       erb(:build, locals: locals, layout: FastlaneCI.default_layout)

--- a/features/build/build_websocket_backend.rb
+++ b/features/build/build_websocket_backend.rb
@@ -45,8 +45,9 @@ module FastlaneCI
       ws.on(:open) do |event|
         logger.debug([:open, ws.object_id])
 
-        build_number = fetch_build_details(event)[:build_number]
-        project_id = fetch_build_details(event)[:project_id]
+        url_details = fetch_build_details(event)
+        build_number = url_details[:build_number]
+        project_id = url_details[:project_id]
 
         self.websocket_clients[project_id] ||= {}
         self.websocket_clients[project_id][build_number] ||= []
@@ -78,9 +79,11 @@ module FastlaneCI
       ws.on(:close) do |event|
         logger.debug([:close, ws.object_id, event.code, event.reason])
 
-        build_id = fetch_build_id(event)
+        url_details = fetch_build_details(event)
+        build_number = url_details[:build_number]
+        project_id = url_details[:project_id]
 
-        self.websocket_clients[build_id].delete(ws)
+        self.websocket_clients[project_id][build_number].delete(ws)
         ws = nil
       end
 

--- a/features/build/build_websocket_backend.rb
+++ b/features/build/build_websocket_backend.rb
@@ -14,7 +14,7 @@ module FastlaneCI
 
     KEEPALIVE_TIME = 30 # in seconds
 
-    # A hash of connected web sockets, the key being the build ID # TODO: right now we still use the sha
+    # A hash of connected web sockets, the key being the project ID, and then the build number
     attr_accessor :websocket_clients
 
     def initialize(app)
@@ -24,10 +24,14 @@ module FastlaneCI
       self.websocket_clients = {}
     end
 
-    def fetch_build_id(event)
+    def fetch_build_details(event)
       url = event.target.url
       parameters = Rack::Utils.parse_query(url)
-      return parameters["build"]
+
+      return {
+        project_id: parameters["project"],
+        build_number: parameters["build"].to_i
+      }
     end
 
     def call(env)
@@ -41,18 +45,25 @@ module FastlaneCI
       ws.on(:open) do |event|
         logger.debug([:open, ws.object_id])
 
-        build_id = fetch_build_id(event)
+        build_number = fetch_build_details(event)[:build_number]
+        project_id = fetch_build_details(event)[:project_id]
 
-        self.websocket_clients[build_id] ||= []
-        self.websocket_clients[build_id] << ws
+        self.websocket_clients[project_id] ||= {}
+        self.websocket_clients[project_id][build_number] ||= []
+        self.websocket_clients[project_id][build_number] << ws
 
         TestRunnerService.test_runner_services.each do |test_runner_service|
-          next if test_runner_service.sha != build_id # TODO: mismatch of sha, unify sha/build_id
+          next if test_runner_service.current_build.number != build_number
+          next if test_runner_service.project.id != project_id
 
+          # TODO: Think this through, do we properly add new listener, and notify them of line changes, etc.
+          #       Also how does the "offboarding" of runners work once the tests are finished
           test_runner_service.add_listener(proc do |row|
-            logger.debug("Streaming #{row} to #{self.websocket_clients.count} client(s)")
+            web_sockets = self.websocket_clients[project_id][build_number]
+            logger.debug("Streaming #{row} to #{web_sockets.count} client(s)")
 
-            self.websocket_clients[build_id].each do |current_socket|
+            web_sockets.each do |current_socket|
+              # TODO: Add auth check here, so a user isn't able to get the log from another build
               current_socket.send(row.to_json)
             end
           end)

--- a/features/build/views/build.erb
+++ b/features/build/views/build.erb
@@ -12,7 +12,7 @@
   document.addEventListener("DOMContentLoaded", function(event) { 
     var scheme = "ws://"
     var uri = scheme + window.document.location.host
-    uri += "/?&project=<%= project.id %>&build=<%= build.id %>"; // we add that extra & to make the Ruby URI parser work
+    uri += "/?&project=<%= project.id %>&build=<%= build.number %>"; // we add that extra & to make the Ruby URI parser work
     var ws = new WebSocket(uri);
     console.log("Listening to web socket connection now for URL " + uri + "...")
     var firstMessageReceived = <%= existing_rows.count == 0 ? false : true %>;

--- a/features/build/views/build.erb
+++ b/features/build/views/build.erb
@@ -12,7 +12,7 @@
   document.addEventListener("DOMContentLoaded", function(event) { 
     var scheme = "ws://"
     var uri = scheme + window.document.location.host
-    uri += "/?&project=<%= project.id %>&build=<%= build.sha %>"; // we add that extra & to make the Ruby URI parser work
+    uri += "/?&project=<%= project.id %>&build=<%= build.id %>"; // we add that extra & to make the Ruby URI parser work
     var ws = new WebSocket(uri);
     console.log("Listening to web socket connection now for URL " + uri + "...")
     var firstMessageReceived = <%= existing_rows.count == 0 ? false : true %>;

--- a/features/project/project_controller.rb
+++ b/features/project/project_controller.rb
@@ -19,15 +19,18 @@ module FastlaneCI
       repo = FastlaneCI::GitRepo.new(git_config: project.repo_config, provider_credential: current_github_provider_credential)
       current_sha = repo.most_recent_commit.sha
 
+      test_runner = FastlaneCI::TestRunnerService.new(
+        project: project,
+        sha: current_sha
+      )
+
       # TODO: not the best approach to spawn a thread
+      # Use TaskQueue instead
       Thread.new do
-        FastlaneCI::TestRunnerService.new(
-          project: project,
-          sha: current_sha
-        ).run
+        test_runner.run
       end
 
-      redirect("#{HOME}/#{project_id}/builds/#{current_sha}")
+      redirect("#{HOME}/#{project_id}/builds/#{test_runner.current_build.id}")
     end
 
     # Edit a project settings

--- a/features/project/project_controller.rb
+++ b/features/project/project_controller.rb
@@ -19,7 +19,7 @@ module FastlaneCI
       repo = FastlaneCI::GitRepo.new(git_config: project.repo_config, provider_credential: current_github_provider_credential)
       current_sha = repo.most_recent_commit.sha
 
-      test_runner = FastlaneCI::TestRunnerService.new(
+      test_runner_service = FastlaneCI::TestRunnerService.new(
         project: project,
         sha: current_sha
       )
@@ -27,10 +27,10 @@ module FastlaneCI
       # TODO: not the best approach to spawn a thread
       # Use TaskQueue instead
       Thread.new do
-        test_runner.run
+        test_runner_service.run
       end
 
-      redirect("#{HOME}/#{project_id}/builds/#{test_runner.current_build.id}")
+      redirect("#{HOME}/#{project_id}/builds/#{test_runner_service.current_build.number}")
     end
 
     # Edit a project settings

--- a/features/project/views/project.erb
+++ b/features/project/views/project.erb
@@ -25,7 +25,7 @@
       </thead>
       <tbody>
         <% project.builds.each do |build| %>
-          <% url = "/projects/#{project.id}/builds/#{build.id}" %>
+          <% url = "/projects/#{project.id}/builds/#{build.number}" %>
           <tr style="cursor: pointer;" onclick="location.href='<%= url %>'">
             <td>
               <% if build.status == "success" %>

--- a/features/project/views/project.erb
+++ b/features/project/views/project.erb
@@ -25,7 +25,7 @@
       </thead>
       <tbody>
         <% project.builds.each do |build| %>
-          <% url = "/projects/#{project.id}/builds/#{build.sha}" %>
+          <% url = "/projects/#{project.id}/builds/#{build.id}" %>
           <tr style="cursor: pointer;" onclick="location.href='<%= url %>'">
             <td>
               <% if build.status == "success" %>

--- a/services/test_runner_service.rb
+++ b/services/test_runner_service.rb
@@ -56,9 +56,10 @@ module FastlaneCI
         parameters: nil
       )
 
+      self.prepare_build_object
+
       # Add yourself to the list of active workers so we can stream the output to the user
       # this might be nil, while the server still starts
-      puts("added myself to the backend list")
       self.class.test_runner_services << self
     end
 
@@ -80,12 +81,7 @@ module FastlaneCI
       end
     end
 
-    # Runs a new build, incrementing the build number from the number of builds
-    # for a given project
-    #
-    # @return [nil]
-    def run
-      start_time = Time.now
+    def prepare_build_object
       builds = build_service.list_builds(project: self.project)
 
       if builds.count > 0
@@ -103,8 +99,17 @@ module FastlaneCI
         sha: self.sha
       )
       update_build_status!
+    end
+
+    # Runs a new build, incrementing the build number from the number of builds
+    # for a given project
+    #
+    # @return [nil]
+    def run
+      start_time = Time.now
 
       logger.debug("Running runner now")
+
       test_runner.run do |current_row|
         new_row(current_row)
       end

--- a/shared/models/build.rb
+++ b/shared/models/build.rb
@@ -1,5 +1,6 @@
 module FastlaneCI
   # Represents a build, part of a project, usually many builds per project
+  # One build is identified using the `build.project.id` + `build.number`
   class Build
     BUILD_STATUSES = [
       :success,
@@ -9,9 +10,6 @@ module FastlaneCI
 
     # A reference to the project this build is associated with
     attr_accessor :project
-
-    # @return [String] UDID to identify the build
-    attr_accessor :id
 
     # @return [Integer]
     attr_accessor :number
@@ -28,14 +26,13 @@ module FastlaneCI
     # @return [String] The git sha of the commit this build was run for
     attr_accessor :sha
 
-    def initialize(project: nil, number: nil, status: nil, timestamp: nil, duration: nil, sha: nil, id: nil)
+    def initialize(project: nil, number: nil, status: nil, timestamp: nil, duration: nil, sha: nil)
       self.project = project
       self.number = number
       self.status = status
       self.timestamp = timestamp
       self.duration = duration
       self.sha = sha
-      self.id = id || SecureRandom.uuid
     end
 
     def status=(new_value)

--- a/shared/models/build.rb
+++ b/shared/models/build.rb
@@ -10,6 +10,9 @@ module FastlaneCI
     # A reference to the project this build is associated with
     attr_accessor :project
 
+    # @return [String] UDID to identify the build
+    attr_accessor :id
+
     # @return [Integer]
     attr_accessor :number
 
@@ -25,13 +28,14 @@ module FastlaneCI
     # @return [String] The git sha of the commit this build was run for
     attr_accessor :sha
 
-    def initialize(project: nil, number: nil, status: nil, timestamp: nil, duration: nil, sha: nil)
+    def initialize(project: nil, number: nil, status: nil, timestamp: nil, duration: nil, sha: nil, id: nil)
       self.project = project
       self.number = number
       self.status = status
       self.timestamp = timestamp
       self.duration = duration
       self.sha = sha
+      self.id = id || SecureRandom.uuid
     end
 
     def status=(new_value)


### PR DESCRIPTION
Fixes https://github.com/fastlane/ci/issues/219
Fixes https://github.com/fastlane/ci/issues/211

This allows us to
- Identify each build with `project.id` + `build.number`
- Properly identify a build for real time streaming (access control missing)
- Properly fetch existing running test runners and get their output
- Automatically redirect to the build output right after triggering a new build manually
- Run multiple builds for one commit sha