### PR TITLE
bug fix: git repo config has incorrect local repo path

### DIFF
--- a/shared/models/repo_config.rb
+++ b/shared/models/repo_config.rb
@@ -13,7 +13,6 @@ module FastlaneCI
     attr_accessor :hidden # Do we want normal users to be able to see this?
     attr_accessor :provider_credential_type_needed # what kind of provider is needed? PROVIDER_CREDENTIAL_TYPES[]
     attr_writer :containing_path # directory containing the `local_repo_path`
-    attr_accessor :local_repo_path # mandatory to add this if we want to be serialized.
 
     def initialize(id: nil,
                    git_url: nil,
@@ -27,7 +26,10 @@ module FastlaneCI
       self.provider_credential_type_needed = provider_credential_type_needed
       self.name = name
       self.hidden = hidden
-      @local_repo_path = File.join(self.containing_path, @id)
+    end
+
+    def local_repo_path
+      File.join(self.containing_path, @id)
     end
 
     # This is where we store the local git repo


### PR DESCRIPTION
The JSON converter would start by creating a param-less version of the model. The constructor would use a random UUID for the `repo_config ID`. This would be used for the `local_repo_path`. Later as the JSON converter begins to fill in the model's properties the ID is changed to it's proper value, but the `local_repo_path` remains the same.

Git Clone would clone to the containing folder (`~/.fastlane/ci`) with the child folder of `git_config.id`. And we use the `git_config.local_repo_path` to reference this repo but it's in a different castle. 

Had to debug quite a bit to find this issue 😩 BUT NOW IT'S FIXED! 😸 