### PR TITLE
We don't want to have <<~ style multi-line everywhere since it breaks up logging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,7 +55,7 @@ Naming/VariableNumber:
 MultilineBlockChain:
   Enabled: false
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   EnforcedStyle: aligned
 
 #

--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -49,10 +49,9 @@ module FastlaneCI
 
     def initialize(project:, sha:, github_service:, work_queue:, trigger:, git_fork_config: nil)
       if trigger.nil?
-        raise <<~ERROR
-          No trigger provided, this is probably caused by a build being triggered, but then the project not having this
-          particular build trigger associated
-        ERROR
+        # rubocop:disable Metrics/LineLength
+        raise "No trigger provided, this is probably caused by a build being triggered, but then the project not having this particular build trigger associated"
+        # rubocop:enable Metrics/LineLength
       end
 
       # Setting the variables directly (only having `attr_reader`) as they're immutable

--- a/app/features/build_runner/fastlane_build_runner.rb
+++ b/app/features/build_runner/fastlane_build_runner.rb
@@ -61,17 +61,11 @@ module FastlaneCI
       fast_file_path = FastlaneCI::FastfileFinder.find_fastfile_in_repo(repo: repo)
 
       if fast_file_path.nil? || !File.exist?(fast_file_path)
-        logger.info(
-          <<~LOG
-            unable to start fastlane run lane: #{lane} platform: #{platform}, params: #{parameters}, no Fastfile for
-            commit
-          LOG
-        )
+        # rubocop:disable Metrics/LineLength
+        logger.info("unable to start fastlane run lane: #{lane} platform: #{platform}, params: #{parameters}, no Fastfile for commit")
         current_build.status = :missing_fastfile
-        current_build.description = <<~DESCRIPTION
-          We're unable to start fastlane run lane: #{lane} platform: #{platform}, params: #{parameters}, because no
-          Fastfile existed at the time the commit was made
-        DESCRIPTION
+        current_build.description = "We're unable to start fastlane run lane: #{lane} platform: #{platform}, params: #{parameters}, because no Fastfile existed at the time the commit was made"
+        # rubocop:enable Metrics/LineLength
 
         completion_block.call([])
         return
@@ -84,11 +78,9 @@ module FastlaneCI
       begin
         # TODO: I think we need to clear out the singleton values, such as lane context, and all that jazz
         # Execute the Fastfile here
