### PR TITLE
fix that can't find Fastfile when name of branch contains `/`

### DIFF
--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -107,7 +107,8 @@ module FastlaneCI
     get "#{HOME}/*/lanes" do
       content_type :json
 
-      org, repo_name, branch, = params[:splat].first.split("/")
+      org, repo_name, *branch_parts = params[:splat].first.split("/")
+      branch = branch_parts.join("/")
 
       provider_credential = check_and_get_provider_credential(
         type: FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]


### PR DESCRIPTION
When the name of branch contains `/`, occur RuntimeError because not found FastFile 😂