### PR TITLE
Tweak wording of initial commit

### DIFF
--- a/services/configuration_repository_service.rb
+++ b/services/configuration_repository_service.rb
@@ -103,7 +103,7 @@ module FastlaneCI
       client.contents(repo_shortform, path: file_path)
     rescue Octokit::NotFound
       client.create_contents(
-        repo_shortform, file_path, "Adding #{file_path}", json_string
+        repo_shortform, file_path, "Add initial #{file_path}", json_string
       )
     rescue Octokit::UnprocessableEntity
       logger.debug(


### PR DESCRIPTION
Commit messages should always be in present (just like you should live in the present in real life #meditation)