### PR TITLE
Make API clients injectable modules with memoized `client` methods.

### DIFF
--- a/services/api_clients/api_client.rb
+++ b/services/api_clients/api_client.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module FastlaneCI
+  # Injectable ApiClient module exposing APIs for the CI user, and clone users
+  #
+  # @abstract
+  module APIClient
+    # Returns an API client object with the CI user credentials
+    #
+    # @abstract
+    def client
+      not_implemented(__method__)
+    end
+  end
+end

--- a/services/api_clients/github_clients/bot_user_github_client.rb
+++ b/services/api_clients/github_clients/bot_user_github_client.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative "../api_client"
+
+module FastlaneCI
+  # An injectable module for easy access to the GitHub API
+  module BotUserGitHubClient
+    extend APIClient
+
+    # Returns an GitHub API client object with the CI user credentials
+    #
+    # @return [Octokit::Client]
+    def client
+      @client ||= Octokit::Client.new(
+        login: FastlaneCI.env.ci_user_email,
+        password: FastlaneCI.env.ci_user_password,
+        api_endpoint: "https://api.github.com/"
+      )
+    end
+  end
+end

--- a/services/api_clients/github_clients/clone_user_github_client.rb
+++ b/services/api_clients/github_clients/clone_user_github_client.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../api_client"
+
+module FastlaneCI
+  # An injectable module for easy access to the GitHub API
+  module CloneUserGitHubClient
+    extend APIClient
+
+    # Returns an GitHub API client object with the clone user credentials
+    #
+    # @return [Octokit::Client]
+    def client
+      @client ||= Octokit::Client.new(
+        access_token: FastlaneCI.env.clone_user_api_token,
+        api_endpoint: "https://api.github.com/"
+      )
+    end
+  end
+end

--- a/services/code_hosting/git_hub_service.rb
+++ b/services/code_hosting/git_hub_service.rb
@@ -1,6 +1,7 @@
 require_relative "code_hosting_service"
 require_relative "../../taskqueue/task_queue"
 require_relative "../../shared/logging_module"
+require_relative "../api_clients/github_clients/clone_user_github_client"
 
 require "set"
 require "octokit"
@@ -8,6 +9,7 @@ require "octokit"
 module FastlaneCI
   # Data source that interacts with GitHub
   class GitHubService < CodeHostingService
+    include FastlaneCI::CloneUserGitHubClient
     include FastlaneCI::Logging
 
     class << self
@@ -24,13 +26,8 @@ module FastlaneCI
     def initialize(provider_credential: nil)
       self.provider_credential = provider_credential
 
-      @_client = Octokit::Client.new(access_token: provider_credential.api_token)
       Octokit.auto_paginate = true # TODO: just for now, we probably should do smart pagination in the future
       @task_queue = TaskQueue::TaskQueue.new(name: "#{provider_credential.type}-#{provider_credential.email}")
-    end
-
-    def client
-      @_client
     end
 
     def session_valid?

--- a/services/configuration_repository_service.rb
+++ b/services/configuration_repository_service.rb
@@ -1,20 +1,12 @@
 require "json"
+require_relative "./api_clients/github_clients/clone_user_github_client"
 
 module FastlaneCI
   # Provides operations to create and mutate the FastlaneCI configuration
   # repository
   class ConfigurationRepositoryService
+    include FastlaneCI::CloneUserGitHubClient
     include FastlaneCI::Logging
-
-    # @return [Octokit::Client]
-    attr_reader :client
-
-    # Instantiates new `ConfigurationRepositoryService` class
-    #
-    # @param  [ProviderCredential] provider_credential
-    def initialize(provider_credential: nil)
-      @client = Octokit::Client.new(access_token: provider_credential.api_token)
-    end
 
     # Creates a remote repository if it does not already exist, complete with
     # the expected remote files `user.json` and `projects.json`

--- a/services/services.rb
+++ b/services/services.rb
@@ -157,9 +157,7 @@ module FastlaneCI
 
     # @return [ConfigurationRepositoryService]
     def self.configuration_repository_service
-      @_configuration_repository_service ||= FastlaneCI::ConfigurationRepositoryService.new(
-        provider_credential: provider_credential
-      )
+      @_configuration_repository_service ||= FastlaneCI::ConfigurationRepositoryService.new
     end
 
     def self.environment_variable_service


### PR DESCRIPTION
### Usage

```ruby
class ClassThatNeedsBotUserCredentialsForAPI
  include FastlaneCI::BotUserGitHubClient

  def use_client
    client.repository?("fake_repo")
  end
end
```

> CI Bot User Credentials

```ruby
class ClassThatNeedsCloneUserCredentialsForAPI
  include FastlaneCI::CloneUserGitHubClient

  def use_client
    client.repository?("fake_repo")
  end
end
```

> Clone User Credentials

### Rationale

These modules can be easily extended/modified for when we wish to extend `fastlane.ci` for other API clients (Gitlab, etc.).

Thoughts?