### PR TITLE
add callback to extend a class from github_action

### DIFF
--- a/app/services/code_hosting/git_hub_service.rb
+++ b/app/services/code_hosting/git_hub_service.rb
@@ -13,9 +13,10 @@ module FastlaneCI
     include FastlaneCI::GitHubHandler
 
     class << self
-      include FastlaneCI::GitHubHandler
       attr_accessor :status_context_prefix
     end
+
+    GitHubService.status_context_prefix = "fastlane.ci: "
 
     def remote_status_updates_disabled?
       disable_status_update = ENV["FASTLANE_CI_DISABLE_REMOTE_STATUS_UPDATE"]
@@ -26,8 +27,6 @@ module FastlaneCI
 
       return true
     end
-
-    GitHubService.status_context_prefix = "fastlane.ci: "
 
     # The email is actually optional for API access
     # However we ask for the email on login, as we also plan on doing commits for the user

--- a/app/shared/github_handler.rb
+++ b/app/shared/github_handler.rb
@@ -34,6 +34,11 @@ module FastlaneCI
   # TODO: handle if the user doesn't have write permission and they are trying to do some writing
   module GitHubHandler
     include FastlaneCI::Logging
+
+    def self.included(klass)
+      klass.extend(self)
+    end
+
     def github_action(&block)
       retry_count ||= 0
       begin

--- a/spec/shared/github_handler_spec.rb
+++ b/spec/shared/github_handler_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+require "app/shared/github_handler"
+
+describe FastlaneCI::GitHubHandler do
+  class TestClass
+    include FastlaneCI::GitHubHandler
+  end
+
+  it "adds handler methods to on instances of a class" do
+    test_class = TestClass.new
+    expect(test_class).to respond_to(:github_action)
+  end
+
+  it "adds handler methods to as static methods of a class" do
+    expect(TestClass).to respond_to(:github_action)
+  end
+end


### PR DESCRIPTION
in reference to the question here: https://github.com/fastlane/ci/pull/584/files/9efd1ef3ee360f84ea22531b1c3d5deea1b14412#r179347420

this PR will add `github_action` as an instance and class-level method to the class which includes `GithubHandler` mixin