### PR TITLE
Don't call `split` on the `FastlaneCI.env.repo_url` if it doesn't exist.

### DIFF
--- a/services/configuration_repository_service.rb
+++ b/services/configuration_repository_service.rb
@@ -157,6 +157,7 @@ module FastlaneCI
     #
     # @return [String]
     def repo_name
+      return "" unless FastlaneCI.env.repo_url
       FastlaneCI.env.repo_url.split("/").last
     end
 
@@ -164,6 +165,7 @@ module FastlaneCI
     #
     # @return [String]
     def repo_shortform
+      return "" unless FastlaneCI.env.repo_url
       FastlaneCI.env.repo_url.split("/").last(2).join("/")
     end
   end


### PR DESCRIPTION
This is an onboarding edge-case where the user's local configuration repo doesn't exist, and the server tries to see if the remote configuration repository is valid without a valid `ENV["FASTLANE_CI_REPO_URL"]`.

https://github.com/fastlane/ci/blob/afd7dacbbcc47f800d3cd57bac2abf9c87f15f56/launch.rb#L22

https://github.com/fastlane/ci/blob/afd7dacbbcc47f800d3cd57bac2abf9c87f15f56/launch.rb#L68-L69

> When the first expression in the conditional is true (i.e., no local repository exists), and it checks the second expression in the conditional

https://github.com/fastlane/ci/blob/afd7dacbbcc47f800d3cd57bac2abf9c87f15f56/services/configuration_repository_service.rb#L160

> This `split` will fail if the `ENV["FASTLANE_CI_REPO_URL"]` has not been set