### PR TITLE
Automatically clean completed build runners

### DIFF
--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -123,6 +123,9 @@ module FastlaneCI
           time: Time.now
         )
       )
+      # Remove ourselves from the list of active build runners
+      # to let the garbage collector do its thing
+      Services.build_runner_service.remove_build_runner(build_runner: self)
     end
 
     def checkout_sha

--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -226,15 +226,16 @@ module FastlaneCI
       logger.debug("Starting build runner #{self.class} for #{project.project_name} #{project.id} sha: #{sha} now...")
       start_time = Time.now
 
-      artifact_handler_block = proc do |artifact_paths|
-        complete_run(start_time: start_time, artifact_paths: artifact_paths)
-      end
-
       work_block = proc {
         pre_run_action
-        run(completion_block: artifact_handler_block) do |current_row|
-          new_row(current_row)
-        end
+        run(
+          new_line_block: proc do |current_row|
+            new_row(current_row)
+          end,
+          completion_block: proc do |artifact_paths|
+            complete_run(start_time: start_time, artifact_paths: artifact_paths)
+          end
+        )
       }
 
       post_run_block = proc {
@@ -255,7 +256,8 @@ module FastlaneCI
 
     # @return [Array[String]] of references for the different artifacts created by the runner.
     # TODO: are these Artifact objects or paths?
-    def run(*args)
+    # Important: The `run` method must always call completion_block, even when there is an exception
+    def run(new_line_block:, completion_block:)
       not_implemented(__method__)
     end
 

--- a/app/features/build_runner/fastlane_build_runner.rb
+++ b/app/features/build_runner/fastlane_build_runner.rb
@@ -73,8 +73,6 @@ module FastlaneCI
         current_build.status = :missing_fastfile
         current_build.description = "We're unable to start fastlane run lane: #{lane} platform: #{platform}, params: #{parameters}, because no Fastfile existed at the time the commit was made"
         # rubocop:enable Metrics/LineLength
-
-        completion_block.call([])
         return
       end
 

--- a/app/features/build_runner/fastlane_build_runner.rb
+++ b/app/features/build_runner/fastlane_build_runner.rb
@@ -38,14 +38,13 @@ module FastlaneCI
     end
 
     # completion_block is called with an array of artifacts
-    def run(completion_block: nil, &block)
-      raise "No block provided for `run` method" unless block_given?
-      raise "No completion_block provided for `run` method" if completion_block.nil?
+    def run(new_line_block:, completion_block:)
+      artifacts_paths = [] # first thing we do, as we access it in the `ensure` block of this method
       require "fastlane"
 
       ci_output = FastlaneCI::FastlaneCIOutput.new(
         each_line_block: proc do |raw_row|
-          block.call(convert_raw_row_to_object(raw_row))
+          new_line_block.call(convert_raw_row_to_object(raw_row))
         end
       )
 

--- a/app/services/build_runner_service.rb
+++ b/app/services/build_runner_service.rb
@@ -28,6 +28,10 @@ module FastlaneCI
       return task
     end
 
+    def remove_build_runner(build_runner:)
+      build_runners.delete(build_runner)
+    end
+
     def build_runner_task_queue
       @_build_runner_task_queue ||= TaskQueue::TaskQueue.new(name: "build runner service")
     end

--- a/app/services/build_runner_service.rb
+++ b/app/services/build_runner_service.rb
@@ -17,7 +17,7 @@ module FastlaneCI
     end
 
     # @return TaskQueue::Task
-    def add_build_runner(build_runner: nil)
+    def add_build_runner(build_runner:)
       raise "No build runner provided" unless build_runner.kind_of?(BuildRunner)
 
       build_runners << build_runner

--- a/app/services/build_runner_service.rb
+++ b/app/services/build_runner_service.rb
@@ -20,16 +20,20 @@ module FastlaneCI
     def add_build_runner(build_runner:)
       raise "No build runner provided" unless build_runner.kind_of?(BuildRunner)
 
-      build_runners << build_runner
-
-      task = TaskQueue::Task.new(work_block: proc { build_runner.start })
+      task = TaskQueue::Task.new(work_block: proc do
+        build_runners << build_runner
+        build_runner.start
+      end)
       build_runner_task_queue.add_task_async(task: task)
 
       return task
     end
 
     def remove_build_runner(build_runner:)
-      build_runners.delete(build_runner)
+      task = TaskQueue::Task.new(work_block: proc do
+        build_runners.delete(build_runner)
+      end)
+      build_runner_task_queue.add_task_async(task: task)
     end
 
     def build_runner_task_queue


### PR DESCRIPTION
- Make build_runner a required parameter for `add_build_runner`
- Automatically clean completed build runners
- Refactor to have named blocks for all BuildRunners & required parameters
- Don't call the completion block twice

Fixes https://github.com/fastlane/ci/issues/496

I haven't done any memory debugging in Ruby yet. With this PR we for sure remove the reference we were holding in the array, but how we can verify the BuildRunner object actually gets deallocated?