### PR TITLE
Fixed broken create user

### DIFF
--- a/app/services/data_sources/json_user_data_source.rb
+++ b/app/services/data_sources/json_user_data_source.rb
@@ -101,7 +101,7 @@ module FastlaneCI
       end
     end
 
-    def login(email: nil, password: nil)
+    def login(email:, password:)
       user = users.detect { |existing_user| existing_user.email.casecmp(email.downcase).zero? }
 
       if user.nil?
@@ -125,12 +125,12 @@ module FastlaneCI
     end
 
     # just check to see if we have a user with that email...
-    def user_exist?(email: nil)
+    def user_exist?(email:)
       return users.any? { |existing_user| existing_user.email.casecmp(email.downcase).zero? }
     end
 
     # TODO: this isn't threadsafe
-    def update_user!(user: nil)
+    def update_user!(user:)
       user_index = user_index(user: user)
 
       if user_index.nil?
@@ -143,7 +143,7 @@ module FastlaneCI
       end
     end
 
-    def delete_user!(user: nil)
+    def delete_user!(user:)
       if find_user(id: user.id).nil?
         logger.debug("Couldn't delete user #{user.email} because they don't exist")
         raise "Couldn't delete user #{user.email} because they don't exist"
@@ -154,7 +154,7 @@ module FastlaneCI
       end
     end
 
-    def create_user!(id: nil, email: nil, password: nil, provider_credentials: [])
+    def create_user!(id: nil, email:, password:, provider_credentials: [])
       users = self.users
       new_user = User.new(
         id: id,

--- a/app/services/data_sources/user_data_source.rb
+++ b/app/services/data_sources/user_data_source.rb
@@ -7,32 +7,32 @@ module FastlaneCI
     end
 
     # returns logged-in user if password check passes, else nil
-    def login(email: nil, password: nil)
+    def login(email:, password:)
       not_implemented(__method__)
     end
 
     # If user exists, returns true, else false
-    def user_exist?(email: nil)
+    def user_exist?(email:)
       not_implemented(__method__)
     end
 
     # Saves the updated user state or raises exception
-    def update_user!(user: nil)
+    def update_user!(user:)
       not_implemented(__method__)
     end
 
     # Deletes the user
-    def delete_user!(user: nil)
+    def delete_user!(user:)
       not_implemented(__method__)
     end
 
     # Creates and returns a user if one doesn't already exist, otherwise fails and returns nil
-    def create_user!(id: nil, email: nil, password: nil, provider_credentials: [])
+    def create_user!(id: nil, email:, password:, provider_credentials: [])
       not_implemented(__method__)
     end
 
     # @return [User]
-    def find_user(id: nil)
+    def find_user(id:)
       not_implemented(__method__)
     end
   end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -37,7 +37,7 @@ module FastlaneCI
       user_data_source.users
     end
 
-    def create_user!(id:, email:, password:)
+    def create_user!(id: nil, email:, password:)
       email.strip!
 
       unless user_data_source.user_exist?(email: email)

--- a/app/shared/models/user.rb
+++ b/app/shared/models/user.rb
@@ -5,12 +5,36 @@ require_relative "github_provider_credential"
 module FastlaneCI
   # User model that will end up in the session as session[:user]
   class User
+    # @return [String] The UUID of the user
     attr_accessor :id
+
+    # @return [String] The email associated with the User's account
     attr_accessor :email
+
+    # @return [String] A password hash encrypted with the `FASTLANE_CI_ENCRYPTION_KEY`
     attr_accessor :password_hash
 
-    attr_accessor :provider_credentials # Array of {GitHubProviderCredential, BitBucketProvider, etc...}
+    # @return [Array[ProviderCredential]] {GitHubProviderCredential, BitBucketProvider, etc...}
+    attr_accessor :provider_credentials
 
+    # Creates a `User` model associated with a fastlane.ci account.
+    #
+    # NOTE: The `id` parameter can be `nil`, because you may want to create a
+    # `User` model from an existing record in the `JSONUserDataSource` which has
+    # an existing `id`.
+    #
+    # An example of this is when you wish to update an existing user. The
+    # `update_user!` method in the `UserDataSource` takes in a `User` as a
+    # required parameter, and looks up said user by its `id` in the `find_user`
+    # method.
+    #
+    # @param [String] id: an optional UUID parameter. If the parameter is `nil`
+    #   will create a new UUID for the user
+    # @param [String] email: a required parameter denoting the user's email
+    # @param [String] password_hash: a required parameter denoting the user's
+    #   password, encrypted with the `FASTLANE_CI_ENCRYPTION_KEY`
+    # @param [Array[ProviderCredential]] provider_credentials: an optional
+    #   parameter denoting provider credentials for code hosting services
     def initialize(id: nil, email: nil, password_hash: nil, provider_credentials: [])
       @id = id || SecureRandom.uuid
       @email = email

--- a/spec/services/data_sources/json_user_data_source_spec.rb
+++ b/spec/services/data_sources/json_user_data_source_spec.rb
@@ -20,6 +20,39 @@ describe FastlaneCI::JSONUserDataSource do
 
   subject { described_class.create(file_path) }
 
+  describe "#create_user!" do
+    let(:users) { user_params.map { |params| FastlaneCI::User.new(params) } }
+
+    # Removes the `password_hash` key, and adds the `password` key
+    let(:create_user_params) do
+      user_params.first
+                 .tap { |hs| hs.delete(:password_hash) }
+                 .merge(password: "password")
+    end
+
+    before(:each) do
+      subject.stub(:users).and_return(users)
+    end
+
+    context "user doesn't exist" do
+      let(:new_user_email) { "new.user1@gmail.com" }
+      let(:new_user_params) { create_user_params.merge(email: new_user_email) }
+
+      it "returns `User` object when a new user is created" do
+        expect(subject.create_user!(new_user_params)).to be_an_instance_of(FastlaneCI::User)
+      end
+    end
+
+    context "user exists" do
+      let(:old_user_params) { create_user_params }
+
+      it "returns `nil` if the user already exists" do
+        expect(File).not_to(receive(:write))
+        expect(subject.create_user!(old_user_params)).to be_nil
+      end
+    end
+  end
+
   describe "#update_user!" do
     let(:user) { users.first }
     let(:users) { user_params.map { |params| FastlaneCI::User.new(params) } }


### PR DESCRIPTION
Closes #817.

### Changes
- Fixed `User` creation in login. Removed optional parameters in favor of required parameters where possible.
- Added specs for `create_user!` method in `JSONUserDataSource`.