### PR TITLE
Improve fastfile finder for local and remote repo

### DIFF
--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -132,14 +132,10 @@ module FastlaneCI
       )
       repo_config = GitHubRepoConfig.from_octokit_repo!(repo: selected_repo)
 
-      fastfile_parser = fastfile_peeker.fastfile_from_github(
-        repo_full_name: repo_config.full_name,
+      fastfile_parser = fastfile_peeker.fastfile(
+        repo_config: repo_config,
         sha_or_branch: branch
       )
-      if fastfile_parser.nil?
-        logger.debug("Checking out repo and searching for fastfile in #{repo_full_name}")
-        fastfile_parser = fastfile_peeker.fastfile_from_repo(repo_config: repo_config, branch: branch)
-      end
 
       fetch_available_lanes(fastfile_parser).to_json
     end

--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -137,6 +137,7 @@ module FastlaneCI
         sha_or_branch: branch
       )
       if fastfile_parser.nil?
+        logger.debug("Checking out repo and searching for fastfile in #{repo_full_name}")
         fastfile_parser = fastfile_peeker.fastfile_from_repo(repo_config: repo_config, branch: branch)
       end
 

--- a/app/shared/fastfile_finder.rb
+++ b/app/shared/fastfile_finder.rb
@@ -30,11 +30,18 @@ module FastlaneCI
       end
 
       # return the Fastfile at path/fastlane/Fastfile if present, otherwise the first one found
-      fastfile_path = fastfiles.find { |current_path| current_path.downcase == "#{path}/fastlane/fastfile" } || fastfiles.first
+      fastfile_path = FastfileFinder.find_prioritary_fastfile_path(paths: fastfiles, path: path)
       if relative_path
         fastfile_path = Pathname.new(fastfile_path).relative_path_from(Pathname.new(path))
       end
       return fastfile_path
+    end
+
+    def self.find_prioritary_fastfile_path(paths:, path: nil)
+      path = path.nil? ? "" : "#{path}/"
+      return paths
+             .select { |current_path| current_path.downcase.end_with?("/fastfile") || current_path.casecmp("fastfile").zero? }
+             .find { |current_path| current_path.downcase == "#{path}fastlane/fastfile" } || paths.first
     end
   end
 end

--- a/app/shared/fastfile_finder.rb
+++ b/app/shared/fastfile_finder.rb
@@ -39,9 +39,9 @@ module FastlaneCI
 
     def self.find_prioritary_fastfile_path(paths:, path: nil)
       path = path.nil? ? "" : "#{path}/"
+      paths = paths.select { |current| current.downcase.end_with?("/fastfile") || current.casecmp("fastfile").zero? }
       return paths
-             .select { |current_path| current_path.downcase.end_with?("/fastfile") || current_path.casecmp("fastfile").zero? }
-             .find { |current_path| current_path.downcase == "#{path}fastlane/fastfile" } || paths.first
+             .find { |current| current.downcase == "#{path}fastlane/fastfile" } || paths.first
     end
   end
 end

--- a/app/shared/fastfile_finder.rb
+++ b/app/shared/fastfile_finder.rb
@@ -14,25 +14,25 @@ module FastlaneCI
 
     # if you're using this with the fastfile parser, you need to use `relative: false`
     def self.search_path(path:, relative_path: false)
-      # First assume the fastlane directory and its file is in the root of the project
-      fastfiles = Dir.glob(File.join(path, "fastlane/Fastfile"), File::FNM_CASEFOLD)
-      # If not, it might be in a subfolder
-      fastfiles = Dir.glob(File.join(path, "**/fastlane/Fastfile"), File::FNM_CASEFOLD) if fastfiles.count == 0
+      # fetch recursively for a Fastfile
+      fastfiles = Dir.glob(File.join(path, "**/Fastfile"), File::FNM_CASEFOLD)
+
+      if fastfiles.count == 0
+        directory_contents = Dir[File.expand_path(path)].join("\n")
+        logger.error("No Fastfile found at #{path}/fastlane/Fastfile, or any descendants")
+        logger.error("Directory contents: #{directory_contents}")
+        return nil
+      end
 
       if fastfiles.count > 1
         logger.error("Ugh, multiple Fastfiles found, we're gonna have to build a selection in the future")
         # for now, just take the first one
       end
 
