### PR TITLE
Make artifact reference accessor

### DIFF
--- a/app/shared/models/artifact.rb
+++ b/app/shared/models/artifact.rb
@@ -17,7 +17,7 @@ module FastlaneCI
     attr_reader :type
 
     # @return [String] The reference to the artifact to a certain ArtifactProvider
-    attr_reader :reference
+    attr_accessor :reference
 
     # @return [ArtifactProvider] The reference to the ArtifactProvider that stores the artifact
     attr_reader :provider

--- a/app/shared/models/artifact.rb
+++ b/app/shared/models/artifact.rb
@@ -20,7 +20,7 @@ module FastlaneCI
     attr_accessor :reference
 
     # @return [ArtifactProvider] The reference to the ArtifactProvider that stores the artifact
-    attr_reader :provider
+    attr_accessor :provider
 
     def initialize(type: nil, reference: nil, provider: nil, id: nil)
       @type = type


### PR DESCRIPTION
Otherwise we're running into the following crash
```
[2018-04-03 14:50:48] ERROR FastlaneBuildRunner:  undefined method `reference=' for #<FastlaneCI::Artifact:0x007fb9a406f378>
Did you mean?  reference
```

Let's merge this to get things working, but check with @minuscorp once he's up