### PR TITLE
Rename environment_variable_service to dot_keys_variable_service

### DIFF
--- a/app/features/configuration/configuration_controller.rb
+++ b/app/features/configuration/configuration_controller.rb
@@ -29,10 +29,10 @@ module FastlaneCI
     # 3) If the data is not valid, display an error message
     post "#{HOME}/keys" do
       if valid_params?(params, post_parameter_list_for_validation)
-        Services.environment_variable_service.write_keys_file!(locals: params)
-        flash[:success] = "#{Services.environment_variable_service.keys_file_path_relative_to_home} file written."
+        Services.dot_keys_variable_service.write_keys_file!(locals: params)
+        flash[:success] = "#{Services.dot_keys_variable_service.keys_file_path_relative_to_home} file written."
       else
-        flash[:error] = "#{Services.environment_variable_service.keys_file_path_relative_to_home} file NOT written."
+        flash[:error] = "#{Services.dot_keys_variable_service.keys_file_path_relative_to_home} file NOT written."
       end
 
       locals = { title: "Configuration" }
@@ -47,7 +47,7 @@ module FastlaneCI
 
     # @return [Hash]
     def keys
-      return FastlaneCI.env.all
+      return FastlaneCI.dot_keys.all
     end
 
     #####################################################

--- a/app/features/login/login_controller.rb
+++ b/app/features/login/login_controller.rb
@@ -1,7 +1,7 @@
 # Internal
 require_relative "../../shared/controller_base"
 require_relative "../../services/user_service"
-require_relative "../../services/environment_variable_service"
+require_relative "../../services/dot_keys_variable_service"
 require_relative "../../shared/models/github_provider_credential"
 
 require "octokit"
@@ -36,7 +36,7 @@ module FastlaneCI
 
     # Login with fastlane.ci credentials
     get "#{HOME}/ci_login" do
-      client = Octokit::Client.new(access_token: FastlaneCI.env.ci_user_api_token)
+      client = Octokit::Client.new(access_token: FastlaneCI.dot_keys.ci_user_api_token)
 
       unless client.nil?
         email = client.emails.find(&:primary).email

--- a/app/features/onboarding/onboarding_controller.rb
+++ b/app/features/onboarding/onboarding_controller.rb
@@ -49,25 +49,25 @@ module FastlaneCI
     #
     # 2) If the encryption key is not `nil`:
     #
-    #    i.  write the encryption key to the CI keys file (FastlaneCI::EnvironmentVariableService#keys_file_path)
+    #    i.  write the encryption key to the CI keys file (FastlaneCI::DotKeysVariableService#keys_file_path)
     #    ii. load the new environment variables (implicitly)
     #
     # 3) If the encryption key is `nil`, display an error message
     post "#{HOME}/encryption_key" do
       if valid_params?(params, post_parameter_list_for_encryption_key_validation)
