### PR TITLE
Add support for project specific settings

### DIFF
--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -217,6 +217,14 @@ module FastlaneCI
         env_mapping[environment_variable.key.to_sym] = environment_variable.value
       end
 
+      # Now set the project specific environment variables
+      project.environment_variables.each do |environment_variable|
+        env_mapping[environment_variable.key.to_sym] = environment_variable.value
+      end
+
+      # Here we'll set the branch specific environment variables once this is implemented
+      # This might not be top priority for a v1
+
       # Finally, set all the ENV variables for the given build
       env_mapping.each do |key, value|
         set_build_specific_env_variable(key: key, value: value)

--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -219,6 +219,11 @@ module FastlaneCI
 
       # Now set the project specific environment variables
       project.environment_variables.each do |environment_variable|
+        if env_mapping.key?(environment_variable.key.to_sym)
+          # TODO: similar to above: better error handling, depending on what variable gets overwritten
+          #       this might be a big deal
+          logger.error("Overwriting CI specific environment variable of key #{environment_variable.key}")
+        end
         env_mapping[environment_variable.key.to_sym] = environment_variable.value
       end
 

--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -279,6 +279,12 @@ module FastlaneCI
         locals[:available_lanes] = available_lanes
       end
 
+      # TODO: We should think carefully about exposing the value of an existing ENV variable
+      #       as this could potentially introduce a security risk. During development
+      #       the code below will make debugging easier
+      locals[:global_env_variables] = Services.environment_variable_service.environment_variables
+      locals[:project_env_variables] = project.environment_variables
+
       erb(:project, locals: locals, layout: FastlaneCI.default_layout)
     end
 

--- a/app/features/project/views/project.erb
+++ b/app/features/project/views/project.erb
@@ -22,7 +22,7 @@
       <%= erb(:project_info, locals: { project: project }) %>
     </section>
     <section class="mdl-layout__tab-panel" id="scroll-tab-settings">
-      <%= erb(:project_settings, locals: { project: project , available_lanes: available_lanes, fastfile_path: fastfile_path }) %>
+      <%= erb(:project_settings, locals: { project: project , available_lanes: available_lanes, fastfile_path: fastfile_path, global_env_variables: global_env_variables, project_env_variables: project_env_variables }) %>
     </section>
   </main>
 </div>

--- a/app/features/project/views/project_settings.erb
+++ b/app/features/project/views/project_settings.erb
@@ -15,6 +15,19 @@
     <% end %>
   </select>
   <br />
+  <h5>Environment Variables</h5>
+  <h6>Global</h6>
+  <ul>
+    <% global_env_variables.each do |environment_variable| %>
+      <li><%= environment_variable.key %> => <%= environment_variable.value %></li>
+    <% end %>
+  </ul>
+  <h6>Project specific</h6>
+  <ul>
+    <% project_env_variables.each do |environment_variable| %>
+      <li><%= environment_variable.key %> => <%= environment_variable.value %></li>
+    <% end %>
+  </ul>
   <br />
   <input class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" type="submit" title="Save">
 </form>

--- a/app/services/config_data_sources/json_project_data_source.rb
+++ b/app/services/config_data_sources/json_project_data_source.rb
@@ -120,14 +120,7 @@ module FastlaneCI
         saved_projects = JSON.parse(File.read(path)).map do |project_json|
           project = Project.from_json!(project_json)
 
-          # Now load the project specific files here
-          # that are in
-          #
-          #   `projects/[project_id]/[file].json
-          #
-          # more information on https://github.com/fastlane/ci/issues/643
-          project_specific_path = File.join(git_repo.file_path("projects"), project.id)
-          environment_variable_data_source = JSONEnvironmentDataSource.create(project_specific_path)
+          environment_variable_data_source = project_specific_environment_variables_data_source(project: project)
           project.environment_variables = environment_variable_data_source.environment_variables
 
           project
@@ -158,7 +151,15 @@ module FastlaneCI
 
     def projects=(projects)
       JSONProjectDataSource.projects_file_semaphore.synchronize do
-        File.write(git_repo.file_path("projects.json"), JSON.pretty_generate(projects.map(&:to_object_dictionary)))
+        # We have to ignore the `environment_variables` instance variable, as it's stored in a separate file
+        json_data = JSON.pretty_generate(projects.map do |project|
+          # While we iterate, also store the project specific configuration files
+          environment_variable_data_source = project_specific_environment_variables_data_source(project: project)
+          environment_variable_data_source.environment_variables = project.environment_variables
+
+          project.to_object_dictionary(ignore_instance_variables: [:@environment_variables])
+        end)
+        File.write(git_repo.file_path("projects.json"), json_data)
       end
     end
 
@@ -218,6 +219,7 @@ module FastlaneCI
       unless project.nil?
         raise "project must be configured with an instance of #{Project.name}" unless project.class <= Project
       end
+
       project_index = nil
       existing_project = nil
       projects.each.with_index do |old_project, index|
@@ -266,6 +268,19 @@ module FastlaneCI
         projects.delete_at(project_index)
         self.projects = projects
       end
+    end
+
+    private
+
+    def project_specific_environment_variables_data_source(project: nil)
+      # Now access the project specific files here
+      # that are in
+      #
+      #   `projects/[project_id]/[file].json
+      #
+      # more information on https://github.com/fastlane/ci/issues/643
+      project_specific_path = File.join(git_repo.file_path("projects"), project.id)
+      return JSONEnvironmentDataSource.create(project_specific_path)
     end
   end
 end

--- a/app/services/config_data_sources/json_project_data_source.rb
+++ b/app/services/config_data_sources/json_project_data_source.rb
@@ -119,6 +119,17 @@ module FastlaneCI
 
         saved_projects = JSON.parse(File.read(path)).map do |project_json|
           project = Project.from_json!(project_json)
