### PR TITLE
require spec helper and absolute path

### DIFF
--- a/spec/services/code_hosting/git_hub_service_spec.rb
+++ b/spec/services/code_hosting/git_hub_service_spec.rb
@@ -1,4 +1,5 @@
-require File.expand_path("../../../../services/code_hosting/git_hub_service.rb", __FILE__)
+require "spec_helper"
+require "app/services/code_hosting/git_hub_service"
 
 describe FastlaneCI::GitHubService do
   describe ".token_scope_validation_error" do


### PR DESCRIPTION
`require` with relative path is a bit brittle. Also we should make sure our specs start with `require "spec_helper"` so they can be run in isolation.