### PR TITLE
Check commits

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,9 @@ GIT
 
 GIT
   remote: https://github.com/fastlane/fastlane
-  revision: 937ea1917cd189506b80a76c050b53121b52f4c5
+  revision: 6f55e7acf460de0e0d4c5af5f924862043bf8692
   specs:
-    fastlane (2.87.0)
+    fastlane (2.88.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -92,7 +92,7 @@ GEM
     et-orbi (1.1.0)
       tzinfo
     eventmachine (1.2.5)
-    excon (0.61.0)
+    excon (0.62.0)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -178,7 +178,7 @@ GEM
     rack (2.0.4)
     rack-protection (2.0.1)
       rack
-    rack-test (0.8.3)
+    rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rake (12.3.1)

--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -214,7 +214,7 @@ module FastlaneCI
         project: self.project,
         number: new_build_number,
         status: :pending,
-        timestamp: Time.now,
+        timestamp: Time.now.utc,
         duration: -1,
         sha: self.sha
       )

--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -214,6 +214,9 @@ module FastlaneCI
         project: self.project,
         number: new_build_number,
         status: :pending,
+        # Ensure we're using UTC because your server might have a different timezone.
+        # While this isn't neccesary since timestamps are already UTC, it's good to message it here.
+        # so that utc stuff is discoverable
         timestamp: Time.now.utc,
         duration: -1,
         sha: self.sha

--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -90,7 +90,6 @@ module FastlaneCI
                                     provider_credential: provider_credential,
                                     async_start: false)
 
