### PR TITLE
Make new frontend (Angular) default frontend instead of erb

### DIFF
--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -47,7 +47,7 @@ module FastlaneCI
     # which is required to support web socket streams for the
     # display of real-time output
     set(:server, "thin")
-    if ENV["ERB_CLIENT"]
+    if ENV["FASTLANE_CI_ERB_CLIENT"]
       get "/" do
         if session[:user]
           redirect("/dashboard_erb")

--- a/fastlane_app.rb
+++ b/fastlane_app.rb
@@ -47,13 +47,7 @@ module FastlaneCI
     # which is required to support web socket streams for the
     # display of real-time output
     set(:server, "thin")
-    if ENV["WEB_APP"]
-      # Anything except a data route
-      get %r{/(?!data.*).*} do
-        # Use Angular Web App instead
-        send_file(File.join("public", ".dist", "index.html"))
-      end
-    else
+    if ENV["ERB_CLIENT"]
       get "/" do
         if session[:user]
           redirect("/dashboard_erb")
@@ -61,10 +55,16 @@ module FastlaneCI
           redirect("/login_erb")
         end
       end
-
-      get "/favico.ico" do
-        "nope" # TODO: Add favicon once we have it
+    else
+      # Anything except a data route
+      get %r{/(?!data.*).*} do
+        # Use Angular Web App instead
+        send_file(File.join("public", ".dist", "index.html"))
       end
+    end
+
+    get "/favicon.ico" do
+      send_file(File.join("public", "favicon.ico"))
     end
   end
 end

--- a/launch.rb
+++ b/launch.rb
@@ -48,7 +48,7 @@ module FastlaneCI
     end
 
     def self.verify_app_built
-      if ENV["WEB_APP"]
+      unless ENV["ERB_CLIENT"]
         app_exists = File.file?(File.join("public", ".dist", "index.html"))
 
         unless app_exists
@@ -119,25 +119,29 @@ module FastlaneCI
     def self.register_available_controllers
       # require all controllers
       require_relative "app/features/all"
-
       # Load up all the available controllers
-      # NOTE: ORDER MATTERS HERE
-      # If using REST-style endpoints, you must list the controllers from
-      # the outter most first.
-      # Example:
-      # BuildController is `project/build/*`
-      # ProjectControoler is `project/*`
-      # BuildController build be `used` first, so it is defined here first
-      FastlaneCI::FastlaneApp.use(FastlaneCI::BuildController)
-      FastlaneCI::FastlaneApp.use(FastlaneCI::ProjectController)
-      FastlaneCI::FastlaneApp.use(FastlaneCI::ConfigurationController)
-      FastlaneCI::FastlaneApp.use(FastlaneCI::DashboardController)
+
+      if ENV["ERB_CLIENT"]
+        # NOTE: ORDER MATTERS HERE
+        # If using REST-style endpoints, you must list the controllers from
+        # the outter most first.
+        # Example:
+        # BuildController is `project/build/*`
+        # ProjectControoler is `project/*`
+        # BuildController build be `used` first, so it is defined here first
+        FastlaneCI::FastlaneApp.use(FastlaneCI::BuildController)
+        FastlaneCI::FastlaneApp.use(FastlaneCI::ProjectController)
+        FastlaneCI::FastlaneApp.use(FastlaneCI::ConfigurationController)
+        FastlaneCI::FastlaneApp.use(FastlaneCI::DashboardController)
+        FastlaneCI::FastlaneApp.use(FastlaneCI::NotificationsController)
+        FastlaneCI::FastlaneApp.use(FastlaneCI::OnboardingController)
+        FastlaneCI::FastlaneApp.use(FastlaneCI::ProviderCredentialsController)
+        FastlaneCI::FastlaneApp.use(FastlaneCI::UsersController)
+        FastlaneCI::FastlaneApp.use(FastlaneCI::EnvironmentVariablesController)
+      end
+
+      # TODO: Only load this with ERB_CLIENT env once Web app has login support
       FastlaneCI::FastlaneApp.use(FastlaneCI::LoginController)
-      FastlaneCI::FastlaneApp.use(FastlaneCI::NotificationsController)
-      FastlaneCI::FastlaneApp.use(FastlaneCI::OnboardingController)
-      FastlaneCI::FastlaneApp.use(FastlaneCI::ProviderCredentialsController)
-      FastlaneCI::FastlaneApp.use(FastlaneCI::UsersController)
-      FastlaneCI::FastlaneApp.use(FastlaneCI::EnvironmentVariablesController)
 
       # Load JSON controllers
       require_relative "app/features-json/project_json_controller"

--- a/launch.rb
+++ b/launch.rb
@@ -48,7 +48,7 @@ module FastlaneCI
     end
 
     def self.verify_app_built
-      unless ENV["ERB_CLIENT"]
+      unless ENV["FASTLANE_CI_ERB_CLIENT"]
         app_exists = File.file?(File.join("public", ".dist", "index.html"))
 
         unless app_exists
@@ -121,7 +121,7 @@ module FastlaneCI
       require_relative "app/features/all"
       # Load up all the available controllers
 
-      if ENV["ERB_CLIENT"]
+      if ENV["FASTLANE_CI_ERB_CLIENT"]
         # NOTE: ORDER MATTERS HERE
         # If using REST-style endpoints, you must list the controllers from
         # the outter most first.

--- a/web/README.md
+++ b/web/README.md
@@ -6,7 +6,7 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Development server
 
-1. Run fastlane.ci with the `WEB_APP=1` environment variable.
+1. Run fastlane.ci
 1. continuously build the web application with the follow command. If you only want to build once remove `-w`.
 ```
 ng build --deploy-url="/.dist" --dev -w


### PR DESCRIPTION
Fixes: #767 

Load the Angular app by default, and launch with ERB client when the `ERB_CLIENT` env key is set.

One drawback here is the lack of login implementation in the Angular app. This switch should motivate us to get these features done.