### PR TITLE
Add tests to ensure each feature and service directory has a README.md

### DIFF
--- a/features/build/README.md
+++ b/features/build/README.md
@@ -1,0 +1,5 @@
+# `features/build`
+
+This directory contains all classes necessary to access and render build details, including their output.
+
+This includes the real-time output streaming using a web socket connection.

--- a/features/build_runner/README.md
+++ b/features/build_runner/README.md
@@ -1,0 +1,5 @@
+# `features/build_runner`
+
+This directory includes the classes to represent a `BuildRunner`. A `BuildRunner` is responsible for running a given build (e.g. running unit tests) and reporting its status back to the `BuildRunnerService`.
+
+As a user of the classes here, you can register yourself as a listener (`add_listener`) to be updated in real-time.

--- a/features/configuration/README.md
+++ b/features/configuration/README.md
@@ -1,0 +1,3 @@
+# `features/configuration`
+
+Manage global `fastlane.ci` configuration, including first time setup. This includes basic information like linking the Git repo that holds the configuration and providing the encryption key.

--- a/features/credentials/README.md
+++ b/features/credentials/README.md
@@ -1,3 +1,3 @@
 # `features/credentials`
 
-A CRUD controller to manage provider credentials associated with a user. A `ProviderCredential` is a credential a user may use to access some third-party provider. For instance, the `GitHubProviderCredential` allows FastlaneCI users to interact with the GitHub API
+Manage provider credentials associated with a user. A `ProviderCredential` is a credential a user may use to access some third-party provider. For instance, the `GitHubProviderCredential` allows FastlaneCI users to interact with the GitHub API

--- a/features/credentials/README.md
+++ b/features/credentials/README.md
@@ -1,0 +1,3 @@
+# `features/credentials`
+
+A CRUD controller to manage provider credentials associated with a user. A `ProviderCredential` is a credential a user may use to access some third-party provider. For instance, the `GitHubProviderCredential` allows FastlaneCI users to interact with the GitHub API

--- a/features/dashboard/README.md
+++ b/features/dashboard/README.md
@@ -1,0 +1,3 @@
+# `features/dashboard`
+
+All the code related to the fastlane.ci dashboard, this is basically the landing page after the user is logged in.

--- a/features/global/README.md
+++ b/features/global/README.md
@@ -1,0 +1,3 @@
+# `features/global`
+
+Globally used `erb` files, meaning that other `features` will access files in this directory.

--- a/features/login/README.md
+++ b/features/login/README.md
@@ -1,0 +1,3 @@
+# `features/login`
+
+All code related to logging in, and creating a user. This does not include user management after being logged in.

--- a/features/notifications/README.md
+++ b/features/notifications/README.md
@@ -1,0 +1,3 @@
+# `features/notifications`
+
+Everything around handling and displaying notifications to user

--- a/features/partials/README.md
+++ b/features/partials/README.md
@@ -1,0 +1,3 @@
+# `features/partials`
+
+Similar to `global`, files in this directory will be used by other `features`. This folder includes `.erb` files.

--- a/features/project/README.md
+++ b/features/project/README.md
@@ -1,0 +1,3 @@
+# `features/project`
+
+Accessing a single project view. Responsible for updates, triggering builds, and displaying project info

--- a/features/users/README.md
+++ b/features/users/README.md
@@ -1,0 +1,3 @@
+# `features/users`
+
+Managing existing users of fastlane.ci

--- a/services/code_hosting/README.md
+++ b/services/code_hosting/README.md
@@ -1,0 +1,3 @@
+# `services/code_hosting`
+
+Accessing code hosting services, like GitHub or Bitbucket.

--- a/services/config_data_sources/README.md
+++ b/services/config_data_sources/README.md
@@ -1,9 +1,3 @@
-# configuration_data_sources
+# `services/config_data_sources`
 
 This directory contains all available data sources for storing the user's configuration.
-
-Example data for this directory:
-
-- Repos to monitor
-- Repo settings
-- Environment variables to use

