### PR TITLE
Wrap FastlaneCI-specific environment variables in their own class

### DIFF
--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -7,6 +7,7 @@ require_relative "./fastfile-parser/fastfile_parser"
 require_relative "services/services"
 require_relative "workers/refresh_config_data_sources_worker"
 require_relative "shared/logging_module"
+require_relative "shared/environment_variables"
 require_relative "shared/fastlane_ci_error" # TODO: move somewhere else
 require_relative "features/build_runner/build_runner"
 
@@ -16,6 +17,10 @@ module FastlaneCI
   # https://stackoverflow.com/questions/26080599/sinatra-method-to-set-layout
   def self.default_layout
     "../../../features/global/layout".to_sym
+  end
+
+  def self.env
+    @env ||= FastlaneCI::EnvironmentVariables.new
   end
 
   # Our CI app main class

--- a/features/configuration/configuration_controller.rb
+++ b/features/configuration/configuration_controller.rb
@@ -73,14 +73,7 @@ module FastlaneCI
 
     # @return [Hash]
     def keys
-      {
-        encryption_key: ENV["FASTLANE_CI_ENCRYPTION_KEY"],
-        ci_user_email: ENV["FASTLANE_CI_USER"],
-        ci_user_api_token: ENV["FASTLANE_CI_PASSWORD"],
-        repo_url: ENV["FASTLANE_CI_REPO_URL"],
-        clone_user_email: ENV["FASTLANE_CI_INITIAL_CLONE_EMAIL"],
-        clone_user_api_token: ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"]
-      }
+      FastlaneCI.env.all
     end
 
     #####################################################

--- a/features/configuration/views/warnings/_env_variables.erb
+++ b/features/configuration/views/warnings/_env_variables.erb
@@ -9,11 +9,11 @@
     # Randomly generated key, that's used to encrypt the user passwords
     FASTLANE_CI_ENCRYPTION_KEY='key'
 
-    # The email address of your fastlane CI bot account
+    # The email address for your fastlane CI bot account
     FASTLANE_CI_USER='email-for-your-bot-account@gmail.com'
 
-    # The API token of your fastlane CI bot account
-    FASTLANE_CI_PASSWORD='encrypted_api_password'
+    # The password for your fastlane CI bot account
+    FASTLANE_CI_PASSWORD='your_ci_bot_password'
 
     # The git URL (https) for the configuration repo
     FASTLANE_CI_REPO_URL='https://github.com/username/reponame'

