### PR TITLE
Fix onboarding without existing configuration.

### DIFF
--- a/app/services/onboarding_service.rb
+++ b/app/services/onboarding_service.rb
@@ -1,5 +1,6 @@
 require "json"
 require_relative "../shared/logging_module"
+require_relative "../services/services"
 
 module FastlaneCI
   # Provides operations to create and mutate the FastlaneCI configuration
@@ -15,13 +16,7 @@ module FastlaneCI
       logger.info("No config repo cloned yet, doing that now")
 
       # Trigger the initial clone
-      FastlaneCI::ProjectService.new(
-        project_data_source: FastlaneCI::JSONProjectDataSource.create(
-          Services.ci_config_repo,
-          git_repo_config: Services.ci_config_repo,
-          provider_credential: Services.provider_credential
-        )
-      )
+      Services.configuration_git_repo
       logger.info("Successfully did the initial clone on this machine")
     rescue StandardError => ex
       logger.error("Something went wrong on the initial clone")
@@ -80,7 +75,11 @@ module FastlaneCI
 
     # @return [Boolean]
     def remote_configuration_repository_valid?
-      return Services.configuration_repository_service.configuration_repository_valid?
+      if Services.configuration_repository_service.respond_to?(:configuration_repository_valid?)
+        return Services.configuration_repository_service.configuration_repository_valid?
+      else
+        return false
+      end
     end
 
     # @return [Boolean]

--- a/app/services/onboarding_service.rb
+++ b/app/services/onboarding_service.rb
@@ -75,11 +75,7 @@ module FastlaneCI
 
     # @return [Boolean]
     def remote_configuration_repository_valid?
-      if Services.configuration_repository_service.respond_to?(:configuration_repository_valid?)
-        return Services.configuration_repository_service.configuration_repository_valid?
-      else
-        return false
-      end
+      return Services.configuration_repository_service.configuration_repository_valid?
     end
 
     # @return [Boolean]


### PR DESCRIPTION
Fixes: 
```
NoMethodError: undefined method `git_url' for nil:NilClass
  /Users/GabrielVillarrubia/Documents/ci/shared/models/git_repo.rb:72:in `initialize'
  /Users/GabrielVillarrubia/Documents/ci/services/config_data_sources/json_project_data_source.rb:97:in `new'
  /Users/GabrielVillarrubia/Documents/ci/services/config_data_sources/json_project_data_source.rb:97:in `after_creation'
  /Users/GabrielVillarrubia/Documents/ci/services/data_sources/json_data_source.rb:22:in `create'
  /Users/GabrielVillarrubia/Documents/ci/services/onboarding_service.rb:19:in `clone_remote_repository_locally'
  /Users/GabrielVillarrubia/Documents/ci/launch.rb:80:in `clone_repo_if_no_local_repo_and_remote_repo_exists'
  /Users/GabrielVillarrubia/Documents/ci/launch.rb:23:in `take_off'
```