-
       fastfile = FastlaneCI::FastfilePeeker.peek(
         git_repo: repo,
         branch: branch

--- a/app/services/code_hosting/git_hub_service.rb
+++ b/app/services/code_hosting/git_hub_service.rb
@@ -99,6 +99,10 @@ module FastlaneCI
       return updated_commits
     end
 
+    def get_commits(repo_full_name:, branch: nil, since_time_utc:)
+      self.client.commits(repo_full_name, branch: branch, since: since_time_utc.iso8601)
+    end
+
     # TODO: parse those here or in service layer?
     def repos
       client.repos({}, query: { sort: "asc" })

--- a/app/services/fastfile_peeker/fastfile_peeker.rb
+++ b/app/services/fastfile_peeker/fastfile_peeker.rb
@@ -7,7 +7,6 @@ module FastlaneCI
   # Utility class designed for parsing Fastfiles in a repo.
   class FastfilePeeker
     class << self
-
       # @param [GitRepo] git_repo
       # @param [String, nil] branch
       # @param [String, nil] sha

--- a/app/shared/models/git_repo.rb
+++ b/app/shared/models/git_repo.rb
@@ -120,7 +120,7 @@ module FastlaneCI
         return
       end
 
-      logger.debug("Synchronously starting up repo: #{self.git_config.git_url}")
+      logger.debug("Synchronously starting up repo: #{self.git_config.git_url} at: #{local_folder}")
       now = Time.now.utc
       sleep_timeout = now + sync_setup_timeout_seconds # 10 second startup timeout
       while !setup_task.completed && now < sleep_timeout
@@ -233,7 +233,7 @@ module FastlaneCI
 
     # call like you would self.git.branches.remote.each { |branch| branch.yolo }
     # call like you would, but you also get the git repo involved, so it's  .each { |git, branch| branch.yolo; git.yolo }
-    def git_and_remote_branches_each(&each_block)
+    def git_and_remote_branches_each_async(&each_block)
       git_action_with_queue do
         branch_count = 0
         self.git.branches.remote.each do |branch|

--- a/app/workers/check_for_new_commits_on_github_worker.rb
+++ b/app/workers/check_for_new_commits_on_github_worker.rb
@@ -4,6 +4,8 @@ require_relative "../services/build_service"
 require_relative "../shared/models/job_trigger"
 require_relative "../shared/logging_module"
 
+require "time"
+
 module FastlaneCI
   # Responsible for checking if there have been new commits
   # We have to poll, as there is no easy way to hear about
@@ -14,32 +16,49 @@ module FastlaneCI
 
     attr_accessor :trigger_type
     attr_accessor :scheduler
+    attr_reader :github_service
 
     def initialize(provider_credential: nil, project: nil)
       self.trigger_type = FastlaneCI::JobTrigger::TRIGGER_TYPE[:commit]
       self.scheduler = WorkerScheduler.new(interval_time: 10)
+      @github_service = FastlaneCI::GitHubService.new(provider_credential: provider_credential)
 
       super(provider_credential: provider_credential, project: project) # This starts the work by calling `work`
     end
 
-    def work
-      logger.debug("Checking for new commits in #{self.project.project_name}")
-      repo = self.git_repo
-
-      # TODO: ensure BuildService subclasses are thread-safe
+    def check_for_new_commits
       build_service = FastlaneCI::Services.build_service
 
-      self.target_branches do |git, branch|
-        current_sha = repo.most_recent_commit.sha
+      # Sorted by newest timestamps first
+      sorted_builds = build_service.list_builds(project: self.project).sort { |x, y| y.timestamp.to_i <=> x.timestamp.to_i }
 
-        # Skips branches that have previously been built
-        builds = build_service.list_builds(project: self.project)
-        next if builds.map(&:sha).include?(current_sha)
+      # All the shas for builds we have run, sorted by build timestamp (newest builds first)
+      local_build_shas_by_date = sorted_builds.map(&:sha)
 
-        logger.debug("Detected new commit in #{self.project.project_name} on branch #{branch.name} with sha #{current_sha}")
+      # Look at the last commit time, then subtract 5 minutes from it to account for clock drift between this computer and the git repo
+      drift_time_seconds = 300
+      since_time_utc_seconds = sorted_builds.first&.timestamp.to_i - drift_time_seconds || Time.now.utc.to_i - drift_time_seconds
 
-        self.create_and_queue_build_task(sha: current_sha, repo: repo)
+      since_time_utc = Time.at(since_time_utc_seconds.to_i).utc
+      repo_full_name = self.project.repo_config.full_name
+      logger.debug("Looking for commits that are newer than #{since_time_utc.iso8601} for #{self.project.project_name} (#{repo_full_name})")
+
+      # Get all the new commits since the last build time (minus whatever drift we determined above)
+      new_commits = github_service.get_commits(repo_full_name: repo_full_name, since_time_utc: since_time_utc)
+      logger.debug("Found #{new_commits.length} potential new commit(s)") unless new_commits.length == 0
+      new_commit_shas = new_commits.map(&:sha)
+
+      # Trim out all the commits that we already have a build for, so we're just left with the new commits
+      shas_to_build = new_commit_shas - local_build_shas_by_date
+      logger.debug("Creating a build task for commits: #{shas_to_build}")
+
+      shas_to_build.each do |sha|
+        self.create_and_queue_build_task(sha: sha)
       end
+    end
+
+    def work
+      check_for_new_commits
     end
   end
 end

--- a/app/workers/check_for_new_commits_on_github_worker.rb
+++ b/app/workers/check_for_new_commits_on_github_worker.rb
@@ -51,11 +51,11 @@ module FastlaneCI
       # Trim out all the commits that we already have a build for, so we're just left with the new commits
       shas_to_build = new_commit_shas - local_build_shas_by_date
       if shas_to_build.length == 0
-        logger.debug("No new commits found")
+        logger.debug("No new commits found for #{self.project.project_name} (#{repo_full_name})")
         return
       end
 
-      logger.debug("Creating a build task for commits: #{shas_to_build}")
+      logger.debug("Creating a build task for commits: #{shas_to_build} from #{self.project.project_name} (#{repo_full_name})")
 
       shas_to_build.each do |sha|
         self.create_and_queue_build_task(sha: sha)

--- a/app/workers/check_for_new_commits_on_github_worker.rb
+++ b/app/workers/check_for_new_commits_on_github_worker.rb
@@ -50,6 +50,11 @@ module FastlaneCI
 
       # Trim out all the commits that we already have a build for, so we're just left with the new commits
       shas_to_build = new_commit_shas - local_build_shas_by_date
+      if shas_to_build.length == 0
+        logger.debug("No new commits found")
+        return
+      end
+
       logger.debug("Creating a build task for commits: #{shas_to_build}")
 
       shas_to_build.each do |sha|

--- a/app/workers/nightly_build_github_worker.rb
+++ b/app/workers/nightly_build_github_worker.rb
@@ -21,11 +21,11 @@ module FastlaneCI
     def work
       logger.debug("Running nightly builds on GitHub")
 
-      self.target_branches do |git, branch|
+      self.target_branches_async do |git, branch|
         current_sha = self.repo.most_recent_commit.sha
         logger.debug("Running Nightly build on branch #{branch.name} with sha #{current_sha}")
 
-        self.create_and_queue_build_task(sha: current_sha, repo: self.repo)
+        self.create_and_queue_build_task(sha: current_sha)
       end
     end
   end


### PR DESCRIPTION
- rename some methods to be more obvious that they are asynchronous
- be explicit about storing build timestamps as utc
- create_and_queue_build_task(sha:) now creates a new repo each time
