### PR TITLE
#262 Unique new repo URL

### DIFF
--- a/features/onboarding/onboarding_controller.rb
+++ b/features/onboarding/onboarding_controller.rb
@@ -67,12 +67,12 @@ module FastlaneCI
         )
 
         session[:message] = <<~HTML
-          ~/.fastlane/ci/keys file written with the configuration values:<br />
+          #{Services.environment_variable_service.keys_file_path} file written with the configuration values:<br />
             FASTLANE_CI_ENCRYPTION_KEY=#{params[:encryption_key]}
         HTML
       else
         session[:message] = <<~HTML
-          ERROR: ~/.fastlane/ci/keys file not written.
+          ERROR: #{Services.environment_variable_service.keys_file_path} file not written.
         HTML
       end
 
@@ -98,7 +98,7 @@ module FastlaneCI
         )
 
         session[:message] = <<~HTML
-          ~/.fastlane/ci/keys file written with the configuration values:<br />
+          #{Services.environment_variable_service.keys_file_path} file written with the configuration values:<br />
 
           <ul>
             <li>FASTLANE_CI_USER=#{params[:ci_user_email]}</li>
@@ -107,7 +107,7 @@ module FastlaneCI
         HTML
       else
         session[:message] = <<~HTML
-          ERROR: ~/.fastlane/ci/keys file not written.
+          ERROR: #{Services.environment_variable_service.keys_file_path} file not written.
         HTML
       end
 
@@ -133,7 +133,7 @@ module FastlaneCI
         )
 
         session[:message] = <<~HTML
-          ~/.fastlane/ci/keys file written with the configuration values:
+          #{Services.environment_variable_service.keys_file_path} file written with the configuration values:
 
           <ul>
             <li>FASTLANE_CI_INITIAL_CLONE_EMAIL='#{params[:clone_user_email]}'</li>
@@ -142,7 +142,7 @@ module FastlaneCI
         HTML
       else
         session[:message] = <<~HTML
-          ERROR: ~/.fastlane/ci/keys file not written.
+          ERROR: #{Services.environment_variable_service.keys_file_path} file not written.
         HTML
       end
 

--- a/features/project/project_controller.rb
+++ b/features/project/project_controller.rb
@@ -58,16 +58,21 @@ module FastlaneCI
 
       locals = {
           title: "Add new project",
-          repos: FastlaneCI::GitHubService.new(provider_credential: provider_credential).repos
+          hosting_providers: [{
+            name: provider_credential.type,
+            repos: FastlaneCI::GitHubService.new(provider_credential: provider_credential).repos
+          }]
       }
       erb(:new_project, locals: locals, layout: FastlaneCI.default_layout)
     end
 
-    get "#{HOME}/add/*" do |repo_name|
+    get "#{HOME}/add/*/*/*" do |hosting_provider, owner_login, repo_name|
+      # When other than GitHub service is supported hosting_provider param
+      # will have to be taken into account
       provider_credential = check_and_get_provider_credential(type: FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github])
 
       github_service = FastlaneCI::GitHubService.new(provider_credential: provider_credential)
-      selected_repo = github_service.repos.select { |repo| repo_name == repo.name }.first
+      selected_repo = github_service.repos.select { |repo| owner_login == repo.owner.login and repo_name == repo.name }.first
 
       # We need to check whether we can checkout the project without issues.
       # So a new project is created with default settings so we can fetch it.
@@ -101,7 +106,9 @@ module FastlaneCI
           title: "Add new project",
           repo: repo,
           lanes: available_lanes,
-          fastfile_path: fastfile_path
+          fastfile_path: fastfile_path,
+          provider_name: hosting_provider,
+          owner_login: owner_login
       }
 
       # Delete the project
@@ -110,11 +117,13 @@ module FastlaneCI
       erb(:new_project_form, locals: locals, layout: FastlaneCI.default_layout)
     end
 
-    post "#{HOME}/add/*" do |repo_name|
+    post "#{HOME}/add/*/*/*" do |hosting_provider, owner_login, repo_name|
+      # When other than GitHub service is supported hosting_provider param
+      # will have to be taken into account
       provider_credential = check_and_get_provider_credential(type: FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github])
 
       github_service = FastlaneCI::GitHubService.new(provider_credential: provider_credential)