--- a/launch.rb
+++ b/launch.rb
@@ -81,7 +81,7 @@ module FastlaneCI
       # Setup the fastlane.ci GitRepoConfig
       @_ci_config_repo ||= GitRepoConfig.new(
         id: "fastlane-ci-config",
-        git_url: ENV["FASTLANE_CI_REPO_URL"],
+        git_url: FastlaneCI.env.repo_url,
         description: "Contains the fastlane.ci configuration",
         name: "fastlane ci",
         hidden: true
@@ -221,8 +221,8 @@ module FastlaneCI
     rescue StandardError => ex
       logger.error("Something went wrong on the initial clone")
 
-      if ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"].to_s.length == 0 || ENV["FASTLANE_CI_INITIAL_CLONE_EMAIL"].to_s.length == 0
-        logger.error("Make sure to provide your `FASTLANE_CI_INITIAL_CLONE_EMAIL` and `FASTLANE_CI_INITIAL_CLONE_API_TOKEN` ENV variables")
+      if FastlaneCI.env.initial_clone_api_token.to_s.empty?
+        logger.error("Make sure to provide your `FASTLANE_CI_INITIAL_CLONE_API_TOKEN` ENV variable")
       end
 
       raise ex
@@ -240,8 +240,8 @@ module FastlaneCI
     # @return [GitHubProviderCredential]
     def self.provider_credential
       @provider_credential ||= GitHubProviderCredential.new(
-        email: ENV["FASTLANE_CI_INITIAL_CLONE_EMAIL"],
-        api_token: ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"]
+        email: FastlaneCI.env.initial_clone_email,
+        api_token: FastlaneCI.env.initial_clone_api_token
       )
     end
 

--- a/services/configuration_repository_service.rb
+++ b/services/configuration_repository_service.rb
@@ -58,17 +58,17 @@ module FastlaneCI
     def serialized_users
       users = [
         User.new(
-          email: ENV["FASTLANE_CI_USER"],
-          password_hash: BCrypt::Password.create(ENV["FASTLANE_CI_PASSWORD"]),
+          email: FastlaneCI.env.ci_user_email,
+          password_hash: BCrypt::Password.create(FastlaneCI.env.ci_user_password),
           provider_credentials: [
             FastlaneCI::GitHubProviderCredential.new(
-              email: ENV["FASTLANE_CI_USER"],
-              api_token: ENV["FASTLANE_CI_PASSWORD"],
+              email: FastlaneCI.env.ci_user_email,
+              api_token: FastlaneCI.env.ci_user_password,
               full_name: "CI User credentials"
             ),
             FastlaneCI::GitHubProviderCredential.new(
-              email: ENV["FASTLANE_CI_INITIAL_CLONE_EMAIL"],
-              api_token: ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"],
+              email: FastlaneCI.env.initial_clone_email,
+              api_token: FastlaneCI.env.initial_clone_api_token,
               full_name: "Clone User credentials"
             )
           ]
@@ -128,14 +128,14 @@ module FastlaneCI
     #
     # @return [String]
     def repo_name
-      ENV["FASTLANE_CI_REPO_URL"].split("/").last
+      FastlaneCI.env.repo_url.split("/").last
     end
 
     # The short-form of the configuration repository URL `ueser/repo`
     #
     # @return [String]
     def repo_shortform
-      ENV["FASTLANE_CI_REPO_URL"].split("/").last(2).join("/")
+      FastlaneCI.env.repo_url.split("/").last(2).join("/")
     end
   end
 end

--- a/services/environment_variable_service.rb
+++ b/services/environment_variable_service.rb
@@ -34,17 +34,17 @@ module FastlaneCI
     # Verifies the proper environment variables needed to run the server are
     # present
     def verify_env_variables
-      if ENV["FASTLANE_CI_ENCRYPTION_KEY"].nil?
+      if FastlaneCI.env.encryption_key.nil?
         warn("Error: unable to decrypt sensitive data without environment variable `FASTLANE_CI_ENCRYPTION_KEY` set")
         exit(1)
       end
 
-      if ENV["FASTLANE_CI_USER"].nil? || ENV["FASTLANE_CI_PASSWORD"].nil?
+      if FastlaneCI.env.ci_user_email.nil? || FastlaneCI.env.ci_user_password.nil?
         warn("Error: ensure you have your `FASTLANE_CI_USER` and `FASTLANE_CI_PASSWORD`environment variables set")
         exit(1)
       end
 
-      if ENV["FASTLANE_CI_REPO_URL"].nil?
+      if FastlaneCI.env.repo_url.nil?
         warn("Error: ensure you have your `FASTLANE_CI_REPO_URL` environment variable set")
         exit(1)
       end

--- a/services/services.rb
+++ b/services/services.rb
@@ -55,7 +55,7 @@ module FastlaneCI
     def self.ci_config_repo
       @_ci_config_repo ||= GitRepoConfig.new(
         id: "fastlane-ci-config",
-        git_url: ENV["FASTLANE_CI_REPO_URL"],
+        git_url: FastlaneCI.env.repo_url,
         description: "Contains the fastlane.ci configuration",
         name: "fastlane ci",
         hidden: true
@@ -75,8 +75,8 @@ module FastlaneCI
     def self.ci_user
       # Find our fastlane.ci system user
       @_ci_user ||= Services.user_service.login(
-        email: ENV["FASTLANE_CI_USER"],
-        password: ENV["FASTLANE_CI_PASSWORD"],
+        email: FastlaneCI.env.ci_user_email,
+        password: FastlaneCI.env.ci_user_password,
         ci_config_repo: self.ci_config_repo
       )
     end
@@ -93,8 +93,8 @@ module FastlaneCI
     # @return [GitHubProviderCredential]
     def self.provider_credential
       @_provider_credential ||= GitHubProviderCredential.new(
-        email: ENV["FASTLANE_CI_INITIAL_CLONE_EMAIL"],
-        api_token: ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"]
+        email: FastlaneCI.env.initial_clone_email,
+        api_token: FastlaneCI.env.initial_clone_api_token
       )
     end
 

--- a/shared/environment_variables.rb
+++ b/shared/environment_variables.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module FastlaneCI
+  # Class wrapping fastlane CI environment variables
+  class EnvironmentVariables
+    # @return [Hash]
+    def all
+      {
+        encryption_key: encryption_key,
+        ci_user_email: ci_user_email,
+        ci_user_api_token: ci_user_password,
+        repo_url: repo_url,
+        clone_user_email: initial_clone_email,
+        clone_user_api_token: initial_clone_api_token
+      }
+    end
+
+    # Randomly generated key, that's used to encrypt the user passwords
+    def encryption_key
+      ENV["FASTLANE_CI_ENCRYPTION_KEY"]
+    end
+
+    # The email address for your fastlane CI bot account
+    def ci_user_email
+      ENV["FASTLANE_CI_USER"]
+    end
+
+    # The password for your fastlane CI bot account
+    def ci_user_password
+      ENV["FASTLANE_CI_PASSWORD"]
+    end
+
+    # The git URL (https) for the configuration repo
+    def repo_url
+      ENV["FASTLANE_CI_REPO_URL"]
+    end
+
+    # Needed just for the first startup of fastlane.ci:
+    # The email address used for the intial clone for the config repo
+    def initial_clone_email
+      ENV["FASTLANE_CI_INITIAL_CLONE_EMAIL"]
+    end
+
+    # The API token used for the initial clone for the config repo
+    def initial_clone_api_token
+      ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"]
+    end
+  end
+end

--- a/shared/string_encrypter.rb
+++ b/shared/string_encrypter.rb
@@ -4,10 +4,12 @@ require_relative "logging_module"
 module FastlaneCI
   # makes encrypting string as easy as ijFkpReUM6kLfvry0A78cQ==
   class StringEncrypter
-    include FastlaneCI::Logging
+    class << self
+      include FastlaneCI::Logging
+    end
 
     def self.default_key
-      @_key ||= Digest::SHA256.digest(ENV["FASTLANE_CI_ENCRYPTION_KEY"])
+      @_key ||= Digest::SHA256.digest(FastlaneCI.env.encryption_key)
     end
 
     def self.encode(string, key: StringEncrypter.default_key)


### PR DESCRIPTION
https://github.com/fastlane/ci/issues/241

Wraps environment variables in their own class.

```ruby
FastlaneCI.env.repo_url
```
> Example usage