-      if fastfiles.count == 0
-        directory_contents = Dir[File.expand_path(path)].join("\n")
-        logger.error("No Fastfile found at #{path}/fastlane/Fastfile, or any descendants")
-        logger.error("Directory contents: #{directory_contents}")
-      else
-        fastfile_path = fastfiles.first
-        if relative_path
-          fastfile_path = Pathname.new(fastfile_path).relative_path_from(Pathname.new(path))
-        end
+      # return the Fastfile at path/fastlane/Fastfile if present, otherwise the first one found
+      fastfile_path = fastfiles.find { |current_path| current_path == "#{path}/fastlane/Fastfile" } || fastfiles.first
+      if relative_path
+        fastfile_path = Pathname.new(fastfile_path).relative_path_from(Pathname.new(path))
       end
       return fastfile_path
     end

--- a/app/shared/fastfile_finder.rb
+++ b/app/shared/fastfile_finder.rb
@@ -30,7 +30,7 @@ module FastlaneCI
       end
 
       # return the Fastfile at path/fastlane/Fastfile if present, otherwise the first one found
-      fastfile_path = fastfiles.find { |current_path| current_path == "#{path}/fastlane/Fastfile" } || fastfiles.first
+      fastfile_path = fastfiles.find { |current_path| current_path.downcase == "#{path}/fastlane/fastfile" } || fastfiles.first
       if relative_path
         fastfile_path = Pathname.new(fastfile_path).relative_path_from(Pathname.new(path))
       end

--- a/app/shared/fastfile_peeker.rb
+++ b/app/shared/fastfile_peeker.rb
@@ -95,7 +95,7 @@ module FastlaneCI
                   .select { |resource| resource[:path].end_with?("Fastfile") }
                   .map { |resource| resource[:path] }
 
-      fastfile_path = fastfiles.find { |current_path| current_path == "fastlane/Fastfile" } || fastfiles.first
+      fastfile_path = fastfiles.find { |current_path| current_path.downcase == "fastlane/fastfile" } || fastfiles.first
 
       contents_map = remote_file_contents_map(
         repo_full_name: repo_full_name,

--- a/app/shared/fastfile_peeker.rb
+++ b/app/shared/fastfile_peeker.rb
@@ -64,11 +64,23 @@ module FastlaneCI
       end
     end
 
+    def remote_tree(repo_full_name:, sha_or_branch:)
+      github_action(@client) do
+        begin
+          logger.debug("Checking for fastfile in #{repo_full_name}")
+          result = @client.tree(repo_full_name, sha_or_branch, { recursive: true })
+          return result[:tree] || []
+        rescue Octokit::NotFound
+          return []
+        end
+      end
+    end
+
     def remote_file_contents_map(repo_full_name: nil, sha_or_branch:, path:)
       github_action(@client) do
         begin
           logger.debug("Checking for fastfile in #{repo_full_name}/fastlane/Fastfile")
-          contents_map = @client.contents(repo_full_name, path: "fastlane/Fastfile", ref: sha_or_branch)
+          contents_map = @client.contents(repo_full_name, path: path, ref: sha_or_branch)
           return contents_map
         rescue Octokit::NotFound
           return nil
@@ -77,28 +89,20 @@ module FastlaneCI
     end
 
     def fastfile_from_github(repo_full_name: nil, sha_or_branch:)
-      path = "fastlane/Fastfile"
-      logger.debug("Checking GitHub repo for fastfile in #{repo_full_name}/#{path}")
+      tree = remote_tree(repo_full_name: repo_full_name, sha_or_branch: sha_or_branch)
+
+      fastfiles = tree
+                  .select { |resource| resource[:path].end_with?("Fastfile") }
+                  .map { |resource| resource[:path] }
+
+      fastfile_path = fastfiles.find { |current_path| current_path == "fastlane/Fastfile" } || fastfiles.first
+
       contents_map = remote_file_contents_map(
         repo_full_name: repo_full_name,
         sha_or_branch: sha_or_branch,
-        path: path
+        path: fastfile_path
       )
-      if contents_map.nil?
-        path = "Fastlane/Fastfile"
-        logger.debug("fastfile not at default path, checking for fastfile in #{repo_full_name}/#{path}")
-        contents_map = remote_file_contents_map(
-          repo_full_name: repo_full_name,
-          sha_or_branch: sha_or_branch,
-          path: path
-        )
-      end
-
       contents = fastfile_from_contents_map(contents_map)
-      if contents.nil?
-        logger.debug("Checking out repo and searching for fastfile in #{repo_full_name}")
-        return nil
-      end
 
       return Fastlane::FastfileParser.new(file_content: contents)
     end

--- a/spec/shared/fastfile_peeker_spec.rb
+++ b/spec/shared/fastfile_peeker_spec.rb
@@ -15,7 +15,12 @@ module FastlaneCI
     end
 
     let(:repo_config) do
-      return "repo config"
+      return GitHubRepoConfig.new(id: nil,
+                                  git_url: nil,
+                                  description: nil,
+                                  name: "name",
+                                  full_name: "repo/user",
+                                  hidden: false)
     end
 
     let(:notification_service) do
@@ -35,6 +40,10 @@ module FastlaneCI
       File.join(file_path, "fastfile_peeker", "repo_stub_1")
     end
 
+    let (:repo_1_fastfile_path) do
+      File.join(repo_1_file_path, "fastlane", "Fastfile")
+    end
+
     describe "#fastfile_from_repo" do
       it "returns the Fastfile for a given repo" do
         allow_any_instance_of(FastlaneCI::GitRepo).to receive(:checkout_branch).with({ branch: "master" }).and_return(nil)
@@ -52,6 +61,56 @@ module FastlaneCI
           "android lane1" => { description: [], actions: [], private: false },
           "android lane2" => { description: [], actions: [], private: false } }
         )
