### PR TITLE
Don't list details about the repos without access

### DIFF
--- a/app/features/dashboard/views/dashboard.erb
+++ b/app/features/dashboard/views/dashboard.erb
@@ -34,7 +34,7 @@
 
     <% if projects_without_access.count > 0 %>
       <h3>There are some projects you don't have access to</h3>
-      <p>To gain access to all projects, reach out to your GitHub org admin. They'll have to give you write access to the repo</p>
+      <p>to gain access to any repos you are missing from your organization, reach out to your GitHub org admin. They'll have to give you write access to the repo</p>
       <br />
     <% end %>
 

--- a/app/features/dashboard/views/dashboard.erb
+++ b/app/features/dashboard/views/dashboard.erb
@@ -32,26 +32,11 @@
 
     <br />
 
-    <h3>Projects you don't have access to</h3>
-    <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
-      <thead>
-        <tr>
-          <th style="width: 300px; text-align: center">Project Name</th>
-          <th>Access</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% projects_without_access.each do |project| %>
-          <tr>
-            <td style="text-align: center;"><%= project.project_name %></td>
-            <td>🚫</td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-    <p>To get access to those projects, make sure your GitHub account has access to them</p>
-
-    <br />
+    <% if projects_without_access.count > 0 %>
+      <h3>There are some projects you don't have access to</h3>
+      <p>To gain access to all projects, reach out to your GitHub org admin. They'll have to give you write access to the repo</p>
+      <br />
+    <% end %>
 
     <a href="/projects_erb/add" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
       Add new Project


### PR DESCRIPTION
This could potentially cause "privacy" issues, as a developer you might not have access to all repos. Instead let the user know how to be added to more projects, currently by being added to a given repo on GitHub