### PR TITLE
Use Faraday::Request::Retry to prevent crashes due to poor Internet connectivity

### DIFF
--- a/app/shared/github_handler.rb
+++ b/app/shared/github_handler.rb
@@ -112,7 +112,7 @@ module FastlaneCI
           Faraday::Adapter::NetHttp,
           Faraday::Request::Retry,
           max: 1000,
-          interval: 0.05,
+          interval: 0.5,
           interval_randomness: 0.5,
           backoff_factor: 2,
           exceptions: [

--- a/app/shared/github_handler.rb
+++ b/app/shared/github_handler.rb
@@ -1,5 +1,7 @@
 require "octokit"
 require "faraday"
+require "socket"
+require "net/http"
 require_relative "logging_module"
 
 # TODO: eventually we'll want to consider handling all these:
@@ -42,6 +44,24 @@ module FastlaneCI
 
     def github_action(client, &block)
       if client.kind_of?(Octokit::Client)
+        # Inject Faraday::Request::Retry to the client if necessary
+        unless client.middleware.handlers.include?(Faraday::Request::Retry)
+          middleware_dup = client.middleware.dup
+          client.middleware = middleware_dup
+          client.middleware.insert_before(Faraday::Adapter::NetHttp,
+                                          Faraday::Request::Retry,
+                                          max: 1000,
+                                          interval: 0.05,
+                                          interval_randomness: 0.5,
+                                          backoff_factor: 2,
+                                          exceptions: [
+                                            Errno::ETIMEDOUT,
+                                            "Timeout::Error",
+                                            Faraday::Error::TimeoutError,
+                                            Faraday::Error::RetriableResponse,
+                                            SocketError
+                                          ])
+        end
         # `rate_limit_retry_count` retains the variables through iterations so we assign to 0 the first time.
         rate_limit_retry_count ||= 0
         begin

--- a/app/shared/github_handler.rb
+++ b/app/shared/github_handler.rb
@@ -111,7 +111,7 @@ module FastlaneCI
         client.middleware.insert_before(
           Faraday::Adapter::NetHttp,
           Faraday::Request::Retry,
-          max: 1000,
+          max: 3,
           interval: 0.5,
           interval_randomness: 0.5,
           backoff_factor: 2,

--- a/app/shared/models/git_repo.rb
+++ b/app/shared/models/git_repo.rb
@@ -88,21 +88,6 @@ module FastlaneCI
       def load_octokit_cache_stack
         @stack ||= Faraday::RackBuilder.new do |builder|
           builder.use(Faraday::HttpCache, serializer: Marshal, shared_cache: false)
-          # In order to have access to SocketError and ETIMEDOUT exceptions.
-          require "socket"
-          require "net/http"
-          builder.use(Faraday::Request::Retry,
-                      max: 1000,
-                      interval: 0.05,
-                      interval_randomness: 0.5,
-                      backoff_factor: 2,
-                      exceptions: [
-                        Errno::ETIMEDOUT,
-                        "Timeout::Error",
-                        Faraday::Error::TimeoutError,
-                        Faraday::Error::RetriableResponse,
-                        SocketError
-                      ])
           builder.use(Octokit::Response::RaiseError)
           builder.adapter(Faraday.default_adapter)
         end


### PR DESCRIPTION
Fixes #798 