### PR TITLE
Allow the user to add at least one trigger when creating a Project

### DIFF
--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -159,19 +159,6 @@ module FastlaneCI
         trigger = FastlaneCI::NightlyJobTrigger.new(branch: branch, hour: hour.to_i, minute: minute.to_i)
       end
 
-      dir = Dir.mktmpdir
-      # Do this so we trigger the clone of the repo.
-      # TODO: Do this wherever it should be done, as we must redirect
-      # to the project details only when this task is finished.
-      repo = GitRepo.new(
-        git_config: repo_config,
-        provider_credential: provider_credential,
-        local_folder: dir,
-        async_start: false
-      )
-
-      repo.checkout_branch(branch: branch)
-
       # We now have enough information to create the new project.
       # TODO: add job_triggers here
       # We shouldn't be blocking manual trigger builds
@@ -187,6 +174,18 @@ module FastlaneCI
       )
 
       if !project.nil?
+        # Do this so we trigger the clone of the repo.
+        # TODO: Do this wherever it should be done, as we must redirect
+        # to the project details only when this task is finished.
+        repo = GitRepo.new(
+          git_config: repo_config,
+          provider_credential: provider_credential,
+          local_folder: project.local_repo_path,
+          async_start: false
+        )
+
+        repo.checkout_branch(branch: branch, use_global_git_mutex: false)
+
         redirect("#{HOME}/#{project.id}")
       else
         raise "Project couldn't be created"

--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -172,8 +172,8 @@ module FastlaneCI
         name: project_name,
         repo_config: repo_config,
         enabled: true,
-        platform: lane.split(" ").last,
-        lane: lane.split(" ").first,
+        platform: lane.split(" ").first,
+        lane: lane.split(" ").last,
         # TODO: Until we make a proper interface to attach JobTriggers to a Project, let's add a manual one for the selected branch.
         job_triggers: [trigger]
       )

--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -146,6 +146,18 @@ module FastlaneCI
       lane = params["selected_lane"]
       project_name = params["project_name"]
       branch = params["branch"]
+      trigger_type = params["selected_trigger"]
+      hour = params["hour"]
+      minute = params["minute"]
+
+      case trigger_type
+      when "commit"
+        trigger = FastlaneCI::CommitJobTrigger.new(branch: branch)
+      when "manual"
+        trigger = FastlaneCI::ManualJobTrigger.new(branch: branch)
+      when "nightly"
+        trigger = FastlaneCI::NightlyJobTrigger.new(branch: branch, hour: hour.to_i, minute: minute.to_i)
+      end
 
       dir = Dir.mktmpdir
       # Do this so we trigger the clone of the repo.
@@ -171,7 +183,7 @@ module FastlaneCI
         platform: lane.split(" ").last,
         lane: lane.split(" ").first,
         # TODO: Until we make a proper interface to attach JobTriggers to a Project, let's add a manual one for the selected branch.
-        job_triggers: [FastlaneCI::ManualJobTrigger.new(branch: branch)]
+        job_triggers: (trigger.nil? ? [] : [trigger])
       )
 
       if !project.nil?

--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -151,12 +151,14 @@ module FastlaneCI
       minute = params["minute"]
 
       case trigger_type
-      when "commit"
+      when FastlaneCI::JobTrigger::TRIGGER_TYPE[:commit]
         trigger = FastlaneCI::CommitJobTrigger.new(branch: branch)
-      when "manual"
+      when FastlaneCI::JobTrigger::TRIGGER_TYPE[:manual]
         trigger = FastlaneCI::ManualJobTrigger.new(branch: branch)
-      when "nightly"
+      when FastlaneCI::JobTrigger::TRIGGER_TYPE[:nightly]
         trigger = FastlaneCI::NightlyJobTrigger.new(branch: branch, hour: hour.to_i, minute: minute.to_i)
+      else
+        raise "Couldn't create a JobTrigger"
       end
 
       # We now have enough information to create the new project.
@@ -170,7 +172,7 @@ module FastlaneCI
         platform: lane.split(" ").last,
         lane: lane.split(" ").first,
         # TODO: Until we make a proper interface to attach JobTriggers to a Project, let's add a manual one for the selected branch.
-        job_triggers: (trigger.nil? ? [] : [trigger])
+        job_triggers: [trigger]
       )
 
       if !project.nil?
@@ -184,7 +186,7 @@ module FastlaneCI
           async_start: false
         )
 
-        repo.checkout_branch(branch: branch, use_global_git_mutex: false)
+        repo.checkout_branch(branch: branch)
 
         redirect("#{HOME}/#{project.id}")
       else
