### PR TITLE
 Use github's ref they set up for prs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,6 @@ gem "tty-command", ">= 0.7.0", "< 1.0.0"
 # Communication with GitHub
 gem "octokit", ">= 4.8.0", "< 5.0.0"
 
-# Local git checkouts, commits, etc.
-gem "git", ">= 1.3.0", "< 2.0.0"
-
 gem "dotenv", ">= 2.2.1", "< 3.0.0"
 
 # Caching for octokit operations
@@ -44,6 +41,7 @@ gem "bundler", "~> 1.16.0"
 # 	we shipped a new release
 gem "fastfile-parser", git: "https://github.com/fastlane/fastfile-parser", require: false
 gem "fastlane", git: "https://github.com/fastlane/fastlane"
+gem "git", git: "https://github.com/fastlane/ruby-git", require: false
 gem "taskqueue", git: "https://github.com/fastlane/TaskQueue", require: false
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,12 @@ GIT
       xcpretty (>= 0.2.4, < 1.0.0)
       xcpretty-travis-formatter (>= 0.0.3)
 
+GIT
+  remote: https://github.com/fastlane/ruby-git
+  revision: 166273eac44ac787dcdf53226e53d7505e4deea3
+  specs:
+    git (1.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -112,7 +118,6 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     gh_inspector (1.1.3)
-    git (1.3.0)
     google-api-client (0.13.6)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.5)
@@ -309,7 +314,7 @@ DEPENDENCIES
   fastfile-parser!
   fastlane!
   faye-websocket (>= 0.10.7, < 1.0.0)
-  git (>= 1.3.0, < 2.0.0)
+  git!
   google-cloud-storage (~> 1.5.0)
   octokit (>= 4.8.0, < 5.0.0)
   pry

--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -142,10 +142,8 @@ module FastlaneCI
 
       if git_fork_config
         pull_before_checkout_success = repo.switch_to_fork(
-          clone_url: git_fork_config.clone_url,
-          branch: git_fork_config.branch,
-          sha: git_fork_config.current_sha,
-          local_branch_name: "#{git_fork_config.branch}_local_fork",
+          git_fork_config: git_fork_config,
+          local_branch_prefex: git_fork_config.branch.to_s,
           use_global_git_mutex: false
         )
       else

--- a/app/services/code_hosting/git_hub_service.rb
+++ b/app/services/code_hosting/git_hub_service.rb
@@ -82,6 +82,7 @@ module FastlaneCI
             current_sha: pr.head.sha,
             branch: pr.head.ref,
             repo_full_name: pr.head.repo.full_name,
+            number: pr.number,
             clone_url: pr.head.repo.clone_url
           )
         end

--- a/app/services/code_hosting/github_open_pr.rb
+++ b/app/services/code_hosting/github_open_pr.rb
@@ -5,17 +5,23 @@ module FastlaneCI
     attr_reader :clone_url
     attr_reader :branch
     attr_reader :repo_full_name
+    attr_reader :number
     attr_reader :current_sha
 
-    def initialize(current_sha:, branch:, repo_full_name:, clone_url:)
+    def initialize(current_sha:, branch:, repo_full_name:, number:, clone_url:)
       @current_sha = current_sha
       @branch = branch
       @repo_full_name = repo_full_name
+      @number = number
       @clone_url = clone_url
     end
 
     def fork_of_repo?(repo_full_name:)
       return self.repo_full_name != repo_full_name
+    end
+
+    def git_ref
+      return number.nil? ? nil : "pull/#{number}/head"
     end
   end
 end

--- a/app/shared/fastfile_finder.rb
+++ b/app/shared/fastfile_finder.rb
@@ -38,7 +38,7 @@ module FastlaneCI
     end
 
     def self.find_prioritary_fastfile_path(paths:, path: nil)
-      path = path.nil? ? "" : "#{path}/"
+      path = path.nil? ? "" : "#{path}/".downcase
       paths = paths.select { |current| current.downcase.end_with?("/fastfile") || current.casecmp("fastfile").zero? }
       return paths
              .find { |current| current.downcase == "#{path}fastlane/fastfile" } || paths.first

--- a/app/shared/models/git_fork_config.rb
+++ b/app/shared/models/git_fork_config.rb
@@ -3,12 +3,15 @@ module FastlaneCI
   class GitForkConfig
     attr_reader :clone_url
     attr_reader :branch
+    attr_reader :ref # sometimes we have a ref we can use, in that case, we don't need to pull a fork
     attr_reader :current_sha
 
-    def initialize(current_sha: nil, branch:, clone_url:)
+    # If you have a ref you can pass, e.g.: `pull/661/head`, that's preferred
+    def initialize(current_sha: nil, branch:, clone_url:, ref: nil)
       @current_sha = current_sha
       @branch = branch
       @clone_url = clone_url
+      @ref = ref
     end
   end
 end

--- a/app/shared/models/git_repo.rb
+++ b/app/shared/models/git_repo.rb
@@ -46,6 +46,8 @@ module FastlaneCI
     # rubocop:enable Metrics/ClassLength
     include FastlaneCI::Logging
 
+    DEFAULT_REMOTE = "origin"
+
     # @return [RepoConfig]
     attr_accessor :git_config
     # @return [GitRepoAuth]
@@ -247,7 +249,7 @@ module FastlaneCI
           # Things are looking legit so far
           # Now we have to check if the repo is actually from the
           # same repo URL
