### PR TITLE
Update vision to mention "no build steps" philosophy

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -25,7 +25,7 @@
 - **Sensible defaults**: If something can be automatically figured out by `fastlane.ci`, it should be
 - **Easy permissions**: Instead of manually managing an extra layer of permission, `fastlane.ci` just uses GitHub
 - **Focus on the most established toolings**: git, GitHub and Xcode
-- **No build steps**: `fastlane.ci` will never allow you to add more build steps, instead all automation is done via _fastlane_
+- **No build steps**: `fastlane.ci` will never allow you to add "build steps", instead, all automation is done via _fastlane_
 
 ## Long-term goals
 

--- a/VISION.md
+++ b/VISION.md
@@ -25,6 +25,7 @@
 - **Sensible defaults**: If something can be automatically figured out by `fastlane.ci`, it should be
 - **Easy permissions**: Instead of manually managing an extra layer of permission, `fastlane.ci` just uses GitHub
 - **Focus on the most established toolings**: git, GitHub and Xcode
+- **No build steps**: `fastlane.ci` will never allow you to add more build steps, instead all automation is done via _fastlane_
 
 ## Long-term goals
 


### PR DESCRIPTION
While reviewing https://github.com/fastlane/ci/pull/531/files#diff-61719c654676bde47ad11f033825c172R4 I noticed we didn't write it down yet.