### PR TITLE
Disable a bunch of git resets

### DIFF
--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -149,7 +149,6 @@ module FastlaneCI
           use_global_git_mutex: false
         )
       else
-        repo.reset_hard!
         logger.debug("Pulling `master` in checkout_sha")
         repo.pull
       end
@@ -221,14 +220,8 @@ module FastlaneCI
       environment_variables_set << key
     end
 
-    def reset_repo_state
-      # When we're done, clean up by resetting
-      repo.reset_hard!
-    end
-
     def post_run_action
       logger.debug("Finished running #{project.project_name} for #{sha}")
-      reset_repo_state
 
       unset_build_specific_environment_variables
     end

--- a/app/shared/models/git_repo.rb
+++ b/app/shared/models/git_repo.rb
@@ -474,9 +474,8 @@ module FastlaneCI
 
         success = false
         begin
-          git.reset_hard(
-            git.gcommit(sha)
-          )
+          git.gcommit(sha)
+
           success = true
         rescue StandardError => ex
           exception_context = { sha: sha }
@@ -599,10 +598,8 @@ module FastlaneCI
     def switch_to_fork(clone_url:, branch:, sha: nil, local_branch_name:, use_global_git_mutex: false)
       perform_block(use_global_git_mutex: use_global_git_mutex) do
         logger.debug("Switching to branch #{branch} from forked repo: #{clone_url} (pulling into #{local_branch_name})")
-        reset_hard!(use_global_git_mutex: false)
         # TODO: make sure it doesn't exist yet
         git.branch(local_branch_name)
-        reset_hard!(use_global_git_mutex: false)
 
         begin
           git.pull(clone_url, branch)


### PR DESCRIPTION
- Not needed anymore because we're going to do a new checkout for each sha
- build runner doesn't need to reset as a post-run action for ^
- Most actions in git_repo don't even need the reset