-        Services.environment_variable_service.write_keys_file!(
+        Services.dot_keys_variable_service.write_keys_file!(
           locals: format_params(
             params, post_parameter_list_for_encryption_key_validation
           )
         )
 
         flash[:success] = <<~HTML
-          <code>#{Services.environment_variable_service.keys_file_path_relative_to_home}</code> file written with the
+          <code>#{Services.dot_keys_variable_service.keys_file_path_relative_to_home}</code> file written with the
           configuration value <code>FASTLANE_CI_ENCRYPTION_KEY=#{params[:encryption_key]}</code>
         HTML
       else
         flash[:error] = <<~HTML
-          #{Services.environment_variable_service.keys_file_path_relative_to_home} file not written.
+          #{Services.dot_keys_variable_service.keys_file_path_relative_to_home} file not written.
         HTML
       end
 
@@ -88,19 +88,19 @@ module FastlaneCI
       if valid_params?(params, post_parameter_list_for_ci_bot_user_validation)
         validate_api_token_correct(params[:ci_user_api_token].strip, "ci_bot_account")
 
-        Services.environment_variable_service.write_keys_file!(
+        Services.dot_keys_variable_service.write_keys_file!(
           locals: format_params(
             params, post_parameter_list_for_ci_bot_user_validation
           )
         )
 
         flash[:success] = <<~HTML
-          <code>#{Services.environment_variable_service.keys_file_path_relative_to_home}</code> file written with the
+          <code>#{Services.dot_keys_variable_service.keys_file_path_relative_to_home}</code> file written with the
           configuration values <code>FASTLANE_CI_BOT_API_TOKEN</code> and <code>FASTLANE_CI_PASSWORD</code>
         HTML
       else
         flash[:error] = <<~HTML
-          <code>#{Services.environment_variable_service.keys_file_path_relative_to_home}</code> file not written.
+          <code>#{Services.dot_keys_variable_service.keys_file_path_relative_to_home}</code> file not written.
         HTML
       end
 
@@ -136,14 +136,14 @@ module FastlaneCI
         if scope_validation_error.nil?
           validate_api_token_correct(params[:initial_onboarding_user_api_token].strip, "initial_onboarding_user")
 
-          Services.environment_variable_service.write_keys_file!(
+          Services.dot_keys_variable_service.write_keys_file!(
             locals: format_params(
               params, post_parameter_list_for_onboarding_user_validation
             )
           )
 
           flash[:success] = <<~HTML
-            <code>#{Services.environment_variable_service.keys_file_path_relative_to_home}</code> file written with the
+            <code>#{Services.dot_keys_variable_service.keys_file_path_relative_to_home}</code> file written with the
             configuration value <code>FASTLANE_CI_INITIAL_ONBOARDING_USER_API_TOKEN</code>
           HTML
         else
@@ -157,7 +157,7 @@ module FastlaneCI
           logger.error(error_message)
         end
       else
-        path = Services.environment_variable_service.keys_file_path_relative_to_home
+        path = Services.dot_keys_variable_service.keys_file_path_relative_to_home
         flash[:error] = "#{path} file not written."
       end
 
@@ -176,7 +176,7 @@ module FastlaneCI
     # 2) Redirect back to `/configuration`
     post "#{HOME}/git_repo" do
       if valid_params?(params, post_parameter_list_for_git_repo_validation)
-        Services.environment_variable_service.write_keys_file!(
+        Services.dot_keys_variable_service.write_keys_file!(
           locals: format_params(
             params, post_parameter_list_for_git_repo_validation
           )
@@ -220,7 +220,7 @@ module FastlaneCI
 
     # @return [Hash]
     def keys
-      return FastlaneCI.env.all
+      return FastlaneCI.dot_keys.all
     end
 
     #####################################################
@@ -229,28 +229,28 @@ module FastlaneCI
 
     # @return [Boolean]
     def has_encryption_key?
-      return not_nil_and_not_empty?(FastlaneCI.env.encryption_key)
+      return not_nil_and_not_empty?(FastlaneCI.dot_keys.encryption_key)
     end
 
     # @return [Boolean]
     def has_ci_user_password?
-      return not_nil_and_not_empty?(FastlaneCI.env.ci_user_password)
+      return not_nil_and_not_empty?(FastlaneCI.dot_keys.ci_user_password)
     end
 
     # @return [Boolean]
     def has_ci_user_api_token?
-      return not_nil_and_not_empty?(FastlaneCI.env.ci_user_api_token)
+      return not_nil_and_not_empty?(FastlaneCI.dot_keys.ci_user_api_token)
     end
 
     # @return [Boolean]
     def has_initial_onboarding_user_api_token?
-      return not_nil_and_not_empty?(FastlaneCI.env.initial_onboarding_user_api_token)
+      return not_nil_and_not_empty?(FastlaneCI.dot_keys.initial_onboarding_user_api_token)
     end
 
     # @return [Boolean]
     def has_remote_github_repo?
-      if not_nil_and_not_empty?(FastlaneCI.env.encryption_key)
-        return not_nil_and_not_empty?(FastlaneCI.env.repo_url) &&
+      if not_nil_and_not_empty?(FastlaneCI.dot_keys.encryption_key)
+        return not_nil_and_not_empty?(FastlaneCI.dot_keys.repo_url) &&
                Services.onboarding_service.correct_setup?
       else
         # Need the encryption key for the configuration_repository_service

--- a/app/services/configuration_repository_service.rb
+++ b/app/services/configuration_repository_service.rb
@@ -24,7 +24,7 @@ module FastlaneCI
     # @param  [ProviderCredential] provider_credential
     def initialize(provider_credential:)
       @onboarding_user_client = Octokit::Client.new(access_token: provider_credential.api_token)
-      @bot_user_client = Octokit::Client.new(access_token: FastlaneCI.env.ci_user_api_token)
+      @bot_user_client = Octokit::Client.new(access_token: FastlaneCI.dot_keys.ci_user_api_token)
     end
 
     # Sets up the `fastlane.ci` configuration repository, with the necessary
@@ -180,11 +180,11 @@ module FastlaneCI
       users = [
         User.new(
           email: bot_user_email,
-          password_hash: BCrypt::Password.create(FastlaneCI.env.ci_user_password),
+          password_hash: BCrypt::Password.create(FastlaneCI.dot_keys.ci_user_password),
           provider_credentials: [
             FastlaneCI::GitHubProviderCredential.new(
               email: initial_onboarding_user_email,
-              api_token: FastlaneCI.env.initial_onboarding_user_api_token,
+              api_token: FastlaneCI.dot_keys.initial_onboarding_user_api_token,
               full_name: "Initial Onboarding User credentials"
             )
           ]
@@ -294,16 +294,16 @@ module FastlaneCI
     #
     # @return [String]
     def repo_name
-      return "" unless FastlaneCI.env.repo_url
-      return FastlaneCI.env.repo_url.split("/").last
+      return "" unless FastlaneCI.dot_keys.repo_url
+      return FastlaneCI.dot_keys.repo_url.split("/").last
     end
 
     # The short-form of the configuration repository URL `user/repo`
     #
     # @return [String]
     def repo_shortform
-      return "" unless FastlaneCI.env.repo_url
-      return FastlaneCI.env.repo_url.split("/").last(2).join("/")
+      return "" unless FastlaneCI.dot_keys.repo_url
+      return FastlaneCI.dot_keys.repo_url.split("/").last(2).join("/")
     end
   end
 end

--- a/app/services/dot_keys_variable_service.rb
+++ b/app/services/dot_keys_variable_service.rb
@@ -3,7 +3,7 @@ require_relative "./services"
 
 module FastlaneCI
   # Logic pertaining to environment variable configuration
-  class EnvironmentVariableService
+  class DotKeysVariableService
     # Write .keys configuration file with proper environment variables. Don't
     # override old environment variables with `nil` values
     #
@@ -19,12 +19,12 @@ module FastlaneCI
     )
       non_nil_new_env_variables = locals.reject { |_k, v| v.nil? }
                                         .each_with_object({}) { |(k, v), hash| hash[k.to_sym] = v }
-      new_environment_variables = FastlaneCI.env.all.merge(non_nil_new_env_variables)
-      KeysWriter.new(path: keys_file_path, locals: new_environment_variables).write!
+      new_dot_key_variables = FastlaneCI.dot_keys.all.merge(non_nil_new_env_variables)
+      KeysWriter.new(path: keys_file_path, locals: new_dot_key_variables).write!
       reload_dot_env!
     end
 
-    # Reloads the environment variables and resets the memoized services that
+    # Reloads the dot key variables and resets the memoized services that
     # depend on their values
     def reload_dot_env!
       return unless File.exist?(keys_file_path)
@@ -39,8 +39,8 @@ module FastlaneCI
     # present
     #
     # @return [Boolean]
-    def all_env_variables_non_nil?
-      return FastlaneCI.env.all.none? { |_k, v| v.nil? || v.empty? }
+    def all_dot_variables_non_nil?
+      return FastlaneCI.dot_keys.all.none? { |_k, v| v.nil? || v.empty? }
     end
 
     # The path to the environment variables file

--- a/app/services/onboarding_service.rb
+++ b/app/services/onboarding_service.rb
@@ -21,7 +21,7 @@ module FastlaneCI
     rescue StandardError => ex
       logger.error("Something went wrong on the initial clone")
 
-      if FastlaneCI.env.initial_onboarding_user_api_token.to_s.empty?
+      if FastlaneCI.dot_keys.initial_onboarding_user_api_token.to_s.empty?
         logger.error("Make sure to provide your `FASTLANE_CI_INITIAL_ONBOARDING_USER_API_TOKEN` ENV variable")
       end
 
@@ -83,7 +83,7 @@ module FastlaneCI
 
     # @return [Boolean]
     def no_missing_keys?
-      return Services.environment_variable_service.all_env_variables_non_nil?
+      return Services.dot_keys_variable_service.all_dot_variables_non_nil?
     end
   end
 end

--- a/app/services/services.rb
+++ b/app/services/services.rb
@@ -191,7 +191,9 @@ module FastlaneCI
     end
 
     def self.onboarding_user_client
-      @_onboarding_user_client ||= Octokit::Client.new(access_token: FastlaneCI.dot_keys.initial_onboarding_user_api_token)
+      @_onboarding_user_client ||= Octokit::Client.new(
+        access_token: FastlaneCI.dot_keys.initial_onboarding_user_api_token
+      )
     end
   end
 end

--- a/app/services/services.rb
+++ b/app/services/services.rb
@@ -4,7 +4,7 @@ require_relative "./config_service"
 require_relative "./configuration_repository_service"
 require_relative "./data_sources/json_build_data_source"
 require_relative "./data_sources/json_user_data_source"
-require_relative "./environment_variable_service"
+require_relative "./dot_keys_variable_service"
 require_relative "./onboarding_service"
 require_relative "./project_service"
 require_relative "./notification_service"
@@ -60,7 +60,7 @@ module FastlaneCI
     def self.ci_config_repo
       @_ci_config_repo ||= GitHubRepoConfig.new(
         id: "fastlane-ci-config",
-        git_url: FastlaneCI.env.repo_url,
+        git_url: FastlaneCI.dot_keys.repo_url,
         description: "Contains the fastlane.ci configuration",
         name: "fastlane ci",
         hidden: true
@@ -83,7 +83,7 @@ module FastlaneCI
       # Find our fastlane.ci system user
       @_ci_user ||= Services.user_service.login(
         email: bot_user_client.emails.find(&:primary).email,
-        password: FastlaneCI.env.ci_user_password
+        password: FastlaneCI.dot_keys.ci_user_password
       )
       if @_ci_user.nil?
         raise "Could not find ci_user for current setup, or the provided ci_user_password is incorrect."
@@ -104,7 +104,7 @@ module FastlaneCI
     def self.provider_credential
       @_provider_credential ||= GitHubProviderCredential.new(
         email: onboarding_user_client.emails.find(&:primary).email,
-        api_token: FastlaneCI.env.initial_onboarding_user_api_token
+        api_token: FastlaneCI.dot_keys.initial_onboarding_user_api_token
       )
     end
 
@@ -174,8 +174,8 @@ module FastlaneCI
       )
     end
 
-    def self.environment_variable_service
-      @_environment_variable_service ||= FastlaneCI::EnvironmentVariableService.new
+    def self.dot_keys_variable_service
+      @_dot_keys_variable_service ||= FastlaneCI::DotKeysVariableService.new
     end
 
     def self.provider_credential_service
@@ -187,11 +187,11 @@ module FastlaneCI
     end
 
     def self.bot_user_client
-      @_bot_user_client ||= Octokit::Client.new(access_token: FastlaneCI.env.ci_user_api_token)
+      @_bot_user_client ||= Octokit::Client.new(access_token: FastlaneCI.dot_keys.ci_user_api_token)
     end
 
     def self.onboarding_user_client
-      @_onboarding_user_client ||= Octokit::Client.new(access_token: FastlaneCI.env.initial_onboarding_user_api_token)
+      @_onboarding_user_client ||= Octokit::Client.new(access_token: FastlaneCI.dot_keys.initial_onboarding_user_api_token)
     end
   end
 end

--- a/app/shared/dot_keys_variables.rb
+++ b/app/shared/dot_keys_variables.rb
@@ -4,7 +4,7 @@ module FastlaneCI
   # Class wrapping fastlane CI environment variables that people using fastlane.ci should care about
   # NOTE: This doesn't include the fastlane.ci-developer-sepcific environment variables primarily used
   # during development of fastlane.ci by the fastlane
-  class EnvironmentVariables
+  class DotKeysVariables
     # @return [Hash]
     def all
       {

--- a/app/shared/string_encrypter.rb
+++ b/app/shared/string_encrypter.rb
@@ -9,7 +9,7 @@ module FastlaneCI
     end
 
     def self.default_key
-      @_key ||= Digest::SHA256.digest(FastlaneCI.env.encryption_key)
+      @_key ||= Digest::SHA256.digest(FastlaneCI.dot_keys.encryption_key)
     end
 
     def self.encode(string, key: StringEncrypter.default_key)

--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -7,7 +7,7 @@ require "git"
 require_relative "app/services/services"
 require_relative "app/workers/refresh_config_data_sources_worker"
 require_relative "app/shared/logging_module"
-require_relative "app/shared/environment_variables"
+require_relative "app/shared/dot_keys_variables"
 require_relative "app/shared/fastlane_ci_error" # TODO: move somewhere else
 require_relative "app/features/build_runner/build_runner"
 
@@ -19,9 +19,11 @@ module FastlaneCI
     return "../../../features/global/layout".to_sym
   end
 
-  def self.env
-    @env ||= FastlaneCI::EnvironmentVariables.new
-    return @env
+  # Reference to the `DotKeysVariables` object that holds all the values from the
+  # .keys file. This does not include the global or project specific environment variables
+  def self.dot_keys
+    @_dot_keys ||= FastlaneCI::DotKeysVariables.new
+    return @_dot_keys
   end
 
   def self.server_version

--- a/launch.rb
+++ b/launch.rb
@@ -22,7 +22,7 @@ module FastlaneCI
       verify_app_built
       verify_dependencies
       verify_system_requirements
-      Services.environment_variable_service.reload_dot_env!
+      Services.dot_keys_variable_service.reload_dot_env!
       clone_repo_if_no_local_repo_and_remote_repo_exists
 
       # done making sure our env is sane, let's move on to the next step
@@ -98,7 +98,7 @@ module FastlaneCI
     end
 
     # Will clone the remote configuration repository if the local repository is
-    # not found, but the user has a `FastlaneCI.env.repo_url` which corresponds
+    # not found, but the user has a `FastlaneCI.dot_keys.repo_url` which corresponds
     # to a valid remote configuration repository
     def self.clone_repo_if_no_local_repo_and_remote_repo_exists
       if !Services.onboarding_service.local_configuration_repo_exists? &&

--- a/spec/services/dot_keys_variable_service_spec.rb
+++ b/spec/services/dot_keys_variable_service_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
-require "app/services/environment_variable_service"
+require "app/services/dot_keys_variable_service"
 
-describe FastlaneCI::EnvironmentVariableService do
+describe FastlaneCI::DotKeysVariableService do
   let(:fake_home_path) do
     File.join(FastlaneCI::FastlaneApp.settings.root, "spec/fixtures/files/")
   end
@@ -16,7 +16,7 @@ describe FastlaneCI::EnvironmentVariableService do
   end
 
   subject do
-    FastlaneCI::EnvironmentVariableService.new
+    FastlaneCI::DotKeysVariableService.new
   end
 
   describe "#write_keys_file!" do
@@ -40,26 +40,26 @@ describe FastlaneCI::EnvironmentVariableService do
     end
   end
 
-  describe "#all_env_variables_non_nil?" do
+  describe "#all_dot_variables_non_nil?" do
     it "returns `true` if all environment variables are non-`nil`, and non-'empty'" do
       # Environment variables are set in the `stub_environment_variables` method
-      expect(subject.all_env_variables_non_nil?).to be(true)
+      expect(subject.all_dot_variables_non_nil?).to be(true)
     end
 
     it "returns `false` if an environment variable is `nil`" do
       allow_any_instance_of(
-        FastlaneCI::EnvironmentVariables
+        FastlaneCI::DotKeysVariables
       ).to receive(:all).and_return(environment_variables.merge(encryption_key: nil))
 
-      expect(subject.all_env_variables_non_nil?).to be(false)
+      expect(subject.all_dot_variables_non_nil?).to be(false)
     end
 
     it "returns `false` if an environment variable is 'empty'" do
       allow_any_instance_of(
-        FastlaneCI::EnvironmentVariables
+        FastlaneCI::DotKeysVariables
       ).to receive(:all).and_return(environment_variables.merge(encryption_key: ""))
 
-      expect(subject.all_env_variables_non_nil?).to be(false)
+      expect(subject.all_dot_variables_non_nil?).to be(false)
     end
   end
 

--- a/spec/stub_helpers.rb
+++ b/spec/stub_helpers.rb
@@ -8,12 +8,12 @@ module StubHelpers
   end
 
   def stub_environment_variables
-    allow_any_instance_of(FastlaneCI::EnvironmentVariables).to receive(:all).and_return(environment_variables)
-    allow_any_instance_of(FastlaneCI::EnvironmentVariables).to receive(:encryption_key).and_return("encryption_key")
-    allow_any_instance_of(FastlaneCI::EnvironmentVariables).to receive(:ci_user_password).and_return("ci_user_password")
-    allow_any_instance_of(FastlaneCI::EnvironmentVariables).to receive(:ci_user_api_token).and_return("bot_user_api_token")
-    allow_any_instance_of(FastlaneCI::EnvironmentVariables).to receive(:repo_url).and_return("https://github.com/user_name/repo_name")
-    allow_any_instance_of(FastlaneCI::EnvironmentVariables).to receive(:initial_onboarding_user_api_token).and_return("initial_onboarding_user_api_token")
+    allow_any_instance_of(FastlaneCI::DotKeysVariables).to receive(:all).and_return(environment_variables)
+    allow_any_instance_of(FastlaneCI::DotKeysVariables).to receive(:encryption_key).and_return("encryption_key")
+    allow_any_instance_of(FastlaneCI::DotKeysVariables).to receive(:ci_user_password).and_return("ci_user_password")
+    allow_any_instance_of(FastlaneCI::DotKeysVariables).to receive(:ci_user_api_token).and_return("bot_user_api_token")
+    allow_any_instance_of(FastlaneCI::DotKeysVariables).to receive(:repo_url).and_return("https://github.com/user_name/repo_name")
+    allow_any_instance_of(FastlaneCI::DotKeysVariables).to receive(:initial_onboarding_user_api_token).and_return("initial_onboarding_user_api_token")
   end
 
   def stub_git_repos


### PR DESCRIPTION
Same change as #696

---

.keys manager is limited and only focuses on the non-user specific ENV variables. For all user managed ones, we're gonna use a new data source + service

More information: #643
We're gonna use the names `EnvironmentVariable` and `EnvironmentVariableService` for ENV variables that are provided by the user