### PR TITLE
Should return the plain @api_token if it has not been encrypted yet

### DIFF
--- a/app/shared/models/github_provider_credential.rb
+++ b/app/shared/models/github_provider_credential.rb
@@ -46,7 +46,7 @@ module FastlaneCI
     end
 
     def api_token
-      return nil if @encrypted_api_token.nil?
+      return @api_token if @encrypted_api_token.nil?
       return StringEncrypter.decode(Base64.decode64(@encrypted_api_token))
     end
   end


### PR DESCRIPTION
Fixes #530 