### PR TITLE
Auto-fill project name with repo name

### DIFF
--- a/features/project/views/new_project_form.erb
+++ b/features/project/views/new_project_form.erb
@@ -15,7 +15,7 @@
     <form method="POST" action="/projects/add/<%= repo.git_config.name %>">
       <h5>Adding <%= repo.git_config.full_name %></h5>
       <div class="mdl-textfield mdl-js-textfield">
-        <input class="mdl-textfield__input" type="text" name="project_name">
+        <input class="mdl-textfield__input" type="text" name="project_name" value="<%= repo.git_config.full_name %>">
         <label class="mdl-textfield__label" for="project_name">Project Name</label>
       </div>
       <br />


### PR DESCRIPTION
I'd argue that often you'd have the repo name somewhere in the project title, but often you'd want to append `nightly` or `tests` or similar I think