### PR TITLE
Improve logger messages when they are arrays

### DIFF
--- a/shared/logging_module.rb
+++ b/shared/logging_module.rb
@@ -46,6 +46,9 @@ module FastlaneCI
             thread_id = " #{Thread.current[:thread_id]}" unless Thread.current[:thread_id].nil?
           end
 
+          if msg.class == Array
+            msg = msg.join("\n")
+          end
           "[#{datetime.strftime('%Y-%m-%d %H:%M:%S')}#{thread_id}] #{severity} #{progname}:  #{msg}\n"
         end
 


### PR DESCRIPTION
Instead of printing out the array, we'll join the contents and print. That makes exception printing much nicer when we do logger.error(ex)