### PR TITLE
add pre-commit hook for rubocop

### DIFF
--- a/.pre-commit
+++ b/.pre-commit
@@ -1,19 +1,19 @@
 #!/usr/bin/env ruby
 
-ADDED_OR_MODIFIED = /A|AM|M|^M/.freeze
-OTHER_RUBY_FILES  = %w(Rakefile Gemfile)
-changed_files = `git status --porcelain`.split(/\n/).
-    select { |file_name_with_status|
-      file_name_with_status =~ ADDED_OR_MODIFIED
-    }.
-    map { |file_name_with_status|
-      file_name_with_status.split(' ')[1]
-    }.
-    select { |file_name|
-      File.extname(file_name) == '.rb' or
-        OTHER_RUBY_FILES.include?(file_name)
-    }.join(' ')
+ADDED_OR_MODIFIED = /A|AM|M|^M/
+OTHER_RUBY_FILES  = %w(Rakefile Gemfile .pre-commit)
 
-system("rubocop #{changed_files}") unless changed_files.empty?
+changed_files = `git status --porcelain`
+                .split(/\n/)
+                .select { |file_name_with_status| file_name_with_status =~ ADDED_OR_MODIFIED }
+                .map { |file_name_with_status| file_name_with_status.split(" ")[1] }
+                .select { |file_name| File.extname(file_name) == ".rb" or OTHER_RUBY_FILES.include?(file_name) }
+                .join(" ")
 
-exit $?.existstatus
+exit(0) if changed_files.empty?
+
+exit(0) if system("rubocop #{changed_files}")
+
+puts("\n\n💥 Fix linting errors with `rubocop -a` and stage changed, or bypass hook with `git commit --no-verify`")
+
+exit($?.exitstatus)

--- a/.pre-commit
+++ b/.pre-commit
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+ADDED_OR_MODIFIED = /A|AM|M|^M/.freeze
+OTHER_RUBY_FILES  = %w(Rakefile Gemfile)
+changed_files = `git status --porcelain`.split(/\n/).
+    select { |file_name_with_status|
+      file_name_with_status =~ ADDED_OR_MODIFIED
+    }.
+    map { |file_name_with_status|
+      file_name_with_status.split(' ')[1]
+    }.
+    select { |file_name|
+      File.extname(file_name) == '.rb' or
+        OTHER_RUBY_FILES.include?(file_name)
+    }.join(' ')
+
+system("rubocop #{changed_files}") unless changed_files.empty?
+
+exit $?.existstatus

--- a/Rakefile
+++ b/Rakefile
@@ -3,13 +3,14 @@ task :dev do
 end
 
 task :devbootstrap do
-  #sh "git submodule update --init --recursive"
-  sh "ln -sf .pre-commit .git/hooks/pre-commit"
+  sh "bundle install"
+  sh "git submodule update --init --recursive"
+  sh "ln -sf ../../.pre-commit .git/hooks/pre-commit"
 end
 
 begin
-  require 'rspec/core/rake_task'
+  require "rspec/core/rake_task"
   RSpec::Core::RakeTask.new(:spec)
-  task :default => :spec
+  task(default: :spec)
 rescue LoadError
 end

--- a/Rakefile
+++ b/Rakefile
@@ -2,4 +2,14 @@ task :dev do
   sh "bundle exec rackup -p 8080 --env development"
 end
 
-task(default: [:development])
+task :devbootstrap do
+  #sh "git submodule update --init --recursive"
+  sh "ln -sf .pre-commit .git/hooks/pre-commit"
+end
+
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+  task :default => :spec
+rescue LoadError
+end


### PR DESCRIPTION
This PR adds 2 developer-focused features:
* a rake task for bootstrapping development `rake devbootstrap`
* a pre-commit hook that will help cut down how many PRs being rejected by the linter