### PR TITLE
Default to empty array in `available_lanes` rather than `nil`.

### DIFF
--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -252,7 +252,7 @@ module FastlaneCI
       locals = {
         project: project,
         title: "Project #{project.project_name}",
-        available_lanes: nil,
+        available_lanes: [],
         fastfile_path: nil
       }
 


### PR DESCRIPTION
The problem was referenced in #605, in comments [[1]](https://github.com/fastlane/ci/issues/605#issuecomment-380424652), and [[2]](https://github.com/fastlane/ci/issues/605#issuecomment-380436556).