### PR TITLE
Rescue exception in Sinatra middleware

### DIFF
--- a/app/features/build/build_websocket_backend.rb
+++ b/app/features/build/build_websocket_backend.rb
@@ -87,6 +87,9 @@ module FastlaneCI
 
       # Return async Rack response
       return ws.rack_response
+    rescue => ex
+      logger.error("Error in #{self.class} middleware: #{ex}")
+      logger.error(ex.backtrace.join("\n"))
     end
   end
 end


### PR DESCRIPTION
This previously caused the whole server to crash, this should be fine now. Also I'm not catching just StandardError, as we probably want to catch ANY kind of error, as not getting real-time output is not as bad as the whole server crashing