### PR TITLE
Add UpdateFastlaneCIService class

### DIFF
--- a/app/services/services.rb
+++ b/app/services/services.rb
@@ -9,6 +9,7 @@ require_relative "./environment_variable_service"
 require_relative "./onboarding_service"
 require_relative "./project_service"
 require_relative "./notification_service"
+require_relative "./update_fastlane_ci_service"
 require_relative "./user_service"
 require_relative "./worker_service"
 
@@ -43,6 +44,7 @@ module FastlaneCI
       @_config_service = nil
       @_worker_service = nil
       @_configuration_repository_service = nil
+      @_update_fastlane_ci_service = nil
     end
 
     ########################################################
@@ -195,6 +197,10 @@ module FastlaneCI
 
     def self.bot_user_client
       @_bot_user_client ||= Octokit::Client.new(access_token: FastlaneCI.dot_keys.ci_user_api_token)
+    end
+
+    def self.update_fastlane_ci_service
+      @_update_fastlane_ci_service ||= FastlaneCI::UpdateFastlaneCIService.new
     end
 
     def self.onboarding_user_client

--- a/app/services/update_fastlane_ci_service.rb
+++ b/app/services/update_fastlane_ci_service.rb
@@ -65,7 +65,9 @@ module FastlaneCI
       end
 
       # suppress updater output - very noisy
-      Gem::DefaultUserInteraction.ui = Gem::SilentUI.new
+      unless ENV["FASTLANE_CI_VERBOSE"]
+        Gem::DefaultUserInteraction.ui = Gem::SilentUI.new
+      end
 
       update_needed.each do |tool_info|
         tool = tool_info[0]

--- a/app/services/update_fastlane_ci_service.rb
+++ b/app/services/update_fastlane_ci_service.rb
@@ -1,0 +1,93 @@
+require_relative "../shared/logging_module"
+require_relative "../services/services"
+
+require "rubygems/spec_fetcher"
+require "rubygems/command_manager"
+
+module FastlaneCI
+  # Self-update fastlane.ci, this is called either on manual
+  # user action, or through a background worker
+  class UpdateFastlaneCIService
+    include FastlaneCI::Logging
+
+    GEM_NAME = "fastlane_ci"
+
+    # Trigger an update for fastlane.ci
+    # this method will automatically wait for all builds to finish
+    def update_fastlane_ci
+      loop do
+        break if all_builds_complete? && all_workers_idle?
+        logger.debug("Waiting for builds/workers to be complete to update fastlane.ci")
+        sleep(5)
+      end
+
+      # TODO: Kill all workers here, as we're gonna restart the whole server
+      logger.info("Starting update of fastlane.ci")
+
+      execute_update
+    end
+
+    private
+
+    def all_builds_complete?
+      return true
+      # TODO
+    end
+
+    def all_workers_idle?
+      return true
+      # TODO
+    end
+
+    def execute_update
+      tools_to_update = [GEM_NAME]
+      updater = Gem::CommandManager.instance[:update]
+      cleaner = Gem::CommandManager.instance[:cleanup]
+
+      gem_dir = ENV["GEM_HOME"] || Gem.dir
+      sudo_needed = !File.writable?(gem_dir)
+
+      if sudo_needed
+        # TODO: update the instructions below
+        logger.info("It seems that your Gem directory is not writable by your current user.")
+        logger.info("fastlane would need sudo rights to update itself, however, running 'sudo' is not recommended.")
+        logger.info("If you still want to use this action, please read the documentation how to set this up:")
+        logger.info("https://docs.fastlane.tools/actions/#update_fastlane")
+        return
+      end
+
+      highest_versions = updater.highest_installed_gems.keep_if { |key| tools_to_update.include?(key) }
+      update_needed = updater.which_to_update(highest_versions, tools_to_update)
+
+      if update_needed.count == 0
+        logger.info("Nothing to update for fastlane.ci")
+        return
+      end
+
+      # suppress updater output - very noisy
+      Gem::DefaultUserInteraction.ui = Gem::SilentUI.new
+
+      update_needed.each do |tool_info|
+        tool = tool_info[0]
+        local_version = Gem::Version.new(highest_versions[tool].version)
+
+        # Approximate_recommendation will create a string like "~> 0.10" from a
+        # version 0.10.0, e.g. one that is valid for versions >= 0.10 and <1.0
+        requirement_version = local_version.approximate_recommendation
+        updater.update_gem(tool, Gem::Requirement.new(requirement_version))
+
+        logger.info("Finished updating #{tool}")
+      end
+
+      logger.info("Cleaning up old versions...")
+      cleaner.options[:args] = tools_to_update
+      cleaner.execute
+
+      logger.info("fastlane.ci successfully updated! I will now restart myself... 😴")
+
+      # Set no_update to true so we don't try to update again
+      # TODO: Use actual fastlane.ci launch command
+      # exec("FL_NO_UPDATE=true #{$PROGRAM_NAME} #{ARGV.join(' ')}")
+    end
+  end
+end

--- a/app/workers/check_for_fastlane_ci_update_worker.rb
+++ b/app/workers/check_for_fastlane_ci_update_worker.rb
@@ -20,13 +20,23 @@ module FastlaneCI
 
     def check_for_update
       logger.debug("checking for updates for fastlane.ci...")
+
       return unless update_available?
 
-      logger.info("fastlane.ci version #{version_of_latest_release} is available")
-      # TODO: in a separate PR I'm gonna add support for automatically updating itself
-      #       right now we're just printing out that there is an update available
-      #       the plan is to have the actual updater in a separate class so that it can be
-      #       triggered from various locations, including UI for the user
+      logger.info("New fastlane.ci version #{version_of_latest_release} is available")
+      # This is where we'll check if the user has auto-updates enabled
+      # or if we just show an update message to the user
+
+      # Auto-update enabled code:
+      # FastlaneCI::Services.update_fastlane_ci_service.update_fastlane_ci
+
+      # Manual update enabled code:
+      Services.notification_service.create_notification!(
+        priority: Notification::PRIORITIES[:normal],
+        name: "New version of fastlane.ci available",
+        message: "Please open the fastlane.ci system settings, and hit the \"Update fastlane\" button",
+        details: "Please open the fastlane.ci system settings, and hit the \"Update fastlane\" button"
+      )
     end
 
     def update_available?

--- a/app/workers/check_for_fastlane_ci_update_worker.rb
+++ b/app/workers/check_for_fastlane_ci_update_worker.rb
@@ -34,8 +34,7 @@ module FastlaneCI
       Services.notification_service.create_notification!(
         priority: Notification::PRIORITIES[:normal],
         name: "New version of fastlane.ci available",
-        message: "Please open the fastlane.ci system settings, and hit the \"Update fastlane\" button",
-        details: "Please open the fastlane.ci system settings, and hit the \"Update fastlane\" button"
+        message: "Please open the fastlane.ci system settings, and hit the \"Update fastlane\" button"
       )
     end
 


### PR DESCRIPTION
This PR is ready to be merged - however UpdateFastlaneCIService needs some more updating as soon as we decided on how exactly we're gonna distribute fastlane.ci via RubyGems. In particular how to launch up the server is going to be relevant

As part of UpdateFastlaneCIService, we'll also need some code to check if any background workers or build workers are still running. I left the code empty for now, as we haven't yet finished our build workers setup, and we'd end up re-implementing things if we wrote it today

- Related to [update_fastlane_ci_via_ruby_gem.md](https://github.com/fastlane/ci/blob/master/docs/use_cases/update_fastlane_ci_via_ruby_gem.md) and https://github.com/fastlane/ci/issues/445