-        logger.info(
-          <<~LOG
-            starting fastlane run lane: #{lane} platform: #{platform}, params: #{parameters} from #{fast_file_path}
-          LOG
-        )
+        # rubocop:disable Metrics/LineLength
+        logger.info("starting fastlane run lane: #{lane} platform: #{platform}, params: #{parameters} from #{fast_file_path}")
+        # rubocop:enable Metrics/LineLength
 
         # Attach a listener to the output to see if we have a failure. If so, this build failed
         add_listener(proc do |row|

--- a/app/features/build_runner/fastlane_build_runner_helpers/fastlane_ci_output.rb
+++ b/app/features/build_runner/fastlane_build_runner_helpers/fastlane_ci_output.rb
@@ -191,11 +191,7 @@ module FastlaneCI
 
     def non_interactive!(message)
       important(message)
-      crash!(
-        <<~ERROR
-          Could not retrieve response as fastlane runs fastlane.ci and can't ask for additional inputs during its run
-        ERROR
-      )
+      crash!("Can't ask for additional inputs during fastlane run when in CI")
     end
   end
 end

--- a/app/features/onboarding/onboarding_controller.rb
+++ b/app/features/onboarding/onboarding_controller.rb
@@ -148,18 +148,15 @@ module FastlaneCI
           scopes, required = scope_validation_error
           scopes_list_wording = scopes.count > 0 ? scopes.map { |scope| "\"#{scope}\"" }.join(",") : "empty"
           scopes_wording = scopes.count > 1 ? "scopes" : "scope"
-          error_message = <<~ERROR
-            Token should be in \"#{required}\" scope, currently it's in #{scopes_list_wording} #{scopes_wording}.
-          ERROR
-          session[:message] = <<~HTML
-            ERROR: #{error_message} See the image below.
-          HTML
+          # rubocop:disable Metrics/LineLength
+          error_message = "Token should be in \"#{required}\" scope, currently it's in #{scopes_list_wording} #{scopes_wording}."
+          # rubocop:enable Metrics/LineLength
+          session[:message] = "ERROR: #{error_message} See the image below."
           logger.error(error_message)
         end
       else
-        session[:message] = <<~HTML
-          ERROR: #{Services.environment_variable_service.keys_file_path_relative_to_home} file not written.
-        HTML
+        path = Services.environment_variable_service.keys_file_path_relative_to_home
+        session[:message] = "ERROR: #{path} file not written."
       end
 
       redirect("#{HOME}/initial_clone_user")

--- a/app/services/code_hosting/git_hub_service.rb
+++ b/app/services/code_hosting/git_hub_service.rb
@@ -73,12 +73,8 @@ module FastlaneCI
       end
 
       # we want only the PRs whose latest commit was to one of the branches passed in
-      logger.debug(
-        <<~LOG
-          Returning all open prs from: #{repo_full_name}, branches: #{branches}, pr count:
-          #{all_open_pull_requests.count}
-        LOG
-      )
+      pr_count = all_open_pull_requests.count
+      logger.debug("Returning all open prs from: #{repo_full_name}, branches: #{branches}, pr count: #{pr_count}")
 
       return all_open_pull_requests_on_branch
     end

--- a/app/services/config_data_sources/json_project_data_source.rb
+++ b/app/services/config_data_sources/json_project_data_source.rb
@@ -220,11 +220,8 @@ module FastlaneCI
         logger.debug("Couldn't update project #{project.project_name} because it doesn't exists")
         raise "Couldn't update project #{project.project_name} because it doesn't exists"
       else
-        logger.debug(
-          <<~LOG
-            Updating project #{existing_project.project_name}, writing out to projects.json to #{json_folder_path}
-          LOG
-        )
+        project_name = existing_project.project_name
+        logger.debug("Updating project #{project_name}, writing out to projects.json to #{json_folder_path}")
 
         projects = self.projects
         projects[project_index] = project
@@ -250,11 +247,8 @@ module FastlaneCI
         logger.debug("Couldn't delete project #{project.project_name} because it doesn't exists")
         raise "Couldn't update project #{project.project_name} because it doesn't exists"
       else
-        logger.debug(
-          <<~LOG
-            Deleting project #{existing_project.project_name}, writing out to projects.json to #{json_folder_path}
-          LOG
-        )
+        project_name = existing_project.project_name
+        logger.debug("Deleting project #{project_name}, writing out to projects.json to #{json_folder_path}")
 
         projects = self.projects
         projects.delete_at(project_index)

--- a/app/services/configuration_repository_service.rb
+++ b/app/services/configuration_repository_service.rb
@@ -114,12 +114,9 @@ module FastlaneCI
         repo_shortform, file_path, "Add initial #{file_path}", json_string
       )
     rescue Octokit::UnprocessableEntity
-      logger.debug(
-        <<~WARNING_MESSAGE
-          The file #{file_path} already exists in remote configuration repo:
-          #{repo_shortform}. Not overwriting the file.
-        WARNING_MESSAGE
-      )
+      # rubocop:disable Metrics/LineLength
+      logger.debug("The file #{file_path} already exists in remote configuration repo: #{repo_shortform}. Not overwriting the file.")
+      # rubocop:enable Metrics/LineLength
     end
 
     #####################################################

--- a/app/services/data_sources/json_notification_data_source.rb
+++ b/app/services/data_sources/json_notification_data_source.rb
@@ -91,12 +91,9 @@ module FastlaneCI
       else
         @notifications[notification_index] = notification
         self.notifications = @notifications
