### PR TITLE
Removed dead code `STATUS` in `controller_base.rb`.

### DIFF
--- a/app/shared/controller_base.rb
+++ b/app/shared/controller_base.rb
@@ -22,9 +22,6 @@ module FastlaneCI
 
     include FastlaneCI::Logging
 
-    # Enum for status of POST operations
-    STATUS = { success: :success, error: :error }
-
     # I don't like this here, I'd rather use the mixin for organization, but that isn't done
     # TODO: use mixin
     configure :development do


### PR DESCRIPTION
When I changed the session messages to use [sinatra-flash](https://github.com/SFEley/sinatra-flash). I forgot to remove this enum in the base controller.