### PR TITLE
Dot Keys environment missing param

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "tty-command", ">= 0.7.0", "< 1.0.0"
 gem "octokit", ">= 4.8.0", "< 5.0.0"
 
 # Load the `.keys` dotenv file we use to store encryption data
-gem "dotenv", ">= 2.2.1", "< 3.0.0"
+gem "dotenv", ">= 2.4.0", "< 3.0.0"
 
 # Caching for octokit operations
 gem "faraday-http-cache"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/fastlane/fastlane
-  revision: 27fd2c57a9519c03393b21191285caacf075f294
+  revision: 960b4e82261bed07fc560f1a1f1396484ce8ff49
   specs:
     fastlane (2.94.0)
       CFPropertyList (>= 2.3, < 4.0.0)
@@ -313,7 +313,7 @@ DEPENDENCIES
   bcrypt (>= 3.1.11, < 4.0.0)
   bundler (~> 1.16.0)
   coveralls
-  dotenv (>= 2.2.1, < 3.0.0)
+  dotenv (>= 2.4.0, < 3.0.0)
   faraday-http-cache
   fastfile-parser!
   fastlane!

--- a/app/services/dot_keys_variable_service.rb
+++ b/app/services/dot_keys_variable_service.rb
@@ -31,7 +31,7 @@ module FastlaneCI
       return unless File.exist?(keys_file_path)
 
       require "dotenv"
-      ENV.update(Dotenv::Environment.new(keys_file_path))
+      ENV.update(Dotenv::Environment.new(keys_file_path, true))
 
       Services.reset_services!
     end


### PR DESCRIPTION
Fixes the following error i was getting
```
bundler: failed to load command: rackup (/Users/nakhbari/.rbenv/versions/2.3.3/bin/rackup)
ArgumentError: wrong number of arguments (given 1, expected 2)
  /Users/nakhbari/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/dotenv-2.4.0/lib/dotenv/environment.rb:7:in `initialize'
  /Users/nakhbari/Documents/fastlane/ci/app/services/dot_keys_variable_service.rb:34:in `new'
  /Users/nakhbari/Documents/fastlane/ci/app/services/dot_keys_variable_service.rb:34:in `reload_dot_env!'
```