### PR TITLE
Fix issues with clean startup and Add Project workflow

### DIFF
--- a/features/configuration/configuration_controller.rb
+++ b/features/configuration/configuration_controller.rb
@@ -83,7 +83,7 @@ module FastlaneCI
     # @return [Set[String]]
     def post_parameter_list_for_validation
       Set.new(
-        %w(encryption_key ci_user_email ci_user_api_token repo_url
+        %w(encryption_key ci_user_email ci_user_password repo_url
            clone_user_email clone_user_api_token)
       )
     end

--- a/features/configuration/views/forms/_keys.erb
+++ b/features/configuration/views/forms/_keys.erb
@@ -11,7 +11,7 @@
 
   <p>
     <code>FASTLANE_CI_PASSWORD=</code>
-    <input type="text" name="ci_user_api_token", value=<%= keys[:ci_user_api_token] %>>
+    <input type="text" name="ci_user_password", value=<%= keys[:ci_user_password] %>>
   </p>
 
   <p>

--- a/features/project/project_controller.rb
+++ b/features/project/project_controller.rb
@@ -41,37 +41,6 @@ module FastlaneCI
       redirect("#{HOME}/#{project_id}/builds/#{build_runner.current_build_number}")
     end
 
-    # Details of a project settings
-    get "#{HOME}/:project_id" do
-      project = self.user_project_with_id(project_id: params[:project_id])
-
-      # TODO: We now access a file directly from the submodule
-      # That's of course far from ideal, and not something we want to do long term
-      # Long term, the best appraoch would probably to have the FastfileParser be
-      # its own Ruby gem, or even part of the fastlane/fastlane main repo
-      # For now, this is good enough, as we'll be moving so fast with this one
-
-      relative_fastfile_path = nil
-      available_lanes = []
-      absolute_fastfile_path = project.local_fastfile_path
-      unless absolute_fastfile_path.nil?
-        parser = Fastlane::FastfileParser.new(path: absolute_fastfile_path)
-        available_lanes = parser.available_lanes
-
-        project_path = project.repo_config.local_repo_path
-        relative_fastfile_path = Pathname.new(absolute_fastfile_path).relative_path_from(Pathname.new(project_path))
-      end
-
-      locals = {
-        project: project,
-        title: "Project #{project.project_name}",
-        available_lanes: available_lanes,
-        fastfile_path: relative_fastfile_path # TODO: rename param `fastfile_path` to `relative_fastfile_path`
-      }
-
-      erb(:project, locals: locals, layout: FastlaneCI.default_layout)
-    end
-
     post "#{HOME}/:project_id/save" do
       project_id = params[:project_id]
       project = self.user_project_with_id(project_id: project_id)
@@ -162,6 +131,37 @@ module FastlaneCI
       else
         raise "Project couldn't be created"
       end
+    end
+
+    # Details of a project settings
+    get "#{HOME}/:project_id" do
+      project = self.user_project_with_id(project_id: params[:project_id])
+
+      # TODO: We now access a file directly from the submodule
+      # That's of course far from ideal, and not something we want to do long term
+      # Long term, the best appraoch would probably to have the FastfileParser be
+      # its own Ruby gem, or even part of the fastlane/fastlane main repo
+      # For now, this is good enough, as we'll be moving so fast with this one
+
+      relative_fastfile_path = nil
+      available_lanes = []
+      absolute_fastfile_path = project.local_fastfile_path
+      unless absolute_fastfile_path.nil?
+        parser = Fastlane::FastfileParser.new(path: absolute_fastfile_path)
+        available_lanes = parser.available_lanes
+
+        project_path = project.repo_config.local_repo_path
+        relative_fastfile_path = Pathname.new(absolute_fastfile_path).relative_path_from(Pathname.new(project_path))
+      end
+
+      locals = {
+        project: project,
+        title: "Project #{project.project_name}",
+        available_lanes: available_lanes,
+        fastfile_path: relative_fastfile_path # TODO: rename param `fastfile_path` to `relative_fastfile_path`
+      }
+
+      erb(:project, locals: locals, layout: FastlaneCI.default_layout)
     end
   end
 end

--- a/launch.rb
+++ b/launch.rb
@@ -232,7 +232,7 @@ module FastlaneCI
     rescue StandardError => ex
       logger.error("Something went wrong on the initial clone")
 
-      if FastlaneCI.env.initial_clone_api_token.to_s.empty?
+      if FastlaneCI.env.clone_user_api_token.to_s.empty?
         logger.error("Make sure to provide your `FASTLANE_CI_INITIAL_CLONE_API_TOKEN` ENV variable")
       end
 
@@ -252,7 +252,7 @@ module FastlaneCI
     def self.provider_credential
       @provider_credential ||= GitHubProviderCredential.new(
         email: FastlaneCI.env.initial_clone_email,
-        api_token: FastlaneCI.env.initial_clone_api_token
+        api_token: FastlaneCI.env.clone_user_api_token
       )
     end
 

--- a/services/configuration_repository_service.rb
+++ b/services/configuration_repository_service.rb
@@ -62,13 +62,8 @@ module FastlaneCI
           password_hash: BCrypt::Password.create(FastlaneCI.env.ci_user_password),
           provider_credentials: [
             FastlaneCI::GitHubProviderCredential.new(
-              email: FastlaneCI.env.ci_user_email,
-              api_token: FastlaneCI.env.ci_user_password,
-              full_name: "CI User credentials"
-            ),
-            FastlaneCI::GitHubProviderCredential.new(
               email: FastlaneCI.env.initial_clone_email,
-              api_token: FastlaneCI.env.initial_clone_api_token,
+              api_token: FastlaneCI.env.clone_user_api_token,
               full_name: "Clone User credentials"
             )
           ]

--- a/services/data_sources/json_user_data_source.rb
+++ b/services/data_sources/json_user_data_source.rb
@@ -112,8 +112,8 @@ module FastlaneCI
           password_hash: BCrypt::Password.create(ENV["FASTLANE_CI_PASSWORD"]),
           provider_credentials: [
             FastlaneCI::GitHubProviderCredential.new(
-              email: FastlaneCI.env.ci_user_email,
-              api_token: FastlaneCI.env.ci_user_password,
+              email: FastlaneCI.env.initial_clone_email,
+              api_token: FastlaneCI.env.clone_user_api_token,
               full_name: "CI User credentials"
             )
           ]

--- a/services/environment_variable_service.rb
+++ b/services/environment_variable_service.rb
@@ -11,7 +11,7 @@ module FastlaneCI
       locals: {
         encryption_key: nil,
         ci_user_email: nil,
-        ci_user_api_token: nil,
+        ci_user_password: nil,
         repo_url: nil,
         clone_user_email: nil,
         clone_user_api_token: nil

--- a/services/file_writers/keys_writer.rb
+++ b/services/file_writers/keys_writer.rb
@@ -16,7 +16,7 @@ module FastlaneCI
         FASTLANE_CI_USER='#{locals[:ci_user_email]}'
 
         # The encrypted API token of your fastlane CI bot account
-        FASTLANE_CI_PASSWORD='#{locals[:ci_user_api_token]}'
+        FASTLANE_CI_PASSWORD='#{locals[:ci_user_password]}'
 
         # The git URL (https) for the configuration repo
         FASTLANE_CI_REPO_URL='#{locals[:repo_url]}'

--- a/services/services.rb
+++ b/services/services.rb
@@ -95,7 +95,7 @@ module FastlaneCI
     def self.provider_credential
       @_provider_credential ||= GitHubProviderCredential.new(
         email: FastlaneCI.env.initial_clone_email,
-        api_token: FastlaneCI.env.initial_clone_api_token
+        api_token: FastlaneCI.env.clone_user_api_token
       )
     end
 

--- a/shared/environment_variables.rb
+++ b/shared/environment_variables.rb
@@ -8,7 +8,7 @@ module FastlaneCI
       {
         encryption_key: encryption_key,
         ci_user_email: ci_user_email,
-        ci_user_api_token: ci_user_password,
+        ci_user_password: ci_user_password,
         repo_url: repo_url,
         clone_user_email: initial_clone_email,
         clone_user_api_token: initial_clone_api_token
@@ -42,7 +42,7 @@ module FastlaneCI
     end
 
     # The API token used for the initial clone for the config repo
-    def initial_clone_api_token
+    def clone_user_api_token
       ENV["FASTLANE_CI_INITIAL_CLONE_API_TOKEN"]
     end
   end

--- a/shared/models/project.rb
+++ b/shared/models/project.rb
@@ -1,5 +1,6 @@
 require "securerandom"
 
+require_relative "../../shared/logging_module"
 require_relative "artifact_provider"
 require_relative "local_artifact_provider"
 
@@ -7,6 +8,8 @@ module FastlaneCI
   # All metadata about a project.
   # A project is usually a git url, a lane, and a project name, like "Production Build"
   class Project
+    include FastlaneCI::Logging
+
     # @return [GitRepoConfig] URL to the Git repo
     attr_accessor :repo_config
 

--- a/spec/fixtures/files/templates/keys_template.txt
+++ b/spec/fixtures/files/templates/keys_template.txt
@@ -5,7 +5,7 @@ FASTLANE_CI_ENCRYPTION_KEY='key'
 FASTLANE_CI_USER='ci_user_email'
 
 # The encrypted API token of your fastlane CI bot account
-FASTLANE_CI_PASSWORD='ci_user_api_token'
+FASTLANE_CI_PASSWORD='ci_user_password'
 
 # The git URL (https) for the configuration repo
 FASTLANE_CI_REPO_URL='https://github.com/user/repo'

--- a/spec/services/file_writers/keys_writer_spec.rb
+++ b/spec/services/file_writers/keys_writer_spec.rb
@@ -27,7 +27,7 @@ describe FastlaneCI::KeysWriter do
       locals: {
         encryption_key: "key",
         ci_user_email: "ci_user_email",
-        ci_user_api_token: "ci_user_api_token",
+        ci_user_password: "ci_user_password",
         repo_url: "https://github.com/user/repo",
         clone_user_email: "clone_user_email",
         clone_user_api_token: "clone_user_api_token"


### PR DESCRIPTION
There were some issues raised by the latest PR, so I have tried to tackled them all. As far as I've tested, this should work out of the box with an empty ci-config repo and no previous session stored in the browser.