### PR TITLE
Refactor notice about 2FA and introduce the ability to use PAT instead

### DIFF
--- a/app/features/onboarding/views/forms/_ci_bot_account.erb
+++ b/app/features/onboarding/views/forms/_ci_bot_account.erb
@@ -19,8 +19,10 @@
 
   <ol>
     <li>
-      <a href="https://help.github.com/articles/signing-up-for-a-new-github-account/">
-        Create an account</a> for your <code>fastlane.ci</code> bot on GitHub.
+      <a href="https://help.github.com/articles/signing-up-for-a-new-github-account/" target="_blank">
+        Create an account</a> and a
+      <a href="https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/" target="_blank">
+        Personal Access Token</a> for your <code>fastlane.ci</code> bot on GitHub.
     </li>
 
     <li>Enter your bot user account email:</li>
@@ -37,7 +39,7 @@
       />
     </div>
 
-    <li>Enter your bot user account password:</li>
+    <li>Enter your bot user Personal Access Token:</li>
 
     <div class="mdl-textfield mdl-js-textfield">
       <label for="input"><code>FASTLANE_CI_PASSWORD</code></label>


### PR DESCRIPTION
Fixes #648 and enhances #652. 

@taquitos This is the PR I had in mind originally. I don't think its good to entirely remove the 2FA warning as its an _actual_ limitation at the moment.

Let me know your thoughts.

Thanks! 