-        logger.debug(
-          <<~LOG
-            Updating notification #{existing_notification.name}, writing out notifications.json to
-            #{notifications_file_path}
-          LOG
-        )
+        path = notifications_file_path
+        notification_name = existing_notification.name
+        logger.debug("Updating notification #{notification_name}, writing out notifications.json to #{path}")
       end
     end
 

--- a/app/services/services.rb
+++ b/app/services/services.rb
@@ -83,10 +83,9 @@ module FastlaneCI
         password: FastlaneCI.env.ci_user_password
       )
       if @_ci_user.nil?
-        raise <<~ERROR
-          Could not find ci_user for current setup, or the provided ci_user_password is incorrect, please make sure a
-          user with the email #{FastlaneCI.env.ci_user_email} exists in your users.json
-        ERROR
+        # rubocop:disable Metrics/LineLength
+        raise "Could not find ci_user for current setup, or the provided ci_user_password is incorrect, please make sure a user with the email #{FastlaneCI.env.ci_user_email} exists in your users.json"
+        # rubocop:enable Metrics/LineLength
       end
       return @_ci_user
     end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -54,12 +54,9 @@ module FastlaneCI
       success = user_data_source.update_user!(user: user)
       if success
         # TODO: remove this message if https://github.com/fastlane/ci/issues/292 is fixed
-        logger.info(
-          <<~LOG
-            Updated user #{user.email}, that means you should call `find_user(id:)` see
-            https://github.com/fastlane/ci/issues/292
-          LOG
-        )
+        # rubocop:disable Metrics/LineLength
+        logger.info("Updated user #{user.email}, that means you should call `find_user(id:)` see https://github.com/fastlane/ci/issues/292")
+        # rubocop:enable Metrics/LineLength
       end
       return success
     end

--- a/app/services/worker_service.rb
+++ b/app/services/worker_service.rb
@@ -26,10 +26,9 @@ module FastlaneCI
       user_responsible = provider_credential.ci_user
 
       if user_responsible.nil?
-        raise <<~ERROR
-          Unable to start workers for `#{project.project_name}`, no `user_responsible` for given `provider_credential`:
-          #{provider_credential.email}
-        ERROR
+        name = project.project_name
+        email = provider_credential.email
+        raise "Unable to start workers for `#{name}`, no `user_responsible` for given `provider_credential`: #{email}"
       end
 
       workers_key = project_to_workers_dictionary_key(project: project, user_responsible: user_responsible)

--- a/app/shared/authentication_request_checker.rb
+++ b/app/shared/authentication_request_checker.rb
@@ -13,11 +13,9 @@ module FastlaneCI
         if defined?(self::HOME)
           route = "#{self::HOME}*"
         else
-          message = <<~MESSAGE
-            \nYou must define a const called `HOME` on #{self} or you must pass the routes you intend to protect to
-            `ensure_logged_in()`\n
-          MESSAGE
-          raise message
+          # rubocop:disable Metrics/LineLength
+          raise "You must define a const called `HOME` on #{self} or you must pass the routes you intend to protect to `ensure_logged_in()`"
+          # rubocop:enable Metrics/LineLength
         end
       end
       logger.debug("requiring logged-in user for access to `#{route}`")

--- a/app/shared/models/gcp_artifact_provider.rb
+++ b/app/shared/models/gcp_artifact_provider.rb
@@ -54,10 +54,9 @@ module FastlaneCI
       permissions = bucket.test_permissions("storage.objects.create", "storage.objects.get")
 
       unless permissions.include?("storage.objects.create") && permissions.include?("storage.objects.get")