@@ -196,27 +198,20 @@ module FastlaneCI
     get "#{HOME}/:project_id" do
       project = self.user_project_with_id(project_id: params[:project_id])
 
-      # TODO: We now access a file directly from the submodule
-      # That's of course far from ideal, and not something we want to do long term
-      # Long term, the best appraoch would probably to have the FastfileParser be
-      # its own Ruby gem, or even part of the fastlane/fastlane main repo
-      # For now, this is good enough, as we'll be moving so fast with this one
-
       project_path = project.local_repo_path
 
-      # TODO: remove this once the Fastfile peeker is implemented
-      absolute_fastfile_path = File.join(project_path, "master/fastlane/Fastfile")
-      fastfile_parser = Fastlane::FastfileParser.new(path: absolute_fastfile_path)
+      fastfile_path = FastlaneCI::FastfileFinder.search_path(path: project_path)
+      fastfile_parser = Fastlane::FastfileParser.new(path: fastfile_path)
       available_lanes = fastfile_parser.available_lanes
 
-      relative_fastfile_path = Pathname.new(absolute_fastfile_path).relative_path_from(Pathname.new(project_path))
+      relative_fastfile_path = Pathname.new(fastfile_path).relative_path_from(Pathname.new(project_path))
 
       locals = {
         project: project,
         title: "Project #{project.project_name}",
         available_lanes: available_lanes,
         fastfile_parser: fastfile_parser,
-        fastfile_path: relative_fastfile_path # TODO: rename param `fastfile_path` to `relative_fastfile_path`
+        fastfile_path: relative_fastfile_path
       }
 
       erb(:project, locals: locals, layout: FastlaneCI.default_layout)

--- a/app/features/project/views/new_project_form.erb
+++ b/app/features/project/views/new_project_form.erb
@@ -84,25 +84,33 @@
       case "commit":
         document.querySelectorAll("#submit_form")[0].disabled = false;
         document.querySelectorAll("#nightly")[0].style.display = "none";
+        check_nightly(null);
         break;
       case "manual":
         document.querySelectorAll("#submit_form")[0].disabled = false;
         document.querySelectorAll("#nightly")[0].style.display = "none";
+        check_nightly(null);
         break;
       case "nightly":
         document.querySelectorAll("#nightly")[0].style.display = "";
+        document.querySelectorAll("#submit_form")[0].disabled = true;
+        check_nightly(document.querySelectorAll("#nightly")[0]);
         break;
     }
+    
   }
   function check_nightly(el) {
-    if (el.value) {
-      if (isFinite(parseInt(el.value))) {
+    if (el && el.value) {
+      if (isFinite(parseInt(document.querySelectorAll("#minute")[0].value)) && isFinite(parseInt(document.querySelectorAll("#hour")[0].value))) {
         document.querySelectorAll("#submit_form")[0].disabled = false;
-      } else {
+      }
+      else {
         document.querySelectorAll("#submit_form")[0].disabled = true;
       }
     } else {
-      document.querySelectorAll("#submit_form")[0].disabled = true;
+      if (isFinite(parseInt(document.querySelectorAll("#minute")[0].value)) && isFinite(parseInt(document.querySelectorAll("#hour")[0].value))) {
+        document.querySelectorAll("#submit_form")[0].disabled = false;
+      }
     }
   }
   </script>

--- a/app/features/project/views/new_project_form.erb
+++ b/app/features/project/views/new_project_form.erb
@@ -10,6 +10,9 @@
     document.querySelectorAll("#selected_lane")[0].style.display = "none";
     document.querySelectorAll("#lane_to_run")[0].style.display = "none";
     document.querySelectorAll("#loading")[0].style.display = "none";
+    document.querySelectorAll("#trigger")[0].style.display = "none";
+    document.querySelectorAll("#trigger_selector")[0].style.display = "none";
+    document.querySelectorAll("#nightly")[0].style.display = "none";
     setInterval(function() { 
       max_dots = 5;
       str = document.querySelectorAll("#loading")[0].querySelector("p").innerHTML;
@@ -36,6 +39,9 @@
     document.querySelectorAll("#selected_lane")[0].style.display = "none";
     document.querySelectorAll("#selected_lane")[0].innerHTML = "";
     document.querySelectorAll("#loading")[0].style.display = "";
+    document.querySelectorAll("#trigger")[0].style.display = "none";
+    document.querySelectorAll("#trigger_selector")[0].style.display = "none";
+    document.querySelectorAll("#nightly")[0].style.display = "none";
     request = new XMLHttpRequest();
     request.timeout = 1000 * 60 * 10; // 10 minutes
     request.responseType = 'json';
@@ -55,8 +61,7 @@
           }
         }
         document.querySelectorAll("#selected_lane")[0].style.display = "";
-        document.querySelectorAll("#lane_to_run")[0].style.display = "";
-        
+        document.querySelectorAll("#lane_to_run")[0].style.display = "";        
       } else {
         // We reached our target server, but it returned an error
       }
@@ -70,7 +75,35 @@
     request.send();
   }
   function check_lane() {
-    document.querySelectorAll("#submit_form")[0].disabled = false;
+    document.querySelectorAll("#trigger")[0].style.display = "";
+    document.querySelectorAll("#trigger_selector")[0].style.display = "";
+  }
+  function check_trigger(el) {
+    var trigger_value = el.value;
+    switch(trigger_value) {
+      case "commit":
+        document.querySelectorAll("#submit_form")[0].disabled = false;
+        document.querySelectorAll("#nightly")[0].style.display = "none";
+        break;
+      case "manual":
+        document.querySelectorAll("#submit_form")[0].disabled = false;
+        document.querySelectorAll("#nightly")[0].style.display = "none";
+        break;
+      case "nightly":
+        document.querySelectorAll("#nightly")[0].style.display = "";
+        break;
+    }
+  }
+  function check_nightly(el) {
+    if (el.value) {
+      if (isFinite(parseInt(el.value))) {
+        document.querySelectorAll("#submit_form")[0].disabled = false;
+      } else {
+        document.querySelectorAll("#submit_form")[0].disabled = true;
+      }
+    } else {
+      document.querySelectorAll("#submit_form")[0].disabled = true;
+    }
   }
   </script>
   