+
+          # Now load the project specific files here
+          # that are in
+          #
+          #   `projects/[project_id]/[file].json
+          #
+          # more information on https://github.com/fastlane/ci/issues/643
+          project_specific_path = File.join(git_repo.file_path("projects"), project.id)
+          environment_variable_data_source = JSONEnvironmentDataSource.create(project_specific_path)
+          project.environment_variables = environment_variable_data_source.environment_variables
+
           project
         end
 

--- a/app/services/data_sources/json_environment_variable_data_source.rb
+++ b/app/services/data_sources/json_environment_variable_data_source.rb
@@ -21,6 +21,9 @@ module FastlaneCI
     end
 
     # can't have us reading and writing to a file at the same time
+    # TODO: currently we just have this global lock
+    #   Instead we'll have multiple instances of `JSONEnvironmentVariableDataSource` objects
+    #   for each project and a global one
     JSONEnvironmentDataSource.file_semaphore = Mutex.new
 
     def after_creation(**params)
@@ -31,9 +34,7 @@ module FastlaneCI
     end
 
     def environment_file_path(path: "environment_variables.json")
-      # TODO: Remove this, for some reason `json_folder_path` is `nil` here
-      json_folder_path = File.expand_path("~/.fastlane/ci/fastlane-ci-config")
-      File.join(json_folder_path, path)
+      return File.join(json_folder_path, path)
     end
 
     def environment_variables

--- a/app/services/environment_variable_service.rb
+++ b/app/services/environment_variable_service.rb
@@ -24,7 +24,7 @@ module FastlaneCI
         )
         data_store_folder = ENV["data_store_folder"] # you can set it at runtime!
         data_store_folder ||= File.join(FastlaneCI::FastlaneApp.settings.root, "sample_data")
-        environment_variable_data_source = JSONEnvironmentDataSource.create(json_folder_path: data_store_folder)
+        environment_variable_data_source = JSONEnvironmentDataSource.create(data_store_folder)
       end
 
       self.environment_variable_data_source = environment_variable_data_source

--- a/app/services/services.rb
+++ b/app/services/services.rb
@@ -180,7 +180,9 @@ module FastlaneCI
     end
 
     def self.environment_variable_service
-      @environment_variable_service ||= FastlaneCI::EnvironmentVariableService.new
+      @environment_variable_service ||= FastlaneCI::EnvironmentVariableService.new(
+        environment_variable_data_source: JSONEnvironmentDataSource.create(ci_config_git_repo_path)
+      )
     end
 
     def self.provider_credential_service

--- a/app/shared/models/project.rb
+++ b/app/shared/models/project.rb
@@ -55,7 +55,7 @@ module FastlaneCI
       @id = id || SecureRandom.uuid
       @platform = platform
       @lane = lane
-      @environment_variables = environment_variables
+      @environment_variables = environment_variables || []
       @artifact_provider = artifact_provider
       # TODO: This is fine for now to avoid runtime fails due to lack of triggers.
       # In the future, the Add Project workflow, should provide the enough interface

--- a/app/shared/models/project.rb
+++ b/app/shared/models/project.rb
@@ -32,6 +32,9 @@ module FastlaneCI
     # @return [Array[JobTrigger]] The job triggers
     attr_reader :job_triggers
 
+    # @return [Array[EnvironmentVariable]] The project specific environment variables
+    attr_accessor :environment_variables
+
     # @return [ArtifactProvider]
     attr_reader :artifact_provider
 
@@ -42,6 +45,7 @@ module FastlaneCI
       platform: nil,
       lane: nil,
       id: nil,
+      environment_variables: nil,
       artifact_provider: LocalArtifactProvider.new,
       job_triggers: []
     )
@@ -51,6 +55,7 @@ module FastlaneCI
       @id = id || SecureRandom.uuid
       @platform = platform
       @lane = lane
+      @environment_variables = environment_variables
       @artifact_provider = artifact_provider
       # TODO: This is fine for now to avoid runtime fails due to lack of triggers.
       # In the future, the Add Project workflow, should provide the enough interface


### PR DESCRIPTION
- Fixes https://github.com/fastlane/ci/issues/643
- Fixes https://github.com/fastlane/ci/issues/441

This PR does the following
- Add support for project specific ENV variables. This is a crucial feature, which allows the user to set certain ENV variables, like the `FASTLANE_USER`, `APP_SCHEME`, `KEYCHAIN_PATH` and similar
- While those values can already be set on a system-wide level, being able to override the global ones per project is critical, and is made possible with this PR
- This required some custom code when reading/writing projects to ignore the `environment_variables` key of `Project` and use a separate `environment_variables.json` in the project's folder instead
- When editing a project, just using the regular `service.projects = ...` setter will automatically also trigger saving the ENV variables for the project 👍 
- This PR will also inject the project specific ENV variables into the build, and potentially overrides any existing ENV variables
- Just for debugging purposes, the ENV variables are all rendered in the project edit screen also
- We don't access the EnvironmentVariableService, but access the data source directly instead (see comment I added to this PR). I have the feeling this will allow us to be very flexible in the future, where a user might want to store ENV variables on a different source depending on the project.

<img width="694" alt="screenshot 2018-04-30 06 02 43" src="https://user-images.githubusercontent.com/869950/39437292-b3aa1510-4ca0-11e8-8bc5-8e98ee329328.png">

---

<img width="925" alt="screenshot 2018-04-30 06 02 38" src="https://user-images.githubusercontent.com/869950/39437294-b3c77c68-4ca0-11e8-840d-34fc91e0352e.png">