--- a/services/data_sources/README.md
+++ b/services/data_sources/README.md
@@ -1,4 +1,4 @@
-# data_sources
+# `services/data_sources`
 
 This directory contains all available data sources for storing data by the CI. This does not include any user facing configuration, which is implemented in the `config_data_sources` directory.
 

--- a/services/file_writers/README.md
+++ b/services/file_writers/README.md
@@ -1,0 +1,3 @@
+# `services/file_writers`
+
+Stores content in files, e.g. secret keys

--- a/spec/docs_spec.rb
+++ b/spec/docs_spec.rb
@@ -1,0 +1,19 @@
+describe FastlaneCI do
+  describe "docs" do
+    Dir["features/*"].each do |feature_directory|
+      next unless File.directory?(feature_directory)
+      it "#{feature_directory} has a README.md" do
+        readme_path = File.join(feature_directory, "README.md")
+        expect(File.exist?(readme_path)).to eq(true), "Every directory in the `feature` area must have a README.md describing the scope and responsibilities of the classes (#{feature_directory})"
+      end
+    end
+
+    Dir["services/*"].each do |service_directory|
+      next unless File.directory?(service_directory)
+      it "#{service_directory} has a README.md" do
+        readme_path = File.join(service_directory, "README.md")
+        expect(File.exist?(readme_path)).to eq(true), "Every directory in the `feature` area must have a README.md describing the scope and responsibilities of the classes (#{service_directory})"
+      end
+    end
+  end
+end

--- a/spec/docs_spec.rb
+++ b/spec/docs_spec.rb
@@ -8,7 +8,7 @@ describe FastlaneCI do
 
         content = File.read(readme_path)
         expect(content.length).to be > 20
-        expect(content).to start_with("# `features/#{feature_directory}`")
+        expect(content).to start_with("# `#{feature_directory}`")
       end
     end
 
@@ -17,7 +17,10 @@ describe FastlaneCI do
       it "#{service_directory} has a README.md" do
         readme_path = File.join(service_directory, "README.md")
         expect(File.exist?(readme_path)).to eq(true), "Every directory in the `feature` area must have a README.md describing the scope and responsibilities of the classes (#{service_directory})"
-        expect(File.read(readme_path).length).to be > 20
+
+        content = File.read(readme_path)
+        expect(content).to start_with("# `#{service_directory}`")
+        expect(content.length).to be > 20
       end
     end
   end

--- a/spec/docs_spec.rb
+++ b/spec/docs_spec.rb
@@ -5,6 +5,10 @@ describe FastlaneCI do
       it "#{feature_directory} has a README.md" do
         readme_path = File.join(feature_directory, "README.md")
         expect(File.exist?(readme_path)).to eq(true), "Every directory in the `feature` area must have a README.md describing the scope and responsibilities of the classes (#{feature_directory})"
+
+        content = File.read(readme_path)
+        expect(content.length).to be > 20
+        expect(content).to start_with("# `features/#{feature_directory}`")
       end
     end
 
@@ -13,6 +17,7 @@ describe FastlaneCI do
       it "#{service_directory} has a README.md" do
         readme_path = File.join(service_directory, "README.md")
         expect(File.exist?(readme_path)).to eq(true), "Every directory in the `feature` area must have a README.md describing the scope and responsibilities of the classes (#{service_directory})"
+        expect(File.read(readme_path).length).to be > 20
       end
     end
   end


### PR DESCRIPTION
Just like how we enforce class based comments for each class using rubocop, we should build fastlane.ci with a good documentation base. Having a README.md will make it easy for everyone working on this to see what's going on when they use the code locally, but also makes it a ton easier when using GitHub.com to browse through source code 👍

It's always good to enforce those practices, as it's much easier to add them as we build the system, vs spending a lot of time later on on adding them

This currently causes 13 failures, please append commits to this PR to add the missing documentation for the classes you have enough knowledge of to describe what they're responsible for