### PR TITLE
Update dot_keys file to work with new dotenv

### DIFF
--- a/app/services/dot_keys_variable_service.rb
+++ b/app/services/dot_keys_variable_service.rb
@@ -30,7 +30,7 @@ module FastlaneCI
       return unless File.exist?(keys_file_path)
 
       require "dotenv"
-      ENV.update(Dotenv::Environment.new(keys_file_path))
+      ENV.update(Dotenv::Environment.new(keys_file_path, false))
 
       Services.reset_services!
     end


### PR DESCRIPTION
This breaking change was introduced with a minor version release with https://github.com/bkeepers/dotenv/commit/7f82f73420bb46a06bb3a3e2052c3b3a1f34a0f5

It seems to only be related to `VARIABLE={NAME}` variables and about if they should be expanded. Since we use this just for `~/.fastlane/ci/.keys` we don't really care about this option