### PR TITLE
Avoid duplicate runners

### DIFF
--- a/app/services/build_runner_service.rb
+++ b/app/services/build_runner_service.rb
@@ -33,7 +33,7 @@ module FastlaneCI
     end
 
     # Fetch all the active runners, and see if there is one WIP
-    def find_build_runner(project_id: nil, sha: nil, build_number: nil)
+    def find_build_runner(project_id:, sha: nil, build_number: nil)
       return self.build_runners.find do |build_runner|
         build_runner.project.id == project_id && (build_runner.sha == sha || build_runner.current_build.number == build_number)
       end

--- a/app/services/build_runner_service.rb
+++ b/app/services/build_runner_service.rb
@@ -33,9 +33,9 @@ module FastlaneCI
     end
 
     # Fetch all the active runners, and see if there is one WIP
-    def find_build_runner(project_id:, build_number:)
+    def find_build_runner(project_id: nil, sha: nil, build_number: nil)
       return self.build_runners.find do |build_runner|
-        build_runner.project.id == project_id && build_runner.current_build.number == build_number
+        build_runner.project.id == project_id && (build_runner.sha == sha || build_runner.current_build.number == build_number)
       end
     end
   end

--- a/app/workers/github_worker_base.rb
+++ b/app/workers/github_worker_base.rb
@@ -92,6 +92,7 @@ module FastlaneCI
       credential = self.provider_credential
       current_project = self.project
       current_sha = sha
+      return unless Services.build_runner_service.find_build_runner(project_id: current_project.id, sha: current_sha).nil?
       build_runner = FastlaneBuildRunner.new(
         project: current_project,
         sha: current_sha,

--- a/launch.rb
+++ b/launch.rb
@@ -180,6 +180,7 @@ module FastlaneCI
         # Enqueue each pending build rerun in an asynchronous task queue
         pending_build_shas_needing_rebuilds.each do |sha|
           logger.debug("Found sha #{sha} that needs a rebuild for #{project.project_name}")
+          next unless Services.build_runner_service.find_build_runner(project_id: project.id, sha: sha).nil?
 
           # Did we match a commit sha with an open pull request?
           matching_open_pr = open_pull_requests.detect { |open_pr| open_pr.current_sha == sha }


### PR DESCRIPTION
Filter `build_runner`s that have been already queued. It happens a lot with `CheckForNewCommitsWorker`.