-          if repo.remote("origin").url.casecmp(git_config.git_url.downcase).zero?
+          if repo.remote(GitRepo::DEFAULT_REMOTE).url.casecmp(git_config.git_url.downcase).zero?
             # If our courrent repo is the ci-config repo and has changes on it, we should commit them before
             # other actions, to prevent local changes to be lost.
             # This is a common issue, ci_config repo gets recreated several times trough the
@@ -265,7 +267,7 @@ module FastlaneCI
                 begin
                   repo.add(all: true)
                   repo.commit("Sync changes")
-                  git.push("origin", branch: "master", force: true) unless GitRepo.pushes_disabled?
+                  git.push(GitRepo::DEFAULT_REMOTE, branch: "master", force: true) unless GitRepo.pushes_disabled?
                 rescue StandardError => ex
                   handle_exception(ex, console_message: "Error commiting changes to ci-config repo")
                 end
@@ -604,19 +606,21 @@ module FastlaneCI
       end
     end
 
-    def switch_to_fork(clone_url:, branch:, sha: nil, local_branch_name:, use_global_git_mutex: false)
+    # If we onlt have a git repo, and it isn't specifically from GitHub, we need to use this to switch to a fork
+    # May cause merge conflicts, so don't use it unless we must.
+    def switch_to_git_fork(clone_url:, branch:, sha: nil, local_branch_name:, use_global_git_mutex: false)
       perform_block(use_global_git_mutex: use_global_git_mutex) do
         logger.debug("Switching to branch #{branch} from forked repo: #{clone_url} (pulling into #{local_branch_name})")
 
         begin
           git.branch(local_branch_name)
-          git.pull(clone_url, branch)
+          git.pull(git_fork_config.clone_url, git_fork_config.branch)
           return true
         rescue StandardError => ex
           exception_context = {
             clone_url: clone_url,
             branch: branch,
-            sha: sha,
+            sha: current_sha,
             local_branch_name: local_branch_name
           }
           handle_exception(
@@ -626,6 +630,53 @@ module FastlaneCI
           )
           return false
         end
+      end
+    end
+
+    def switch_to_ref(git_fork_config:, local_branch_name:, use_global_git_mutex: false)
+      perform_block(use_global_git_mutex: use_global_git_mutex) do
+        begin
+          ref = "#{git_fork_config.ref}:#{local_branch_name}"
+          logger.debug("Switching to new branch from ref #{ref} (pulling into #{local_branch_name})")
+          git.fetch(GitRepo::DEFAULT_REMOTE, ref, {})
+          git.branch(local_branch_name)
+          return true
+        rescue StandardError => ex
+          exception_context = {
+            clone_url: git_fork_config.clone_url,
+            branch: git_fork_config.branch,
+            sha: git_fork_config.current_sha,
+            local_branch_name: local_branch_name
+          }
+          handle_exception(
+            ex,
+            console_message: "Error switching to ref: #{ref}",
+            exception_context: exception_context
+          )
+          return false
+        end
+      end
+    end
+
+    # Useful when you don't have a PR, if you have access to a PR, use :switch_to_github_pr
+    def switch_to_fork(git_fork_config:, local_branch_prefex:, use_global_git_mutex: false)
+      local_branch_name = local_branch_prefex + git_fork_config.current_sha[0..7]
+
+      # if we have a git ref to work with, use that instead of the fork
+      if git_fork_config.ref
+        switch_to_ref(
+          git_fork_config: git_fork_config,
+          local_branch_name: local_branch_name,
+          use_global_git_mutex: use_global_git_mutex
+        )
+      else
+        switch_to_git_fork(
+          clone_url: git_fork_config.clone_url,
+          branch: git_fork_config.branch,
+          sha: git_fork_config.current_sha,
+          local_branch_name: local_branch_name,
+          use_global_git_mutex: use_global_git_mutex
+        )
       end
     end
 

--- a/app/workers/check_for_new_commits_on_github_worker.rb
+++ b/app/workers/check_for_new_commits_on_github_worker.rb
@@ -61,7 +61,8 @@ module FastlaneCI
         git_fork_config = GitForkConfig.new(
           current_sha: pr.current_sha,
           branch: pr.branch,
-          clone_url: pr.clone_url
+          clone_url: pr.clone_url,
+          ref: pr.git_ref
         )
         create_and_queue_build_task(
           sha: pr.current_sha,

--- a/launch.rb
+++ b/launch.rb
@@ -238,7 +238,8 @@ module FastlaneCI
             git_fork_config = GitForkConfig.new(
               current_sha: sha,
               branch: matching_open_pr.branch,
-              clone_url: matching_open_pr.clone_url
+              clone_url: matching_open_pr.clone_url,
+              ref: matching_open_pr.git_ref
             )
           end
 
@@ -297,7 +298,8 @@ module FastlaneCI
             git_fork_config = GitForkConfig.new(
               current_sha: open_pr.current_sha,
               branch: open_pr.branch,
-              clone_url: open_pr.clone_url
+              clone_url: open_pr.clone_url,
+              ref: open_pr.git_ref
             )
           end
 


### PR DESCRIPTION
Fix for https://github.com/fastlane/ci/issues/646
Instead of checking out master and pulling a fork on top of it, we can use the github feature where they setup a new ref for your PR. Then you can just fetch that into a branch.
No more tears for merge conflicts

Also forked the `ruby-git` temporarily while we wait and see if we can get some movement on https://github.com/ruby-git/ruby-git/pull/362