@@ -99,6 +132,32 @@
       </div>
       <select name="selected_lane", id="selected_lane" onchange="check_lane()">
       </select>
+      <br />
+      <h5 id="trigger">Select trigger</h5>
+      <div id="trigger_selector">
+        <select name="selected_trigger", id="selected_trigger", onchange="check_trigger(this)">
+          <option disabled selected value>Select a trigger</option>
+          <option value="commit">Commit</option>
+          <option value="manual">Manual</option>
+          <option value="nightly">Nightly</option>
+        </select>
+      <div id="nightly">
+        <br />
+        <br />
+        <p>Select the nightly schedule</p>
+        <select name="hour", id="hour", onchange="check_nightly(this)">
+          <option disabled selected value>Select an hour</option>
+          <% (0..23).each do |hour| %>
+            <option value="<%= hour %>"><%= hour %></option>
+          <% end %>
+        </select>
+        <select name="minute", id="minute", onchange="check_nightly(this)">
+          <option disabled selected value>Select a minute</option>
+          <% (0..59).each do |minute| %>
+            <option value="<%= minute %>"><%= minute %></option>
+          <% end %>
+        </select>
+      </div>
       <br />
       <br />
       <input id="submit_form" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" type="submit" title="Save">

--- a/app/features/project/views/project.erb
+++ b/app/features/project/views/project.erb
@@ -3,9 +3,15 @@
     <div class="mdl-layout__header-row">
       <span class="mdl-layout__title"><%= title %></span>
       <div class="mdl-layout-spacer"></div>
-      <a href="/projects_erb/<%= project.id %>/trigger" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-        Trigger Job Now
-      </a>
+      <% if project.job_triggers.any? { |job_trigger| job_trigger.kind_of?(FastlaneCI::ManualJobTrigger) } %>
+        <a href="/projects_erb/<%= project.id %>/trigger" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
+          Trigger Job Now
+        </a>
+      <% else %>
+        <a class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent mdl-button--disabled">
+          Trigger Job Now
+        </a>
+      <% end %>
     </div>
     <div class="mdl-layout__tab-bar mdl-js-ripple-effect">
       <a href="#scroll-tab-info" class="mdl-layout__tab is-active">Info</a>

--- a/app/shared/models/project.rb
+++ b/app/shared/models/project.rb
@@ -46,7 +46,7 @@ module FastlaneCI
       # TODO: This is fine for now to avoid runtime fails due to lack of triggers.
       # In the future, the Add Project workflow, should provide the enough interface
       # in order to add as many JobTriggers as the user wants.
-      self.job_triggers = [ManualJobTrigger.new(branch: "master")]
+      self.job_triggers = job_triggers
     end
 
     def find_triggers_of_type(trigger_type:)


### PR DESCRIPTION
- [x] Add a minimal interface to add a single `JobTrigger` when creating a new `Project`.
- [x] Disable `Trigger Job` button when no `ManualJobTrigger` is not found in the `Project`

Fixes #455 