### PR TITLE
Make parameters of `login` method for user service required

### DIFF
--- a/services/user_service.rb
+++ b/services/user_service.rb
@@ -60,7 +60,7 @@ module FastlaneCI
       return self.user_data_source.find_user(id: id)
     end
 
-    def login(email: nil, password: nil, ci_config_repo: nil)
+    def login(email:, password:, ci_config_repo:)
       email = email.strip
 
       logger.debug("Attempting to login user with email #{email}")


### PR DESCRIPTION
I don't think we ever want to allow `nil` for any of those parameters