### PR TITLE
Password Fields in Onboarding Forms

### DIFF
--- a/features/onboarding/views/forms/_ci_bot_account.erb
+++ b/features/onboarding/views/forms/_ci_bot_account.erb
@@ -51,7 +51,7 @@
       <input
         id="ci_user_password"
         class="mdl-textfield__input"
-        type="text"
+        type="password"
         name="ci_user_password"
         value="<%= keys[:ci_user_password] %>"
         placeholder="Your GitHub bot's password"

--- a/features/onboarding/views/forms/_initial_clone_user.erb
+++ b/features/onboarding/views/forms/_initial_clone_user.erb
@@ -43,7 +43,7 @@
       <input
         id="clone_user_api_token"
         class="mdl-textfield__input"
-        type="text"
+        type="password"
         name="clone_user_api_token"
         value="<%= keys[:clone_user_api_token] %>"
         placeholder="The API token for your GitHub account"


### PR DESCRIPTION
Use password input fields instead of text fields in onboarding views for `ci_user_password` and `clone_user_api_token`.