### PR TITLE
Allow web app to reload inside Angular

### DIFF
--- a/app/features-json/project_json_controller.rb
+++ b/app/features-json/project_json_controller.rb
@@ -3,7 +3,7 @@ require_relative "../shared/authenticated_controller_base"
 module FastlaneCI
   # Controller for providing all data relating to projects
   class ProjectJSONController < AuthenticatedControllerBase
-    HOME = "/projects"
+    HOME = "/data/projects"
 
     get HOME do
       current_provider_credential = self.check_and_get_provider_credential

--- a/app/src/app/services/data.service.spec.ts
+++ b/app/src/app/services/data.service.spec.ts
@@ -23,7 +23,7 @@ describe('DataService', () => {
         projects = projectsRespone;
       });
 
-      const projectsRequest = mockHttp.expectOne('/projects');
+      const projectsRequest = mockHttp.expectOne('/data/projects');
       projectsRequest.flush(mockProjectListResponse);
 
       expect(projects.length).toBe(3);

--- a/app/src/app/services/data.service.ts
+++ b/app/src/app/services/data.service.ts
@@ -6,7 +6,7 @@ import {map} from 'rxjs/operators';
 import {Project, ProjectResponse} from '../models/project';
 
 // Data server is currently locally hosted.
-const HOSTNAME = '';
+const HOSTNAME = '/data';
 
 @Injectable()
 export class DataService {

--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -31,22 +31,24 @@ module FastlaneCI
     # which is required to support web socket streams for the
     # display of real-time output
     set(:server, "thin")
-
-    get "/" do
-      if ENV["WEB_APP"]
+    if ENV["WEB_APP"]
+      # Anything except a data route
+      get /\/(?!data.*).*/ do
         # Use Angular Web App instead
         send_file(File.join("public", ".dist", "index.html"))
-      else
+      end
+    else
+      get "/" do
         if session[:user]
           redirect("/dashboard_erb")
         else
           redirect("/login_erb")
         end
       end
-    end
 
-    get "/favico.ico" do
-      "nope" # TODO: Add favicon once we have it
+      get "/favico.ico" do
+        "nope" # TODO: Add favicon once we have it
+      end
     end
   end
 end


### PR DESCRIPTION
Angular has it's own router which manages the address navigation so if you go to `/` it can reroute you to `/overview` without having to reload all the assets.

However, if you refresh the page Sinatra will not have a route called `/overview` and it will error out. As a workaround to this, I set up a all the data routes under `/data/...` and anything that isn't a data route should return the Angular page.

This is the pattern Angular describes: https://angular.io/guide/deployment#routed-apps-must-fallback-to-indexhtml

TODO: Need to add fallback route for Angular should the route not exist in their router either.