### PR TITLE
Removed dead code in `notifications_controller` and refactored view helpers.

### DIFF
--- a/features/notifications/notifications_controller.rb
+++ b/features/notifications/notifications_controller.rb
@@ -10,42 +10,17 @@ module FastlaneCI
     # Renders the notifications dashboard, displaying a table of notifications
     # scoped to the user
     get HOME do
-      notifications = Services.notification_service.notification_data_source.notifications
-      user_notifications = notifications.select { |notification| notification.user_id == user.id }
       locals = { notifications: user_notifications, title: "Notifications" }
       erb(:dashboard, locals: locals, layout: FastlaneCI.default_layout)
     end
 
-    # Creates a new notification
-    post "#{HOME}/create" do
-      payload = notification_params(request)
-      Services.notification_service.create_notification!(payload)
-      redirect HOME
-    end
-
-    # Updates a notification with a given `name`
-    post "#{HOME}/update" do
-      notification = Notification.new(notification_params(request))
-      Services.notification_service.update_notification!(notification: notification)
-      redirect HOME
-    end
-
-    # Deletes a notification with a given `name`
-    post "#{HOME}/delete/:id" do
-      Services.notification_service.delete_notification!(id: params[:id])
-      redirect HOME
-    end
-
     private
 
-    # Parameters used for creating and updating notifications:
-    #   { :id, :priority, :type, :user_id, :name, :message }
-    #
-    # @param  [Sinatra::Request] request
-    # @return [Hash]
-    def notification_params(request)
-      parse_request_body(request)
-        .select { |k, _v| %i(id priority type user_id name message).include?(k) }
+    # @return [Array[Notification]]
+    def user_notifications
+      return Services.notification_service
+                     .notifications
+                     .select { |notification| notification.user_id == user.id }
     end
   end
 end

--- a/features/notifications/views/dashboard.erb
+++ b/features/notifications/views/dashboard.erb
@@ -30,11 +30,6 @@
               <td><%= notification.message %></td>
               <td><%= notification.created_at %></td>
               <td><%= notification.updated_at %></td>
-              <td>
-                <form method="post" action="/notifications/delete/<%= notification.id %>">
-                  <input type="submit" value="Delete notification">
-                </form>
-              </td>
             </tr>
           <% end %>
         </tbody>

--- a/services/notification_service.rb
+++ b/services/notification_service.rb
@@ -30,6 +30,13 @@ module FastlaneCI
       @task_queue = TaskQueue::TaskQueue.new(name: "notifications")
     end
 
+    # The list of persisted notifications
+    #
+    # @return Array[Notification]
+    def notifications
+      return notification_data_source.notifications
+    end
+
     # Creates and returns a new Notification
     #
     # @param  [String] id


### PR DESCRIPTION
I initially thought it would be cool to expose an API for the notifications controller so that you could create notifications externally as detailed in https://github.com/fastlane/ci/pull/142.

I don't really know if it makes sense to expose an API, and think it would be better to just create/update notifications through the [`Services.notification_service`](https://github.com/fastlane/ci/blob/master/services/notification_service.rb), and just use the notification controller to display them.

Thoughts?