+      end
+    end
+
+    describe "#fastfile" do
+      it "search Fastfile on GitHub, if found do not search Fastfile in local" do
+        peeker = FastlaneCI::FastfilePeeker.new(provider_credential: provider_credential, notification_service: notification_service)
+        allow(peeker).to receive(:fastfile_from_github).and_return(Fastlane::FastfileParser.new(path: repo_1_fastfile_path))
+        allow(peeker).to receive(:fastfile_from_repo).and_return(nil)
+
+        peeker.fastfile(repo_config: repo_config, sha_or_branch: "master")
+        expect(peeker).to have_received(:fastfile_from_github)
+        expect(peeker).not_to(have_received(:fastfile_from_repo))
+      end
+
+      it "search Fastfile on GitHub, if not found search Fastfile in local" do
+        peeker = FastlaneCI::FastfilePeeker.new(provider_credential: provider_credential, notification_service: notification_service)
+        allow(peeker).to receive(:fastfile_from_github).and_return(nil)
+        allow(peeker).to receive(:fastfile_from_repo).and_return(nil)
+
+        peeker.fastfile(repo_config: repo_config, sha_or_branch: "master")
+        expect(peeker).to have_received(:fastfile_from_github)
+        expect(peeker).to have_received(:fastfile_from_repo)
+      end
+
+      it "returns Fastlane/Fastfile path, if exists" do
+        fastfile_path = FastfileFinder.find_prioritary_fastfile_path(paths:
+            ["path/Fastlane/Fastfile",
+             "path/Fastlane/TestFastfile",
+             "fastfile",
+             "Fastlane/Fastfile"])
+
+        expect(fastfile_path).to eql("Fastlane/Fastfile")
+      end
+
+      it "returns any Fastfile path if Fastlane/Fastfile does not exist" do
+        fastfile_path = FastfileFinder.find_prioritary_fastfile_path(paths:
+                                                                         ["path/Fastlane/Fastfile",
+                                                                          "path/Fastlane/TestFastfile",
+                                                                          "fastfile"])
+
+        expect(fastfile_path).not_to(be(nil))
+      end
+
+      it "returns nil if there are no Fastfile" do
+        fastfile_path = FastfileFinder.find_prioritary_fastfile_path(paths:
+                                                                         ["path/Fastlane/Fastfiles",
+                                                                          "path/Fastlane/TestFastfile",
+                                                                          "Fastlane/BackupFastlane"])
+
+        expect(fastfile_path).to(be(nil))
       end
     end
   end


### PR DESCRIPTION
Hello, this PR fixes #638.

Two main changes:
* the local search of a Fastlane file is done recursively using `Dir["**/Fastfile"]`. we will return `fastlane/Fastfile` if exists, otherwise the first found.
* the remote search has been done using the `Tree API`, which returns recursively all folder and files (there is probably a limit of nodes that can be returned, but it is not specified in GitHub API, anyway if it fails we will still relying on cloning and searching locally). As above, we will return `fastlane/Fastfile` if exists, otherwise the first found. 

A note: I preferred to use the `Tree API` over requesting for the `root` directory and making requests for each directory because it is far more efficient (i.e. one request vs one request per directory)