### PR TITLE
Use `subject` instead of `UserService.any_instance` in method stubs for `UserServiceSpec`.

### DIFF
--- a/services/user_service.rb
+++ b/services/user_service.rb
@@ -74,7 +74,7 @@ module FastlaneCI
       provider_credential = GitHubProviderCredential.new(
         id: id, email: email, api_token: api_token, full_name: full_name
       )
-      user = Services.user_service.find_user(id: user_id)
+      user = find_user(id: user_id)
 
       if user.nil?
         logger.error("Can't create provider credential for user, since user does not exist.")
@@ -85,7 +85,7 @@ module FastlaneCI
           password_hash: user.password_hash,
           provider_credentials: user.provider_credentials.push(provider_credential)
         )
-        Services.user_service.update_user!(user: new_user)
+        update_user!(user: new_user)
       end
     end
 
@@ -97,7 +97,7 @@ module FastlaneCI
       provider_credential = GitHubProviderCredential.new(
         email: email, api_token: api_token, full_name: full_name
       )
-      user = Services.user_service.find_user(id: user_id)
+      user = find_user(id: user_id)
 
       if user.nil?
         logger.error("Can't update provider credential for user, since user does not exist.")
@@ -113,7 +113,7 @@ module FastlaneCI
           password_hash: user.password_hash,
           provider_credentials: new_provider_credentials
         )
-        Services.user_service.update_user!(user: new_user)
+        update_user!(user: new_user)
       end
     end
   end

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -53,8 +53,8 @@ describe FastlaneCI::UserService do
 
     context "user exists" do
       before(:each) do
-        FastlaneCI::UserService.any_instance.stub(:find_user).with(id: user_id) { user }
-        FastlaneCI::UserService.any_instance.stub(:update_user!).with(user: updated_user)
+        subject.stub(:find_user).with(id: user_id) { user }
+        subject.stub(:update_user!).with(user: updated_user)
       end
 
       it "creates a new provider credential for the user" do
@@ -95,8 +95,8 @@ describe FastlaneCI::UserService do
 
     context "user exists" do
       before(:each) do
-        FastlaneCI::UserService.any_instance.stub(:find_user).with(id: user_id) { user }
-        FastlaneCI::UserService.any_instance.stub(:update_user!).with(user: updated_user)
+        subject.stub(:find_user).with(id: user_id) { user }
+        subject.stub(:update_user!).with(user: updated_user)
       end
 
       it "replaces provider credential for the user" do


### PR DESCRIPTION
Originally, these tests were for a `ProviderCredentialService`, not for the `UserService`. I forgot to convert the specs to use `subject` instead of `UserService.any_instance` in the test stubs.