### PR TITLE
[Proposal] Remove unused `commit_repo_changes` method in `UserService`

### DIFF
--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -121,12 +121,5 @@ module FastlaneCI
         update_user!(user: new_user)
       end
     end
-
-    protected
-
-    # Not sure if this must be here or not, but we can open a discussion on this.
-    def commit_repo_changes!(message: nil, file_to_commit: nil)
-      Services.configuration_git_repo.commit_changes!(commit_message: message, file_to_commit: file_to_commit)
-    end
   end
 end


### PR DESCRIPTION
It seems like we don't use this anywhere? We do use it for `ProjectService` though, so this seems a little weird. Creating this PR to start the discussion - I didn't look into why we have this here yet, and why we don't call it