### PR TITLE
Handle git errors more gracefully by killing the build and reporting issues

### DIFF
--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -94,7 +94,7 @@ module FastlaneCI
     def fail_build!(start_time:)
       duration = Time.now - start_time
       current_build.duration = duration
-      current_build.status = :failure # TODO: also handle failure
+      current_build.status = :failure
       save_build_status!
     end
 

--- a/app/shared/models/git_repo.rb
+++ b/app/shared/models/git_repo.rb
@@ -181,6 +181,8 @@ module FastlaneCI
       raise ex unless notification_service
 
       user_unfriendly_message = ex.message.to_s
+
+      # Permission error, or lost interwebs
       if user_unfriendly_message.include?("unable to access")
         priority = Notification::PRIORITIES[:urgent]
         notification_service.create_notification!(
@@ -189,14 +191,29 @@ module FastlaneCI
           message: "Unable to acccess #{git_config.git_url}",
           details: user_unfriendly_message
         )
+
+      # Merge conflict, maybe somebody force-pushed something?
       elsif user_unfriendly_message.include?("Merge conflict")
         priority = Notification::PRIORITIES[:urgent]
         notification_service.create_notification!(
           priority: priority,
-          name: "Merge conflic",
+          name: "Merge conflict",
           message: "Unable to build #{git_config.git_url}",
           details: "#{user_unfriendly_message}, context: #{exception_context}"
         )
+
+      # Object disappeared in current git tree, could have been a force push that now causes SHA  to be missing
+      elsif user_unfriendly_message.include?("Could not parse object")
+        # This happens when there is a force push somewhere and now a previous commit is missing
+        # or a repo is just not up-to-date
+        priority = Notification::PRIORITIES[:urgent]
+        notification_service.create_notification!(
+          priority: priority,
+          name: "Unable to check out sha",
+          message: "Unable to checkout an object from #{git_config.git_url}",
+          details: "#{user_unfriendly_message}, context: #{exception_context}"
+        )
+
       else
         raise ex
       end
@@ -448,13 +465,23 @@ module FastlaneCI
         logger.info("Checking out sha: #{sha} from #{repo_url}")
         setup_auth(repo_auth: repo_auth)
 
+        success = false
         begin
-          git.reset_hard(git.gcommit(sha))
+          git.reset_hard(
+            git.gcommit(sha)
+          )
+          success = true
         rescue StandardError => ex
-          handle_exception(ex, console_message: "Error resetting and checking out sha: #{sha} from #{repo_url}")
+          exception_context = { sha: sha }
+          handle_exception(
+            ex,
+            console_message: "Error resetting and checking out sha: #{sha} from #{repo_url}",
+            exception_context: exception_context
+          )
         end
 
         logger.debug("Done resetting and checking out sha: #{sha} from #{repo_url}")
+        return success
       end
     end
 


### PR DESCRIPTION
- Handle missing git objects
- Don't attempt a build when git
- Fixes #543