### PR TITLE
Improvements to build reporting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/fastlane/fastlane
-  revision: 098fb3f351b73c97cbc077625ca606b6b2fc7da2
+  revision: 0a8b9804602f212b54535c344d589362666ff181
   specs:
-    fastlane (2.84.0)
+    fastlane (2.86.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -27,6 +27,7 @@ GIT
       public_suffix (~> 2.0.0)
       rubyzip (>= 1.1.0, < 2.0.0)
       security (= 0.1.3)
+      simctl (~> 1.6)
       slack-notifier (>= 2.0.0, < 3.0.0)
       terminal-notifier (>= 1.6.2, < 2.0.0)
       terminal-table (>= 1.4.5, < 2.0.0)
@@ -75,7 +76,7 @@ GEM
     et-orbi (1.0.9)
       tzinfo
     eventmachine (1.2.5)
-    excon (0.60.0)
+    excon (0.61.0)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -136,6 +137,7 @@ GEM
     multipart-post (2.0.0)
     mustermann (1.0.2)
     nanaimo (0.2.3)
+    naturally (2.1.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     os (0.9.6)
@@ -201,6 +203,9 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    simctl (1.6.2)
+      CFPropertyList
+      naturally
     sinatra (2.0.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -237,13 +242,13 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.3.0)
-    unparser (0.2.6)
+    unparser (0.2.7)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       concord (~> 0.1.5)
       diff-lcs (~> 1.3)
       equalizer (~> 0.0.9)
-      parser (>= 2.3.1.2, < 2.5)
+      parser (>= 2.3.1.2, < 2.6)
       procto (~> 0.0.2)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)

--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -36,7 +36,7 @@ module FastlaneCI
     get "/" do
       if ENV["WEB_APP"]
         # Use Angular Web App instead
-        send_file File.join('public', '.dist', 'index.html')
+        send_file(File.join("public", ".dist", "index.html"))
       else
         if session[:user]
           redirect("/dashboard")

--- a/features/build_runner/build_runner_output_row.rb
+++ b/features/build_runner/build_runner_output_row.rb
@@ -3,7 +3,7 @@ module FastlaneCI
   # meaning it's a single message that we want to show to the user
   # and store as a build artifact as part of the build log
   class BuildRunnerOutputRow
-    BUILD_FAIL_TYPES = [:user_error, :build_error, :crash, :shell_error, :build_failure, :test_failure, :abort].to_set
+    BUILD_FAIL_TYPES = [:user_error, :build_error, :crash, :error, :shell_error, :build_failure, :test_failure, :abort].to_set
 
     # The type of message (e.g. `:message`, `:error`, `:important`)
     attr_accessor :type

--- a/launch.rb
+++ b/launch.rb
@@ -42,7 +42,7 @@ module FastlaneCI
 
     def self.verify_app_built
       if ENV["WEB_APP"]
-        app_exists = File.file?(File.join('public', '.dist', 'index.html'))
+        app_exists = File.file?(File.join("public", ".dist", "index.html"))
         raise "The web application is not built. Please build with the Angular CLI and Try Again.\nEx. ng build --deploy-url=\"/.dist\"" unless app_exists
       end
     end

--- a/services/code_hosting/git_hub_service.rb
+++ b/services/code_hosting/git_hub_service.rb
@@ -106,11 +106,11 @@ module FastlaneCI
       state = state.to_s
 
       # Available states https://developer.github.com/v3/repos/statuses/
-      if state == "missing_fastfile"
+      if state == "missing_fastfile" || state == "ci_problem"
         state = "failure"
       end
 
-      available_states = ["error", "failure", "pending", "success"]
+      available_states = ["error", "failure", "pending", "success", "ci_problem"]
       raise "Invalid state '#{state}'" unless available_states.include?(state)
 
       # We auto receive the SLUG, so that the user of this class can pass a full URL also
@@ -121,13 +121,13 @@ module FastlaneCI
         description = "Still running" if state == "pending"
 
         # TODO: what's the difference?
-        description = "Something went wrong" if state == "failure"
-        description = "Something went wrong" if state == "error"
+        description = "Build encountered a failure" if state == "failure"
+        description = "Build encountered an error " if state == "error"
       end
 
       # this needs to be synchronous because we're doing it during initialization of our build runner
       state_details = target_url.nil? ? "#{repo}, sha #{sha}" : target_url
-      logger.debug("Setting status #{state} on #{state_details}")
+      logger.debug("Setting status #{state} -> #{status_context} on #{state_details}")
       client.create_status(repo, sha, state, {
         target_url: target_url,
         description: description,

--- a/shared/models/build.rb
+++ b/shared/models/build.rb
@@ -9,7 +9,8 @@ module FastlaneCI
       :success,
       :pending,
       :missing_fastfile,
-      :failure
+      :failure,
+      :ci_problem
     ]
 
     # A reference to the project this build is associated with


### PR DESCRIPTION
- Build failures form UI.error now reporting :error are caught by the build status (#340)
- Clearer reporting of status setting (project, status, and commit sha)
- Reporting of server errors vs fastlane errors in status now supported with new flag :ci_problem
- rubocop updates