### PR TITLE
Remove notice that 2FA is needed for the bot account.

### DIFF
--- a/app/features/onboarding/views/forms/_ci_bot_account.erb
+++ b/app/features/onboarding/views/forms/_ci_bot_account.erb
@@ -21,13 +21,6 @@
     <li>
       <a href="https://help.github.com/articles/signing-up-for-a-new-github-account/">
         Create an account</a> for your <code>fastlane.ci</code> bot on GitHub.
-
-      <p>
-        <i>
-          Note: it's important that you do not enable two-factor authentication
-          for your bot account.
-        </i>
-      </p>
     </li>
 
     <li>Enter your bot user account email:</li>


### PR DESCRIPTION
Closes #648 