### PR TITLE
Dockerfile updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,6 @@ fastlane.log
 fastlane.verbose.log
 public/.dist/*
 **/node_modules/*
+node_modules
 package-lock.json
 npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM ruby:2.5
+FROM node:carbon
+RUN npm install --prod
+FROM ruby:2.3
 
 ENV LANG C.UTF-8
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
-WORKDIR /usr/src/app
-
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock Rakefile ./
+COPY . .
 RUN bundle install
 
-COPY . .
-
-CMD ["prod"]
+CMD ["hosted_prod_test"]
 ENTRYPOINT ["bundle", "exec", "rake"]
+EXPOSE 8080

--- a/Rakefile
+++ b/Rakefile
@@ -6,11 +6,15 @@ task :prod do
   sh "bundle exec rackup -p 8080 --env production"
 end
 
+task :hosted_prod_test do
+  sh("FASTLANE_CI_ERB_CLIENT=1 DEBUG=1 FASTLANE_CI_DISABLE_REMOTE_STATUS_UPDATE=1 FASTLANE_CI_DISABLE_PUSHES=1 FASTLANE_CI_SKIP_RESTARTING_PENDING_WORK=1 bundle exec rackup --host 0.0.0.0 -p 8080 --env development")
+end
+
 task :devbootstrap do
-  sh "bundle install"
+  sh("bundle install")
   sh("brew install node") unless sh("npm -v")
-  sh "npm install"
-  sh "ln -sf ../../.pre-commit .git/hooks/pre-commit"
+  sh("npm install")
+  sh("ln -sf ../../.pre-commit .git/hooks/pre-commit")
 end
 
 begin


### PR DESCRIPTION
- Switch to testing prod mode for now.
- include node
- update ruby version to 2.3 instead of 2.5
- expose port 8080 by default

Fixes: https://github.com/fastlane/ci/issues/830
Although, note that it's running the rake task: `hosted_prod_test` not `prod` 