### PR TITLE
Report status from fastlane, instead of :success

### DIFF
--- a/services/code_hosting/git_hub_service.rb
+++ b/services/code_hosting/git_hub_service.rb
@@ -51,11 +51,11 @@ module FastlaneCI
       # if no specific branch, return all open prs
       return all_open_pull_requests if branches.nil? || branches.count == 0
 
-      # we want only the PRs whose latest commit was to one of the branches passed in
-      logger.debug("Returning all open prs from: #{repo_full_name}, branches: #{branches}")
-
       branch_set = branches.to_set
       all_open_pull_requests_on_branch = all_open_pull_requests.select { |pull_request| branch_set.include?(pull_request.head.ref) }
+
+      # we want only the PRs whose latest commit was to one of the branches passed in
+      logger.debug("Returning all open prs from: #{repo_full_name}, branches: #{branches}, pr count: #{all_open_pull_requests.count}")
       return all_open_pull_requests_on_branch
     end
 

--- a/services/worker_service.rb
+++ b/services/worker_service.rb
@@ -16,7 +16,7 @@ module FastlaneCI
     end
 
     def project_to_workers_dictionary_key(project: nil, user_responsible: nil)
-      logger.debug("Generating a key for project: `#{project.project_name}` (#{project.id}), user: #{user_responsible}")
+      logger.debug("Generating a key for project: `#{project.project_name}` (#{project.id}), user: #{user_responsible.email}")
       return "#{project.id}_#{user_responsible.id}"
     end
 

--- a/shared/models/git_repo.rb
+++ b/shared/models/git_repo.rb
@@ -208,7 +208,6 @@ module FastlaneCI
       logger.debug("Using #{full_name} with #{username} as author information on #{self.git_config.git_url}")
       git.config("user.name", full_name)
       git.config("user.email", username)
-      logger.debug("done setup_author")
     end
 
     def temporary_git_storage
@@ -275,7 +274,7 @@ module FastlaneCI
     # TODO: this method isn't actually tested yet
     def commit_changes!(commit_message: nil, file_to_commit: nil, repo_auth: self.repo_auth)
       git_action_with_queue do
-        logger.debug("Starting commit_changes! #{self.git_config.git_url}")
+        logger.debug("Starting commit_changes! #{self.git_config.git_url} for #{repo_auth.username}")
         raise "file_to_commit not yet implemented" if file_to_commit
         commit_message ||= "Automatic commit by fastlane.ci"
 
@@ -291,7 +290,7 @@ module FastlaneCI
         else
           git.commit(commit_message)
           git.push
-          logger.debug("Done commit_changes! #{self.git_config.full_name}")
+          logger.debug("Done commit_changes! #{self.git_config.full_name} for #{repo_auth.username}")
         end
       end
     end

--- a/workers/github_worker_base.rb
+++ b/workers/github_worker_base.rb
@@ -72,8 +72,8 @@ module FastlaneCI
       repo.fetch
 
       repo.git_and_remote_branches_each do |git, branch|
-        # Only need to look at branches that have associated nightly build triggers
-        next unless self.target_branches_set.include?(branch.name)
+        next if branch.name.include?("HEAD ->")
+        # next unless self.target_branches_set.include?(branch.name)
 
         # There might be un-committed changes in there, so ignore
         git.reset_hard

--- a/workers/worker_base.rb
+++ b/workers/worker_base.rb
@@ -47,7 +47,7 @@ module FastlaneCI
     end
 
     def die!
-      logger.debug("Stopping worker")
+      logger.debug("Shutting down worker's scheduler")
       self.scheduler.shutdown
     end
 


### PR DESCRIPTION
Report status coming from running a lane
Run builds for all commits that are on PRs