### PR TITLE
Reduce global static method code smells and reduce responsibilities of `Launch` class.

### DIFF
--- a/features/onboarding/onboarding_controller.rb
+++ b/features/onboarding/onboarding_controller.rb
@@ -168,7 +168,7 @@ module FastlaneCI
         )
         Services.configuration_repository_service.create_private_remote_configuration_repo
         Services.onboarding_service.trigger_initial_ci_setup
-        Launch.start_github_workers
+        Services.worker_service.start_github_workers
 
         session[:message] = <<~HTML
           Remote repo #{params[:repo_url]} successfully created

--- a/launch.rb
+++ b/launch.rb
@@ -26,8 +26,8 @@ module FastlaneCI
       configure_thread_abort
       Services.reset_services!
       register_available_controllers
-      start_github_workers
-      restart_any_pending_work
+      Services.worker_service.start_github_workers
+      Services.config_service.restart_any_pending_work
     end
 
     def self.require_fastlane_ci
@@ -102,118 +102,6 @@ module FastlaneCI
       FastlaneCI::FastlaneApp.use(FastlaneCI::ProviderCredentialsController)
       FastlaneCI::FastlaneApp.use(FastlaneCI::UsersController)
       FastlaneCI::FastlaneApp.use(FastlaneCI::BuildController)
-    end
-
-    def self.start_github_workers
-      return unless Services.onboarding_service.correct_setup?
-
-      launch_workers unless ENV["FASTLANE_CI_SKIP_WORKER_LAUNCH"]
-    end
-
-    def self.restart_any_pending_work
-      return unless Services.onboarding_service.correct_setup?
-
-      # this helps during debugging
-      # in the future we should allow this to be configurable behavior
-      return if ENV["FASTLANE_CI_SKIP_RESTARTING_PENDING_WORK"]
-
-      github_projects = Services.config_service.projects(provider_credential: Services.provider_credential)
-      github_service = FastlaneCI::GitHubService.new(provider_credential: Services.provider_credential)
-
-      run_pending_github_builds(projects: github_projects, github_service: github_service)
-      enqueue_builds_for_open_github_prs_with_no_status(projects: github_projects, github_service: github_service)
-    end
-
-    def self.launch_workers
-      logger.debug("Starting workers to monitor projects")
-      # Iterate through all provider credentials and their projects and start a worker for each project
-      Services.ci_user.provider_credentials.each do |provider_credential|
-        projects = Services.config_service.projects(provider_credential: provider_credential)
-        projects.each do |project|
-          Services.worker_service.start_workers_for_project_and_credential(
-            project: project,
-            provider_credential: provider_credential
-          )
-        end
-      end
-
-      logger.info("Seems like no workers were started to monitor your projects") if Services.worker_service.num_workers == 0
-
-      # Initialize the workers
-      # For now, we're not using a fancy framework that adds multiple heavy dependencies
-      # including a database, etc.
-      FastlaneCI::RefreshConfigDataSourcesWorker.new
-    end
-
-    # In the event of a server crash, we want to run pending builds on server
-    # initialization for all projects for the provider credentials
-    #
-    # @return [nil]
-    def self.run_pending_github_builds(projects: nil, github_service: nil)
-      logger.debug("Searching all projects for commits with pending status that need a new build")
-      # For each project, rerun all builds with the status of "pending"
-      projects.each do |project|
-        pending_build_shas_needing_rebuilds = Services.build_service.pending_build_shas_needing_rebuilds(project: project)
-        logger.debug("No pending work to reschedule for #{project.project_name}") if pending_build_shas_needing_rebuilds.count == 0
-
-        # Enqueue each pending build rerun in an asynchronous task queue
-        pending_build_shas_needing_rebuilds.each do |sha|
-          logger.debug("Found sha #{sha} that needs a rebuild for #{project.project_name}")
-          build_runner = FastlaneBuildRunner.new(
-            project: project,
-            sha: sha,
-            github_service: github_service,
-            work_queue: FastlaneCI::GitRepo.git_action_queue # using the git repo queue because of https://github.com/ruby-git/ruby-git/issues/355
-          )
-          build_runner.setup(parameters: nil)
-          Services.build_runner_service.add_build_runner(build_runner: build_runner)
-        end
-      end
-    end
-
-    # We might be in a situation where we have an open pr, but no status yet
-    # if that's the case, we should enqueue a build for it
-    def self.enqueue_builds_for_open_github_prs_with_no_status(projects: nil, github_service: nil)
-      logger.debug("Searching for open PRs with no status and starting a build for them")
-      projects.each do |project|
-        # TODO: generalize this sort of thing
-        credential_type = project.repo_config.provider_credential_type_needed
-
-        # we don't support anything other than GitHub right now
-        next unless credential_type == FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]
-
-        # Collect all the branches from the triggers on this project that are commit-based
-        branches_to_check = project.job_triggers
-                                   .select { |trigger| trigger.type == FastlaneCI::JobTrigger::TRIGGER_TYPE[:commit] }
-                                   .map(&:branch)
-                                   .uniq
-
-        repo_full_name = project.repo_config.full_name
-        # let's get all commit shas that need a build (no status yet)
-        commit_shas = github_service.last_commit_sha_for_all_open_pull_requests(repo_full_name: repo_full_name, branches: branches_to_check)
-
-        # no commit shas need to be switched to `pending` state
-        next unless commit_shas.count > 0
-
-        commit_shas.each do |current_sha|
-          logger.debug("Checking #{repo_full_name} sha: #{current_sha} for missing status")
-          statuses = github_service.statuses_for_commit_sha(repo_full_name: repo_full_name, sha: current_sha)
-
-          # if we have a status, skip it!
-          next if statuses.count > 0
-
-          logger.debug("Found sha: #{current_sha} in #{repo_full_name} missing status, adding build.")
-
-          build_runner = FastlaneBuildRunner.new(
-            project: project,
-            sha: current_sha,
-            github_service: github_service,
-            work_queue: FastlaneCI::GitRepo.git_action_queue # using the git repo queue because of https://github.com/ruby-git/ruby-git/issues/355
-          )
-          build_runner.setup(parameters: nil)
-          Services.build_runner_service.add_build_runner(build_runner: build_runner)
-        end
-      end
     end
   end
 end