-        raise <<~ERROR
-          The credentials provided by #{File.basename(json_keyfile_path)} are insufficient to perform needed actions by
-          the provider, needed: 'storage.objects.create', 'storage.objects.get' got #{permissions}.
-        ERROR
+        # rubocop:disable Metrics/LineLength
+        raise "The credentials provided by #{File.basename(json_keyfile_path)} are insufficient to perform needed actions by the provider, needed: 'storage.objects.create', 'storage.objects.get' got #{permissions}."
+        # rubocop:enable Metrics/LineLength
       end
     end
 

--- a/app/shared/models/git_repo.rb
+++ b/app/shared/models/git_repo.rb
@@ -247,10 +247,9 @@ module FastlaneCI
       credential_mismatch = credential_type != git_config_credential_type
 
       if credential_mismatch
-        raise <<~ERROR
-          provider_credential.type and git_config.provider_credential_type_needed mismatch: #{credential_type} vs
-          #{git_config_credential_type}
-        ERROR
+        # rubocop:disable Metrics/LineLength
+        raise "provider_credential.type and git_config.provider_credential_type_needed mismatch: #{credential_type} vs #{git_config_credential_type}"
+        # rubocop:enable Metrics/LineLength
       end
     end
 

--- a/app/workers/nightly_build_github_worker.rb
+++ b/app/workers/nightly_build_github_worker.rb
@@ -33,23 +33,17 @@ module FastlaneCI
 
       since_time_utc = Time.at(since_time_utc_seconds.to_i).utc
       repo_full_name = project.repo_config.full_name
-      logger.debug(
-        <<~LOG
-          Looking for commits that are newer than #{since_time_utc.iso8601} for #{project.project_name}
-          (#{repo_full_name})
-        LOG
-      )
+
+      # rubocop:disable Metrics/LineLength
+      logger.debug("Looking for commits that are newer than #{since_time_utc.iso8601} for #{project.project_name} (#{repo_full_name})")
 
       # Get all the new commits since the last build time (minus whatever drift we determined above)
       new_commits = github_service.recent_commits(repo_full_name: repo_full_name, since_time_utc: since_time_utc)
       unless new_commits.length == 0
-        logger.debug(
-          <<~LOG
-            Found #{new_commits.length} commit(s) since the last run, building the most recent for
-            #{project.project_name} (#{repo_full_name})")
-          LOG
-        )
+        logger.debug("Found #{new_commits.length} commit(s) since the last run, building the most recent for #{project.project_name} (#{repo_full_name})")
       end
+      # rubocop:enable Metrics/LineLength
+
       newest_commit = new_commits.map(&:sha).first
 
       if newest_commit.nil?

--- a/app/workers/worker_scheduler.rb
+++ b/app/workers/worker_scheduler.rb
@@ -36,12 +36,8 @@ module FastlaneCI
         job_id = scheduler.cron(cron_schedule) { block.call }
         scheduled_cron_job = scheduler.job(job_id)
         logger.debug("Scheduling cron job for #{cron_schedule}.")
-        logger.debug(
-          <<~LOG
-            Next time #{scheduled_cron_job.next_time} or #{(scheduled_cron_job.next_time - Time.now) / (60 * 60)} hours
-            from now.
-          LOG
-        )
+        time_from_now = (scheduled_cron_job.next_time - Time.now) / (60 * 60)
+        logger.debug("Next time #{scheduled_cron_job.next_time} or #{time_from_now} hours from now.")
       end
     end
 

--- a/launch.rb
+++ b/launch.rb
@@ -53,10 +53,7 @@ module FastlaneCI
         app_exists = File.file?(File.join("public", ".dist", "index.html"))
 
         unless app_exists
-          raise <<~ERROR
-            The web application is not built. Please build with the Angular CLI and Try Again.\nEx. ng build
-            --deploy-url=\"/.dist\"
-          ERROR
+          raise "The web app not built. Build with the Angular CLI and Try Again, e.g. ng build --deploy-url=\"/.dist\""
         end
       end
     end


### PR DESCRIPTION
# rubocop:disable Metrics/LineLength some of the lines, and rewrite others to work with our new line length requirements.