-      selected_repo = github_service.repos.select { |repo| repo_name == repo.name }.first
+      selected_repo = github_service.repos.select { |repo| owner_login == repo.owner.login and repo_name == repo.name }.first
 
       repo_config = GitRepoConfig.from_octokit_repo!(repo: selected_repo)
 

--- a/features/project/project_controller.rb
+++ b/features/project/project_controller.rb
@@ -72,7 +72,7 @@ module FastlaneCI
       provider_credential = check_and_get_provider_credential(type: FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github])
 
       github_service = FastlaneCI::GitHubService.new(provider_credential: provider_credential)
-      selected_repo = github_service.repos.select { |repo| owner_login == repo.owner.login and repo_name == repo.name }.first
+      selected_repo = github_service.repos.select { |repo| owner_login == repo.owner.login && repo_name == repo.name }.first
 
       # We need to check whether we can checkout the project without issues.
       # So a new project is created with default settings so we can fetch it.
@@ -123,7 +123,7 @@ module FastlaneCI
       provider_credential = check_and_get_provider_credential(type: FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github])
 
       github_service = FastlaneCI::GitHubService.new(provider_credential: provider_credential)
-      selected_repo = github_service.repos.select { |repo| owner_login == repo.owner.login and repo_name == repo.name }.first
+      selected_repo = github_service.repos.select { |repo| owner_login == repo.owner.login && repo_name == repo.name }.first
 
       repo_config = GitRepoConfig.from_octokit_repo!(repo: selected_repo)
 

--- a/features/project/views/new_project.erb
+++ b/features/project/views/new_project.erb
@@ -12,6 +12,7 @@
       <thead>
         <tr>
           <th>Status</th>
+          <th style="width: 200px;">Owner</th>
           <th style="width: 300px;">Project Name</th>
         </tr>
       </thead>
@@ -20,6 +21,7 @@
         <% hosting_provider[:repos].each do |repo| %>
           <tr style="cursor: pointer;">
             <td>💚</td>
+            <td><%= repo[:owner][:login] %></td>
             <td onclick="document.location = '/projects_erb/add/<%= hosting_provider[:name] %>/<%= repo[:owner][:login] %>/<%= repo[:name] %>';"><%= repo[:name] %></td>
           </tr>
         <% end %>

--- a/features/project/views/new_project.erb
+++ b/features/project/views/new_project.erb
@@ -16,11 +16,13 @@
         </tr>
       </thead>
       <tbody>
-        <% repos.each do |repo| %>
+        <% hosting_providers.each do |hosting_provider| %>
+        <% hosting_provider[:repos].each do |repo| %>
           <tr style="cursor: pointer;">
             <td>💚</td>
-            <td onclick="document.location = '/projects_erb/add/<%= repo[:name] %>';"><%= repo[:name] %></td>
+            <td onclick="document.location = '/projects_erb/add/<%= hosting_provider[:name] %>/<%= repo[:owner][:login] %>/<%= repo[:name] %>';"><%= repo[:name] %></td>
           </tr>
+        <% end %>
         <% end %>
       </tbody>
     </table>

--- a/features/project/views/new_project_form.erb
+++ b/features/project/views/new_project_form.erb
@@ -8,7 +8,7 @@
   <%= erb :"../../partials/navigation" %>
 
   <main class="mdl-layout__content" style="padding: 40px">
-    <form method="POST" action="/projects_erb/add/<%= repo.git_config.name %>">
+    <form method="POST" action="/projects_erb/add/<%= provider_name %>/<%= owner_login %>/<%= repo.git_config.name %>">
       <h5>Adding <%= repo.git_config.full_name %></h5>
       <div class="mdl-textfield mdl-js-textfield">
         <input class="mdl-textfield__input" type="text" name="project_name" value="<%= repo.git_config.full_name %>">


### PR DESCRIPTION
Hello 👋 

This is my first try to contribute to an amazing fastlane toolchain.

The first commit is a fix which prints actual file path (the issue was that actual path is `~/.fastlane/.keys`). The drawback is that is prints absolute path (not relative to HOME); looks verbose but I didn't find an easy way to print path relative to HOME.

The second commit is an implementation of #262. I went an easy way and in post action I've added two additional standalone fields. I did not want to extend `GitRepoConfig` with additional two fields as it might impact other places in the code, especially as those two fields currently required only for project import. Any comments on that are highly appreciated.

Probably I could've done something not by the book of guidelines so I'll try to fix any