--- a/services/config_service.rb
+++ b/services/config_service.rb
@@ -11,8 +11,10 @@ module FastlaneCI
     attr_accessor :project_service
     attr_accessor :ci_user
     attr_accessor :active_code_hosting_services # dictionary of active_code_hosting_service_key to CodeHosting
+    attr_accessor :clone_user_provider_credential
 
-    def initialize(project_service: FastlaneCI::Services.project_service, ci_user: nil)
+    def initialize(project_service: FastlaneCI::Services.project_service, ci_user: nil, clone_user_provider_credential:)
+      @clone_user_provider_credential = clone_user_provider_credential
       self.project_service = project_service
       self.ci_user = ci_user
       self.active_code_hosting_services = {}
@@ -26,6 +28,89 @@ module FastlaneCI
 
     def active_code_hosting_service_key(provider_credential: nil)
       return "#{provider_credential.provider_name}_#{self.ci_user.id}"
+    end
+
+    def restart_any_pending_work
+      return unless Services.onboarding_service.correct_setup?
+
+      # this helps during debugging
+      # in the future we should allow this to be configurable behavior
+      return if ENV["FASTLANE_CI_SKIP_RESTARTING_PENDING_WORK"]
+
+      github_projects = projects(provider_credential: clone_user_provider_credential)
+      github_service = FastlaneCI::GitHubService.new(provider_credential: clone_user_provider_credential)
+
+      run_pending_github_builds(projects: github_projects, github_service: github_service)
+      enqueue_builds_for_open_github_prs_with_no_status(projects: github_projects, github_service: github_service)
+    end
+
+    # In the event of a server crash, we want to run pending builds on server
+    # initialization for all projects for the provider credentials
+    def run_pending_github_builds(projects: nil, github_service: nil)
+      logger.debug("Searching all projects for commits with pending status that need a new build")
+      # For each project, rerun all builds with the status of "pending"
+      projects.each do |project|
+        pending_build_shas_needing_rebuilds = Services.build_service.pending_build_shas_needing_rebuilds(project: project)
+        logger.debug("No pending work to reschedule for #{project.project_name}") if pending_build_shas_needing_rebuilds.count == 0
+
+        # Enqueue each pending build rerun in an asynchronous task queue
+        pending_build_shas_needing_rebuilds.each do |sha|
+          logger.debug("Found sha #{sha} that needs a rebuild for #{project.project_name}")
+          build_runner = FastlaneBuildRunner.new(
+            project: project,
+            sha: sha,
+            github_service: github_service,
+            work_queue: FastlaneCI::GitRepo.git_action_queue # using the git repo queue because of https://github.com/ruby-git/ruby-git/issues/355
+          )
+          build_runner.setup(parameters: nil)
+          Services.build_runner_service.add_build_runner(build_runner: build_runner)
+        end
+      end
+    end
+
+    # We might be in a situation where we have an open pr, but no status yet
+    # if that's the case, we should enqueue a build for it
+    def enqueue_builds_for_open_github_prs_with_no_status(projects: nil, github_service: nil)
+      logger.debug("Searching for open PRs with no status and starting a build for them")
+      projects.each do |project|
+        # TODO: generalize this sort of thing
+        credential_type = project.repo_config.provider_credential_type_needed
+
+        # we don't support anything other than GitHub right now
+        next unless credential_type == FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]
+
+        # Collect all the branches from the triggers on this project that are commit-based
+        branches_to_check = project.job_triggers
+                                   .select { |trigger| trigger.type == FastlaneCI::JobTrigger::TRIGGER_TYPE[:commit] }
+                                   .map(&:branch)
+                                   .uniq
+
+        repo_full_name = project.repo_config.full_name
+        # let's get all commit shas that need a build (no status yet)
+        commit_shas = github_service.last_commit_sha_for_all_open_pull_requests(repo_full_name: repo_full_name, branches: branches_to_check)
+
+        # no commit shas need to be switched to `pending` state
+        next unless commit_shas.count > 0
+
+        commit_shas.each do |current_sha|
+          logger.debug("Checking #{repo_full_name} sha: #{current_sha} for missing status")
+          statuses = github_service.statuses_for_commit_sha(repo_full_name: repo_full_name, sha: current_sha)
+
+          # if we have a status, skip it!
+          next if statuses.count > 0
+
+          logger.debug("Found sha: #{current_sha} in #{repo_full_name} missing status, adding build.")
+
+          build_runner = FastlaneBuildRunner.new(
+            project: project,
+            sha: current_sha,
+            github_service: github_service,
+            work_queue: FastlaneCI::GitRepo.git_action_queue # using the git repo queue because of https://github.com/ruby-git/ruby-git/issues/355
+          )
+          build_runner.setup(parameters: nil)
+          Services.build_runner_service.add_build_runner(build_runner: build_runner)
+        end
+      end
     end
 
     # Find the active code host for the provider_credential/user combination

