### PR TITLE
[WIP] Add initial lane visuals to project settings

### DIFF
--- a/features/fastfile_editor/README.md
+++ b/features/fastfile_editor/README.md
@@ -1,0 +1,1 @@
+This directory contains all code related to rendering and editing a `Fastfile`

--- a/features/fastfile_editor/views/fastfile.erb
+++ b/features/fastfile_editor/views/fastfile.erb
@@ -1,0 +1,63 @@
+<hr />
+
+
+<p><code>Fastfile</code> located at path <code><%= fastfile_path %></code></p>
+<div id="lanes">
+	<% fastfile_parser.all_lanes_flat(ignore_actions_outside_of_lanes: true).each do |full_lane_name, lane_content| %>
+		<div class="laneColumn">
+			<button type="button" id="lane-<%= full_lane_name %>" lane="<%= full_lane_name %>" onclick="alert('This button doesnt actually do anything yet, but soon youll be able to select the lane usig it')"><%= full_lane_name %></button>
+
+			<% if lane_content[:description].join("").length > 0 %>
+				<div class="laneDescription">
+					<%= lane_content[:description].join(" ") %>
+				</div>
+			<% end %>
+
+			<% lane_content[:actions].each do |current_action| %>
+				<% if current_action[:action] %>
+					<div class="laneAction" lanename="<%= full_lane_name %>" title="<%= CGI.escapeHTML(current_action[:parameters].to_s) %>"><%= current_action[:action] %></div>
+				<% elsif current_action[:advancedCode] %>
+					<div class="laneAction advancedCode" lanename="<%= full_lane_name %>"><%= current_action[:advancedCode] %></div>
+				<% end %>
+			<% end %>
+		</div>
+	<% end %>
+</div>
+
+
+<style>
+  /* Everything related to rendering the lanes */
+  #lanes {
+    
+  }
+  #lanes > .laneColumn {
+    vertical-align: top;
+    display: inline-block;
+    text-align: center;
+    width: 220px;
+    margin-top: 0;
+  }
+  #lanes > .laneColumn > .laneDescription {
+  	background-color: #EEA;
+  	padding: 10px;
+  	border-radius: 9px;
+  	margin-top: 10px;
+  }
+  #lanes > .laneColumn > .laneButton {
+    margin: 0 10px;
+    width: 200px;
+  }
+  #lanes > .laneColumn > .laneAction {
+    background-color: #CCC;
+    padding: 15px;
+    border-radius: 9px;
+    margin: 10px auto 10px auto;
+    text-align: center;
+    width: 150px;
+  }
+  #lanes > .laneColumn > .laneAction.advancedCode {
+    text-align: left;
+    font-family: Consolas, monaco, monospace;
+    font-size: 10px;
+  }
+</style>

--- a/features/project/project_controller.rb
+++ b/features/project/project_controller.rb
@@ -142,8 +142,8 @@ module FastlaneCI
       available_lanes = []
       absolute_fastfile_path = project.local_fastfile_path
       unless absolute_fastfile_path.nil?
-        parser = Fastlane::FastfileParser.new(path: absolute_fastfile_path)
-        available_lanes = parser.available_lanes
+        fastfile_parser = Fastlane::FastfileParser.new(path: absolute_fastfile_path)
+        available_lanes = fastfile_parser.available_lanes
 
         project_path = project.repo_config.local_repo_path
         relative_fastfile_path = Pathname.new(absolute_fastfile_path).relative_path_from(Pathname.new(project_path))
@@ -153,6 +153,7 @@ module FastlaneCI
         project: project,
         title: "Project #{project.project_name}",
         available_lanes: available_lanes,
+        fastfile_parser: fastfile_parser,
         fastfile_path: relative_fastfile_path # TODO: rename param `fastfile_path` to `relative_fastfile_path`
       }
 

--- a/features/project/views/project.erb
+++ b/features/project/views/project.erb
@@ -21,6 +21,7 @@
     </section>
     <section class="mdl-layout__tab-panel" id="scroll-tab-settings">
       <%= erb(:project_settings, locals: { project: project , available_lanes: available_lanes, fastfile_path: fastfile_path }) %>
+      <%= erb(:project_settings, locals: { project: project , available_lanes: available_lanes, fastfile_path: fastfile_path, fastfile_parser: fastfile_parser }) %>
     </section>
   </main>
 </div>

--- a/features/project/views/project_settings.erb
+++ b/features/project/views/project_settings.erb
@@ -18,3 +18,5 @@
   <br />
   <input class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" type="submit" title="Save">
 </form>
+
+  <%= erb(:"../../fastfile_editor/views/fastfile", locals: { fastfile_parser: fastfile_parser, fastfile_path: fastfile_path }) %>


### PR DESCRIPTION
What kind of magic is this!?!?!?!?!?!111eleven!!

<img width="992" alt="screen shot 2018-03-09 at 4 46 44 pm" src="https://user-images.githubusercontent.com/869950/37231728-403506f8-23ba-11e8-8bbe-ae455f14c483.png">


Early WIP, just a prototype to see what it might look like. We can use this to let the user select the lane and immediately see what each lane does. Please don't continue working on this for now, I'll write more details on the goals about this, etc. next week