### PR TITLE
Let fastlane exceptions bubble up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,12 @@
 GIT
   remote: https://github.com/fastlane/TaskQueue
   revision: 5b3f459be5c451cc9ab25f6819d2eeb67be5e56d
-  ref: 5b3f459
   specs:
     taskqueue (0.0.0)
 
 GIT
   remote: https://github.com/fastlane/fastfile-parser
-  revision: 122825dfb9370a6a2008e2e5ca8613dc6602b45d
-  ref: 122825d
+  revision: 4ee3b130e4d42bd61ee4134708a48e05c00d44b2
   specs:
     fastfile-parser (0.0.0)
       parser (>= 2.4.0.2, < 2.5.0.0)
@@ -16,9 +14,9 @@ GIT
 
 GIT
   remote: https://github.com/fastlane/fastlane
-  revision: 7ee705adc437a4ee3ca6038de368f5833f0c06fc
+  revision: 6b392e8e019d0a8449f3b085b1d8e6c63fe10c69
   specs:
-    fastlane (2.88.0)
+    fastlane (2.89.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -43,7 +41,7 @@ GIT
       public_suffix (~> 2.0.0)
       rubyzip (>= 1.1.0, < 2.0.0)
       security (= 0.1.3)
-      simctl (~> 1.6)
+      simctl (~> 1.6.3)
       slack-notifier (>= 2.0.0, < 3.0.0)
       terminal-notifier (>= 1.6.2, < 2.0.0)
       terminal-table (>= 1.4.5, < 2.0.0)
@@ -161,7 +159,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustermann (1.0.2)
-    nanaimo (0.2.4)
+    nanaimo (0.2.5)
     naturally (2.1.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -228,7 +226,7 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simctl (1.6.2)
+    simctl (1.6.3)
       CFPropertyList
       naturally
     simplecov (0.14.1)

--- a/app/features/build/views/build.erb
+++ b/app/features/build/views/build.erb
@@ -147,6 +147,9 @@
   p.error {
     color: red;
   }
+  p.crash {
+    color: red;
+  }
   p.command_output {
     color: #005aff;
   }

--- a/app/features/build_runner/build_runner_output_row.rb
+++ b/app/features/build_runner/build_runner_output_row.rb
@@ -7,7 +7,6 @@ module FastlaneCI
       :user_error,
       :build_error,
       :crash,
-      :error,
       :shell_error,
       :build_failure,
       :test_failure,
@@ -34,6 +33,8 @@ module FastlaneCI
     end
 
     # Did this particular message fail the build? (e.g. `user_error` or `build_error`)
+    # TODO: Let's think about removing this method, we probably won't need it any more
+    #       and with that, we could remove `BUILD_FAIL_TYPES`
     def did_fail_build?
       # The first time this method is called, we check if this row failed the build
       if @_did_fail_build.nil?

--- a/app/features/build_runner/fastlane_build_runner.rb
+++ b/app/features/build_runner/fastlane_build_runner.rb
@@ -110,6 +110,7 @@ module FastlaneCI
         end
 
         current_build.status = :success
+        current_build.description = "All green"
 
         logger.info("fastlane run complete")
         logger.debug(build_output.join("\n").to_s)

--- a/app/features/build_runner/fastlane_build_runner.rb
+++ b/app/features/build_runner/fastlane_build_runner.rb
@@ -124,7 +124,8 @@ module FastlaneCI
         logger.error(ex)
         logger.error(ex.backtrace)
 
-        # Catching the exception with this rescue block is really important, as we also need to notify the listeners about it
+        # Catching the exception with this rescue block is really important,
+        # as we also need to notify the listeners about it
         # see https://github.com/fastlane/ci/issues/583 for more details
         # notify all interested parties here
         # TODO: the line below could be improved

--- a/app/features/build_runner/fastlane_build_runner_helpers/fastlane_ci_output.rb
+++ b/app/features/build_runner/fastlane_build_runner_helpers/fastlane_ci_output.rb
@@ -9,17 +9,19 @@ module FastlaneCI
     # be stored in the log.
     attr_reader :each_line_block
 
+    attr_accessor :output_listeners
+
     def initialize(each_line_block: nil)
       raise "No each_line_block provided" if each_line_block.nil?
       @each_line_block = each_line_block
-      @output_listeners = []
+      self.output_listeners = []
     end
 
     def add_output_listener!(listener)
       unless listener.kind_of?(FastlaneLog)
         raise "Invalid listener provider, expected #{FastlaneLog.class.name} got #{listener.class.name}"
       end
-      @output_listeners << listener
+      output_listeners << listener
     end
 
     #####################################################
@@ -27,7 +29,7 @@ module FastlaneCI
     #####################################################
 
     def error(message)
-      @output_listeners.each { |listener| listener.error(message) }
+      output_listeners.each { |listener| listener.error(message) }
       each_line_block.call(
         type: :error,
         message: message,
@@ -36,7 +38,7 @@ module FastlaneCI
     end
 
     def important(message)
-      @output_listeners.each { |listener| listener.important(message) }
+      output_listeners.each { |listener| listener.important(message) }
       each_line_block.call(
         type: :important,
         message: message,
@@ -45,7 +47,7 @@ module FastlaneCI
     end
 
     def success(message)
-      @output_listeners.each { |listener| listener.success(message) }
+      output_listeners.each { |listener| listener.success(message) }
       each_line_block.call(
         type: :success,
         message: message,
@@ -56,7 +58,7 @@ module FastlaneCI
     # If you're here because you saw the exception: `wrong number of arguments (given 0, expected 1)`
     # that means you're accidentally calling this method instead of a local variable on the stack frame before this
     def message(message)
-      @output_listeners.each { |listener| listener.message(message) }
+      output_listeners.each { |listener| listener.message(message) }
       each_line_block.call(
         type: :message,
         message: message,
@@ -65,7 +67,7 @@ module FastlaneCI
     end
 
     def deprecated(message)
-      @output_listeners.each { |listener| listener.deprecated(message) }
+      output_listeners.each { |listener| listener.deprecated(message) }
       each_line_block.call(
         type: :error,
         message: message,
@@ -74,7 +76,7 @@ module FastlaneCI
     end
 
     def command(message)
-      @output_listeners.each { |listener| listener.command(message) }
+      output_listeners.each { |listener| listener.command(message) }
       each_line_block.call(
         type: :command,
         message: message,
@@ -88,7 +90,7 @@ module FastlaneCI
         prefix = msg.include?("▸") ? "" : "▸ "
         resulting_message = prefix + msg
 
-        @output_listeners.each { |listener| listener.message(resulting_message) }
+        output_listeners.each { |listener| listener.message(resulting_message) }
         each_line_block.call(
           type: :command_output,
           message: resulting_message,
@@ -98,11 +100,11 @@ module FastlaneCI
     end
 
     def verbose(message)
-      @output_listeners.each { |listener| listener.verbose(message) }
+      output_listeners.each { |listener| listener.verbose(message) }
     end
 
     def header(message)
-      @output_listeners.each { |listener| listener.header(message) }
+      output_listeners.each { |listener| listener.header(message) }
       each_line_block.call(
         type: :header,
         message: message,
@@ -113,62 +115,26 @@ module FastlaneCI
     # TODO: Check if we can find a good way to not have to
     #   overwrite all these methods
     def crash!(exception)
-      @output_listeners.each { |listener| listener.error(exception.to_s) }
-      each_line_block.call(
-        type: :crash,
-        message: exception.to_s,
-        time: Time.now
-      )
       raise FastlaneCrash.new, exception.to_s
     end
 
     def user_error!(error_message, options = {})
-      @output_listeners.each { |listener| listener.error(error_message) }
-      each_line_block.call(
-        type: :user_error,
-        message: error_message,
-        time: Time.now
-      )
       super(error_message, options)
     end
 
     def shell_error!(error_message, options = {})
-      @output_listeners.each { |listener| listener.error(error_message) }
-      each_line_block.call(
-        type: :shell_error,
-        message: error_message,
-        time: Time.now
-      )
       super(error_message, options)
     end
 
     def build_failure!(error_message, options = {})
-      @output_listeners.each { |listener| listener.error(error_message) }
-      each_line_block.call(
-        type: :build_failure,
-        message: error_message,
-        time: Time.now
-      )
       super(error_message, options)
     end
 
     def test_failure!(error_message)
-      @output_listeners.each { |listener| listener.error(error_message) }
-      each_line_block.call(
-        type: :test_failure,
-        message: error_message,
-        time: Time.now
-      )
       super(error_message)
     end
 
     def abort_with_message!(error_message)
-      @output_listeners.each { |listener| listener.error(error_message) }
-      each_line_block.call(
-        type: :abort,
-        message: error_message,
-        time: Time.now
-      )
       super(error_message)
     end
 

--- a/app/shared/models/build.rb
+++ b/app/shared/models/build.rb
@@ -10,7 +10,7 @@ module FastlaneCI
       :pending,
       :missing_fastfile,
       :failure,
-      :ci_problem
+      :ci_problem # TODO: this is actually never used right now
     ]
 
     # A reference to the project this build is associated with

--- a/app/shared/models/build.rb
+++ b/app/shared/models/build.rb
@@ -10,7 +10,7 @@ module FastlaneCI
       :pending,
       :missing_fastfile,
       :failure,
-      :ci_problem # TODO: this is actually never used right now
+      :ci_problem
     ]
 
     # A reference to the project this build is associated with


### PR DESCRIPTION
This will do a few things
- `UI.error` is an error, but not a critical one, it doesn't fail the build
- We let the exceptions bubble up before showing the message and/or failing the build with that particular message
- Show crashes in red also
- Stop using messages to detect a build failure for now, we have exception handling for that to allow catching & re-raising of exceptions

Fixes https://github.com/fastlane/ci/issues/583