--- a/services/config_service.rb
+++ b/services/config_service.rb
@@ -14,7 +14,7 @@ module FastlaneCI
     attr_accessor :clone_user_provider_credential
 
     def initialize(project_service: FastlaneCI::Services.project_service, ci_user: nil, clone_user_provider_credential:)
-      @clone_user_provider_credential = clone_user_provider_credential
+      self.clone_user_provider_credential = clone_user_provider_credential
       self.project_service = project_service
       self.ci_user = ci_user
       self.active_code_hosting_services = {}

--- a/services/onboarding_service.rb
+++ b/services/onboarding_service.rb
@@ -14,8 +14,8 @@ module FastlaneCI
     attr_reader :clone_user_provider_credential
 
     def initialize(ci_config_repo:, clone_user_provider_credential:)
-      @ci_config_repo = ci_config_repo
-      @clone_user_provider_credential = clone_user_provider_credential
+      self.ci_config_repo = ci_config_repo
+      self.clone_user_provider_credential = clone_user_provider_credential
     end
 
     # Triggers the initial clone of the remote configuration repository, to the
@@ -26,7 +26,7 @@ module FastlaneCI
       logger.info("No config repo cloned yet, doing that now")
 
       # Trigger the initial clone
-      # TODO: remote this in favour of a different approach
+      # TODO: remove this in favour of a different approach
       FastlaneCI::ProjectService.new(
         project_data_source: FastlaneCI::JSONProjectDataSource.create(
           ci_config_repo,

--- a/services/project_service.rb
+++ b/services/project_service.rb
@@ -12,12 +12,15 @@ module FastlaneCI
   class ProjectService
     include FastlaneCI::Logging
     attr_accessor :project_data_source
+    attr_accessor :clone_user_provider_credential
+    attr_accessor :configuration_git_repo
 
-    def initialize(project_data_source: nil)
+    def initialize(project_data_source: nil, clone_user_provider_credential:, configuration_git_repo:)
       unless project_data_source.nil?
         raise "project_data_source must be descendant of #{ProjectDataSource.name}" unless project_data_source.class <= ProjectDataSource
       end
 
+      @clone_user_provider_credential = clone_user_provider_credential
       self.project_data_source = project_data_source
     end
 
@@ -78,12 +81,12 @@ module FastlaneCI
 
     # Not sure if this must be here or not, but we can open a discussion on this.
     def commit_repo_changes!(message: nil, file_to_commit: nil)
-      Services.configuration_git_repo.commit_changes!(commit_message: message,
+      configuration_git_repo.commit_changes!(commit_message: message,
                                                         file_to_commit: file_to_commit)
     end
 
     def push_configuration_repo_changes!
-      Services.configuration_git_repo.push
+      configuration_git_repo.push
     end
 
     def git_repo_for_project(project:)
@@ -92,7 +95,7 @@ module FastlaneCI
       # between Service <-> WebServer <-> Client.
       repo = GitRepo.new(
         git_config: project.repo_config,
-        provider_credential: Services.provider_credential,
+        provider_credential: clone_user_provider_credential,
         async_start: false
       )
       repo

--- a/services/project_service.rb
+++ b/services/project_service.rb
@@ -20,7 +20,7 @@ module FastlaneCI
         raise "project_data_source must be descendant of #{ProjectDataSource.name}" unless project_data_source.class <= ProjectDataSource
       end
 
-      @clone_user_provider_credential = clone_user_provider_credential
+      self.clone_user_provider_credential = clone_user_provider_credential
       self.project_data_source = project_data_source
     end
 

--- a/services/services.rb
+++ b/services/services.rb
@@ -29,7 +29,7 @@ module FastlaneCI
       @_ci_config_repo = nil
       @_configuration_git_repo = nil
       @_ci_user = nil
-      @_provider_credential = nil
+      @_clone_user_provider_credential = nil
 
       # Reset services
       @_project_service = nil
@@ -43,12 +43,12 @@ module FastlaneCI
     end
 
     ########################################################
-    # Service helpers
+    # Private Service helpers
     ########################################################
 
     # Get the path to where we store fastlane.ci configuration
     def self.ci_config_git_repo_path
-      self.ci_config_repo.local_repo_path
+      ci_config_repo.local_repo_path
     end
 
     # Setup the fastlane.ci GitRepoConfig
@@ -70,7 +70,7 @@ module FastlaneCI
     def self.configuration_git_repo
       @_configuration_git_repo ||= FastlaneCI::GitRepo.new(
         git_config: ci_config_repo,
-        provider_credential: provider_credential
+        provider_credential: clone_user_provider_credential
       )
     end
 
@@ -79,7 +79,7 @@ module FastlaneCI
       @_ci_user ||= Services.user_service.login(
         email: FastlaneCI.env.ci_user_email,
         password: FastlaneCI.env.ci_user_password,
-        ci_config_repo: self.ci_config_repo
+        ci_config_repo: ci_config_repo
       )
       if @_ci_user.nil?
         raise "Could not find ci_user for current setup, please make sure a user with the email #{FastlaneCI.env.ci_user_email} exists in your users.json"
@@ -87,22 +87,22 @@ module FastlaneCI
       return @_ci_user
     end
 
-    # This happens on the first launch of CI
-    # We don't have access to the config directory yet
-    # So we'll use ENV variables that are used for the initial clone only
-    #
-    # Long term, we'll have a nice onboarding flow, where you can enter those credentials
-    # as part of a web UI. But for containers (e.g. Google Cloud App Engine)
-    # we'll have to support ENV variables also, for the initial clone, so that's the code below
-    # Clone the repo, and login the user
+    # The initial clone user's provider credential
     #
     # @return [GitHubProviderCredential]
-    def self.provider_credential
-      @_provider_credential ||= GitHubProviderCredential.new(
+    def self.clone_user_provider_credential
+      @_clone_user_provider_credential ||= GitHubProviderCredential.new(
         email: FastlaneCI.env.initial_clone_email,
         api_token: FastlaneCI.env.clone_user_api_token
       )
     end
+
+    # These service helper methods should not be exposed, since they become
+    # global static methods, which when referenced in arbitrary classes, becomes
+    # a code smell
+    private_class_method :ci_config_git_repo_path, :ci_config_repo,
+                         :configuration_git_repo, :ci_user,
+                         :clone_user_provider_credential
 
     ########################################################
     # Services that we provide
@@ -111,14 +111,17 @@ module FastlaneCI
     # Start up a ProjectService from our JSONProjectDataSource
     def self.project_service
       @_project_service ||= FastlaneCI::ProjectService.new(
-        project_data_source: FastlaneCI::JSONProjectDataSource.create(ci_config_repo, user: ci_user)
+        project_data_source: FastlaneCI::JSONProjectDataSource.create(ci_config_repo, user: ci_user),
+        clone_user_provider_credential: clone_user_provider_credential,
+        configuration_git_repo: configuration_git_repo
       )
     end
 
     # Start up a UserService from our JSONUserDataSource
     def self.user_service
       @_user_service ||= FastlaneCI::UserService.new(
-        user_data_source: FastlaneCI::JSONUserDataSource.create(ci_config_git_repo_path)
+        user_data_source: FastlaneCI::JSONUserDataSource.create(ci_config_git_repo_path),
+        configuration_git_repo: configuration_git_repo
       )
     end
 
@@ -146,23 +149,29 @@ module FastlaneCI
     # @return [GithubService]
     def self.github_service
       @_github_service ||= FastlaneCI::GitHubService.new(
-        provider_credential: provider_credential
+        provider_credential: clone_user_provider_credential
       )
     end
 
     # Grab a config service that is configured for the CI user
     def self.config_service
-      @_config_service ||= FastlaneCI::ConfigService.new(ci_user: ci_user)
+      @_config_service ||= FastlaneCI::ConfigService.new(
+        ci_user: ci_user,
+        clone_user_provider_credential: clone_user_provider_credential
+      )
     end
 
     def self.worker_service
-      @_worker_service ||= FastlaneCI::WorkerService.new
+      @_worker_service ||= FastlaneCI::WorkerService.new(
+        ci_user: ci_user,
+        provider_credential: clone_user_provider_credential
+      )
     end
 
     # @return [ConfigurationRepositoryService]
     def self.configuration_repository_service
       @_configuration_repository_service ||= FastlaneCI::ConfigurationRepositoryService.new(
-        provider_credential: provider_credential
+        provider_credential: clone_user_provider_credential
       )
     end
 
@@ -175,7 +184,10 @@ module FastlaneCI
     end
 
     def self.onboarding_service
-      @_onboarding_service ||= FastlaneCI::OnboardingService.new
+      @_onboarding_service ||= FastlaneCI::OnboardingService.new(
+        ci_config_repo: ci_config_repo,
+        clone_user_provider_credential: clone_user_provider_credential
+      )
     end
   end
 end

--- a/services/user_service.rb
+++ b/services/user_service.rb
@@ -8,8 +8,9 @@ module FastlaneCI
   class UserService
     include FastlaneCI::Logging
     attr_accessor :user_data_source
+    attr_accessor :configuration_git_repo
 
-    def initialize(user_data_source: nil)
+    def initialize(user_data_source: nil, configuration_git_repo:)
       unless user_data_source.nil?
         raise "user_data_source must be descendant of #{UserDataSource.name}" unless user_data_source.class <= UserDataSource
       end
@@ -22,6 +23,7 @@ module FastlaneCI
         user_data_source = JSONUserDataSource.create(json_folder_path: data_store_folder)
       end
 
+      @configuration_git_repo = configuration_git_repo
       self.user_data_source = user_data_source
     end
 
@@ -122,8 +124,7 @@ module FastlaneCI
 
     # Not sure if this must be here or not, but we can open a discussion on this.
     def commit_repo_changes!(message: nil, file_to_commit: nil)
-      Services.configuration_git_repo.commit_changes!(commit_message: message,
-                                                        file_to_commit: file_to_commit)
+      configuration_git_repo.commit_changes!(commit_message: message, file_to_commit: file_to_commit)
     end
   end
 end

--- a/services/worker_service.rb
+++ b/services/worker_service.rb
@@ -14,8 +14,8 @@ module FastlaneCI
     attr_accessor :provider_credential
 
     def initialize(ci_user:, provider_credential:)
-      @ci_user = ci_user
-      @provider_credential = provider_credential
+      self.ci_user = ci_user
+      self.provider_credential = provider_credential
       self.project_to_workers_dictionary = {}
     end
 

--- a/shared/authenticated_controller_base.rb
+++ b/shared/authenticated_controller_base.rb
@@ -25,7 +25,7 @@ module FastlaneCI
     def current_user_config_service
       if @user_config_service.nil?
         logger.debug("No user_config_service for #{self.user.email}, creating one")
-        @user_config_service = FastlaneCI::ConfigService.new(ci_user: self.user)
+        @user_config_service = FastlaneCI::ConfigService.new(ci_user: self.user, clone_user_provider_credential: check_and_get_provider_credential)
       end
       return @user_config_service
     end

--- a/shared/models/git_repo.rb
+++ b/shared/models/git_repo.rb
@@ -405,6 +405,7 @@ module FastlaneCI
 
       self.temporary_storage_path = self.setup_auth(repo_auth: repo_auth)
       logger.debug("[#{self.git_config.id}]: Cloning git repo #{self.git_config.git_url}")
+
       Git.clone(self.git_config.git_url, self.git_config.id,
                 path: self.git_config.containing_path,
                 recursive: true)

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -23,7 +23,8 @@ describe FastlaneCI::UserService do
 
   subject do
     FastlaneCI::UserService.new(
-      user_data_source: FastlaneCI::JSONUserDataSource.create(git_repo_path)
+      user_data_source: FastlaneCI::JSONUserDataSource.create(git_repo_path),
+      configuration_git_repo: git_repo
     )
   end
 

--- a/spec/stub_helpers.rb
+++ b/spec/stub_helpers.rb
@@ -36,13 +36,16 @@ module StubHelpers
       FastlaneCI::ProjectService.new(
         project_data_source: FastlaneCI::JSONProjectDataSource.create(
           git_repo, user: ci_user
-        )
+        ),
+        clone_user_provider_credential: provider_credential,
+        configuration_git_repo: git_repo
       )
     )
 
     FastlaneCI::Services.stub(:user_service).and_return(
       FastlaneCI::UserService.new(
-        user_data_source: FastlaneCI::JSONUserDataSource.create(git_repo_path)
+        user_data_source: FastlaneCI::JSONUserDataSource.create(git_repo_path),
+        configuration_git_repo: git_repo
       )
     )
 


### PR DESCRIPTION
This introduces fairly substantial changes, but I believe they're necessary in order to reduce code smells that have accumulated over time (largely due to me).

### Changes

The two main goals of this PR are to:

1. Decouple business logic from the static methods in the `Launch` class, and move them to appropriate services
2. Remove references to the static helper functions defined in the `Services` class, and make them `private_class_method`s. Instead of using these helpers as global static methods, inject them into the appropriate services in their constructors.