### PR TITLE
Raise exception if current user doesn't have access to repo

### DIFF
--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -114,6 +114,7 @@ module FastlaneCI
 
       github_service = FastlaneCI::GitHubService.new(provider_credential: provider_credential)
       selected_repo = github_service.repos.detect { |repo| repo_name == repo.name && org = repo.owner }
+      raise "Could not find repo, make sure to have access" if selected_repo.nil?
 
       repo_config = GitRepoConfig.from_octokit_repo!(repo: selected_repo)
 


### PR DESCRIPTION
Better to raise an exception, than to fail with a `nil` error later on