### PR TITLE
Add project dialog and modularize dashboard

### DIFF
--- a/web/app/app-routing.module.ts
+++ b/web/app/app-routing.module.ts
@@ -1,6 +1,8 @@
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
+
 import {DashboardComponent} from './dashboard/dashboard.component';
+import {DashboardModule} from './dashboard/dashboard.module';
 import {ProjectComponent} from './project/project.component';
 
 const routes: Routes = [
@@ -9,7 +11,10 @@ const routes: Routes = [
   {path: 'project/:id', component: ProjectComponent}
 ];
 
-@NgModule({imports: [RouterModule.forRoot(routes)], exports: [RouterModule]})
+@NgModule({
+  imports: [DashboardModule, RouterModule.forRoot(routes)],
+  exports: [RouterModule]
+})
 
 export class AppRoutingModule {
 }

--- a/web/app/app.module.ts
+++ b/web/app/app.module.ts
@@ -6,7 +6,6 @@ import {MomentModule} from 'ngx-moment';
 import {AppRoutingModule} from './/app-routing.module';
 import {AppComponent} from './app.component';
 import {CommonComponentsModule} from './common/components/common-components.module';
-import {DashboardComponent} from './dashboard/dashboard.component';
 import {ProjectComponent} from './project/project.component';
 import {DataService} from './services/data.service';
 import {SharedMaterialModule} from './shared_material.module';
@@ -14,7 +13,6 @@ import {SharedMaterialModule} from './shared_material.module';
 @NgModule({
   declarations: [
     AppComponent,
-    DashboardComponent,
     ProjectComponent,
   ],
   imports: [

--- a/web/app/dashboard/add-project-dialog/add-project-dialog.component.html
+++ b/web/app/dashboard/add-project-dialog/add-project-dialog.component.html
@@ -1,0 +1,3 @@
+<p>
+  add-project-dialog works!
+</p>

--- a/web/app/dashboard/add-project-dialog/add-project-dialog.component.spec.ts
+++ b/web/app/dashboard/add-project-dialog/add-project-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddProjectDialogComponent } from './add-project-dialog.component';
+
+describe('AddProjectDialogComponent', () => {
+  let component: AddProjectDialogComponent;
+  let fixture: ComponentFixture<AddProjectDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AddProjectDialogComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddProjectDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/app/dashboard/add-project-dialog/add-project-dialog.component.ts
+++ b/web/app/dashboard/add-project-dialog/add-project-dialog.component.ts
@@ -1,0 +1,12 @@
+import {Component, OnInit} from '@angular/core';
+
+@Component({
+  selector: 'fci-add-project-dialog',
+  templateUrl: './add-project-dialog.component.html',
+  styleUrls: ['./add-project-dialog.component.scss']
+})
+export class AddProjectDialogComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/web/app/dashboard/dashboard.component.html
+++ b/web/app/dashboard/dashboard.component.html
@@ -5,7 +5,7 @@
       <div class="fci-dashboard-subtitle">
         Open source, self-hosted, mobile-optimized CI powered by fastlane brought to you by the fastlane team.
       </div>
-      <button mat-raised-button color="primary">Add New Project</button>
+      <button mat-raised-button color="primary" (click)="openAddProjectDialog()">Add New Project</button>
     </div>
   </div>
 </div>

--- a/web/app/dashboard/dashboard.component.spec.ts
+++ b/web/app/dashboard/dashboard.component.spec.ts
@@ -1,6 +1,7 @@
 import 'rxjs/add/observable/of';
 
 import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {MatDialogModule} from '@angular/material';
 import {RouterModule} from '@angular/router';
 import {MomentModule} from 'ngx-moment';
 import {Observable} from 'rxjs/Observable';
@@ -26,8 +27,8 @@ describe('DashboardComponent', () => {
     TestBed
         .configureTestingModule({
           imports: [
-            SharedMaterialModule, CommonComponentsModule, MomentModule,
-            RouterModule
+            MatDialogModule, SharedMaterialModule, CommonComponentsModule,
+            MomentModule, RouterModule
           ],
           declarations: [
             DashboardComponent,

--- a/web/app/dashboard/dashboard.component.ts
+++ b/web/app/dashboard/dashboard.component.ts
@@ -1,7 +1,9 @@
 import {Component, OnInit} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material';
 
 import {ProjectSummary, ProjectSummaryResponse} from '../models/project_summary';
 import {DataService} from '../services/data.service';
+import {AddProjectDialogComponent} from './add-project-dialog/add-project-dialog.component';
 
 @Component({
   selector: 'fci-dashboard',
@@ -14,12 +16,24 @@ export class DashboardComponent implements OnInit {
       ['name', 'latestBuild', 'repo', 'lane'];
   isLoading = true;
   projects: ProjectSummary[];
-  constructor(private readonly dataService: DataService) {}
+
+  constructor(
+      private readonly dataService: DataService,
+      private readonly dialog: MatDialog) {}
 
   ngOnInit() {
     this.dataService.getProjects().subscribe((projects) => {
       this.projects = projects;
       this.isLoading = false;
+    });
+  }
+
+  openAddProjectDialog() {
+    const dialogRef =
+        this.dialog.open(AddProjectDialogComponent, {width: '250px', data: {}});
+
+    dialogRef.afterClosed().subscribe(result => {
+      console.log('The dialog was closed');
     });
   }
 }

--- a/web/app/dashboard/dashboard.module.ts
+++ b/web/app/dashboard/dashboard.module.ts
@@ -1,0 +1,39 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatDialogModule} from '@angular/material';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {RouterModule} from '@angular/router';
+import {MomentModule} from 'ngx-moment';
+
+import {CommonComponentsModule} from '../common/components/common-components.module';
+import {DashboardComponent} from '../dashboard/dashboard.component';
+import {ProjectComponent} from '../project/project.component';
+import {DataService} from '../services/data.service';
+import {SharedMaterialModule} from '../shared_material.module';
+import {AddProjectDialogComponent} from './add-project-dialog/add-project-dialog.component';
+
+@NgModule({
+  declarations: [
+    DashboardComponent,
+    AddProjectDialogComponent,
+  ],
+  entryComponents: [
+    DashboardComponent,
+    AddProjectDialogComponent,
+  ],
+  imports: [
+    /** Angular Library Imports */
+    RouterModule,  // For routerLink directive
+    CommonModule,  // For ngIf and other common directives
+    BrowserAnimationsModule,
+    /** Internal Imports */
+    CommonComponentsModule,
+    /** Angular Material Imports */
+    SharedMaterialModule, MatDialogModule,
+    /** Third-Party Module Imports */
+    MomentModule,  // For Date relative time pipes
+  ],
+  providers: [DataService],
+})
+export class DashboardModule {
+}


### PR DESCRIPTION
Added new Dialog for the Add Project flow.
Issue: #713

Some things to note here:
- We should try to be more "modular" having a module at each route/page will allow Angular to do some lazy loading. AKA Performance boost ⚡️ 
- `entryComponents` is used here to denote Components that won't be used in templates and only referenced programmatically. So since DashboardComponent is used in the RouterModule and not actually in any templates we can declare it there instead of the `exports`. 
- `exports` should be used to make components visible to any module that imports it.
- Eventually i'll break out the module some more, instead of using Shared Modules. We can start using Shared Modules when we really know what's being shared.

#### Screenshot
![image](https://user-images.githubusercontent.com/2754461/39378511-789cd574-4a0d-11e8-93b2-b993ada33cf3.png)
