### PR TITLE
Fix crash happening in GitRepo exception handler

### DIFF
--- a/app/shared/models/git_repo.rb
+++ b/app/shared/models/git_repo.rb
@@ -620,6 +620,7 @@ module FastlaneCI
           exception_context = {
             clone_url: clone_url,
             branch: branch,
+            sha: sha,
             local_branch_name: local_branch_name
           }
           handle_exception(

--- a/app/shared/models/git_repo.rb
+++ b/app/shared/models/git_repo.rb
@@ -620,7 +620,6 @@ module FastlaneCI
           exception_context = {
             clone_url: clone_url,
             branch: branch,
-            sha: current_sha,
             local_branch_name: local_branch_name
           }
           handle_exception(


### PR DESCRIPTION
`current_sha` isn't defined