### PR TITLE
Added specs for `JSONProjectDataSource`.

### DIFF
--- a/app/services/config_data_sources/json_project_data_source.rb
+++ b/app/services/config_data_sources/json_project_data_source.rb
@@ -226,6 +226,8 @@ module FastlaneCI
         projects = self.projects
         projects[project_index] = project
         self.projects = projects
+
+        return true
       end
     end
 
@@ -233,6 +235,7 @@ module FastlaneCI
       unless project.nil?
         raise "project must be configured with an instance of #{Project.name}" unless project.class <= Project
       end
+
       project_index = nil
       existing_project = nil
       projects.each.with_index do |old_project, index|
@@ -253,6 +256,8 @@ module FastlaneCI
         projects = self.projects
         projects.delete_at(project_index)
         self.projects = projects
+
+        return true
       end
     end
 

--- a/app/services/config_data_sources/json_project_data_source.rb
+++ b/app/services/config_data_sources/json_project_data_source.rb
@@ -226,8 +226,6 @@ module FastlaneCI
         projects = self.projects
         projects[project_index] = project
         self.projects = projects
-
-        return true
       end
     end
 
@@ -235,7 +233,6 @@ module FastlaneCI
       unless project.nil?
         raise "project must be configured with an instance of #{Project.name}" unless project.class <= Project
       end
-
       project_index = nil
       existing_project = nil
       projects.each.with_index do |old_project, index|
@@ -256,8 +253,6 @@ module FastlaneCI
         projects = self.projects
         projects.delete_at(project_index)
         self.projects = projects
-
-        return true
       end
     end
 

--- a/spec/helper_functions.rb
+++ b/spec/helper_functions.rb
@@ -1,4 +1,8 @@
 module HelperFunctions
+  def fixture_path
+    File.join(FastlaneCI::FastlaneApp.settings.root, "spec/fixtures/files/")
+  end
+
   def provider_credential
     FastlaneCI::GitHubProviderCredential.new(email: "test_user", api_token: nil)
   end

--- a/spec/services/cofig_data_sources/json_project_data_source_spec.rb
+++ b/spec/services/cofig_data_sources/json_project_data_source_spec.rb
@@ -30,7 +30,6 @@ describe FastlaneCI::JSONProjectDataSource do
 
     context "project exists" do
       it "returns `true` if a project exists for given name" do
-        expect(File).not_to(receive(:write))
         expect(subject.project_exist?(first_project_name)).to be(true)
       end
     end
@@ -92,10 +91,6 @@ describe FastlaneCI::JSONProjectDataSource do
         expect { subject.update_project!(project: updated_project) }
           .to change { subject.projects.first.project_name }.from(first_project_name).to(updated_project_name)
       end
-
-      it "returns `true` when a project is updated" do
-        expect(subject.update_project!(project: updated_project)).to be(true)
-      end
     end
   end
 
@@ -122,10 +117,6 @@ describe FastlaneCI::JSONProjectDataSource do
 
       it "removes the `project` from the `projects.json` file" do
         expect { subject.delete_project!(project: project) }.to change { subject.projects.size }.from(1).to(0)
-      end
-
-      it "returns `true` when a project is deleted" do
-        expect(subject.delete_project!(project: project)).to be(true)
       end
     end
   end

--- a/spec/services/cofig_data_sources/json_project_data_source_spec.rb
+++ b/spec/services/cofig_data_sources/json_project_data_source_spec.rb
@@ -1,0 +1,179 @@
+require "spec_helper"
+require "app/shared/models/project"
+require "app/services/config_data_sources/json_project_data_source"
+
+describe FastlaneCI::JSONProjectDataSource do
+  before(:each) do
+    stub_file_io
+    stub_git_repos
+    stub_services
+  end
+
+  subject do
+    FastlaneCI::JSONProjectDataSource.create(git_repo, user: ci_user)
+  end
+
+  let(:projects) do
+    project_params.map { |params| FastlaneCI::Project.new(params) }
+  end
+
+  describe "#project_exist?" do
+    before(:each) do
+      subject.stub(:projects).and_return(projects)
+    end
+
+    context "project doesn't exist" do
+      it "returns `false` when a project does not exist for given name" do
+        expect(subject.project_exist?(new_project_name)).to be(false)
+      end
+    end
+
+    context "project exists" do
+      it "returns `true` if a project exists for given name" do
+        expect(File).not_to(receive(:write))
+        expect(subject.project_exist?(first_project_name)).to be(true)
+      end
+    end
+  end
+
+  describe "#create_project!" do
+    before(:each) do
+      subject.stub(:projects).and_return(projects)
+    end
+
+    context "project doesn't exist" do
+      it "returns `Project` object when a new project is created" do
+        expect(subject.create_project!(new_project_params)).to be_an_instance_of(FastlaneCI::Project)
+      end
+    end
+
+    context "project exists" do
+      let(:old_project_params) do
+        project_params.first.tap do |hs|
+          hs.delete(:id)
+          hs[:name] = hs.delete(:project_name)
+        end
+      end
+
+      it "returns `nil` if the project already exists" do
+        expect(File).not_to(receive(:write))
+        expect(subject.create_project!(old_project_params)).to be_nil
+      end
+    end
+  end
+
+  describe "#update_project!" do
+    let(:project) do
+      projects.first
+    end
+
+    context "project doesn't exist" do
+      before(:each) do
+        subject.stub(:projects).and_return([])
+      end
+
+      it "raises an error message and doesn't write to the `projects.json` file" do
+        expect(File).not_to(receive(:write))
+        expect { subject.update_project!(project: project) }.to raise_error
+      end
+    end
+
+    context "project exists" do
+      before(:each) do
+        subject.stub(:projects).and_return(projects)
+      end
+
+      let(:updated_project_name) { "updated_project_name" }
+      let(:updated_project) do
+        FastlaneCI::Project.new(project_params.first.merge(project_name: updated_project_name))
+      end
+
+      it "updates the `project` name in the `projects.json` file" do
+        expect { subject.update_project!(project: updated_project) }
+          .to change { subject.projects.first.project_name }.from(first_project_name).to(updated_project_name)
+      end
+
+      it "returns `true` when a project is updated" do
+        expect(subject.update_project!(project: updated_project)).to be(true)
+      end
+    end
+  end
+
+  describe "#delete_project!" do
+    let(:project) do
+      projects.first
+    end
+
+    context "project doesn't exist" do
+      before(:each) do
+        subject.stub(:projects).and_return([])
+      end
+
+      it "raises an error message and doesn't write to the `projects.json` file" do
+        expect(File).not_to(receive(:write))
+        expect { subject.delete_project!(project: project) }.to raise_error
+      end
+    end
+
+    context "project exists" do
+      before(:each) do
+        subject.stub(:projects).and_return(projects)
+      end
+
+      it "removes the `project` from the `projects.json` file" do
+        expect { subject.delete_project!(project: project) }.to change { subject.projects.size }.from(1).to(0)
+      end
+
+      it "returns `true` when a project is deleted" do
+        expect(subject.delete_project!(project: project)).to be(true)
+      end
+    end
+  end
+
+  private
+
+  def new_project_name
+    "new-project"
+  end
+
+  def new_project_params
+    {
+      name: new_project_name,
+      repo_config: FastlaneCI::GitHubRepoConfig.new(
+        git_url: "https://github.com/username/#{new_project_name}",
+        description: "New Project",
+        name: new_project_name,
+        full_name: "username/#{new_project_name}"
+      ),
+      enabled: true,
+      platform: "ios",
+      lane: "default",
+      artifact_provider: FastlaneCI::LocalArtifactProvider,
+      job_triggers: []
+    }
+  end
+
+  def first_project_name
+    "project-1"
+  end
+
+  def project_params
+    [
+      {
+        id: "b2be5614-b3a0-4aae-a70b-bf3b29a6ccac",
+        repo_config: FastlaneCI::GitHubRepoConfig.new(
+          git_url: "https://github.com/username/#{first_project_name}",
+          description: "Project1",
+          name: first_project_name,
+          full_name: "username/#{first_project_name}"
+        ),
+        enabled: true,
+        project_name: first_project_name,
+        platform: "ios",
+        lane: "default",
+        artifact_provider: FastlaneCI::LocalArtifactProvider.new,
+        job_triggers: []
+      }
+    ]
+  end
+end

--- a/spec/stub_helpers.rb
+++ b/spec/stub_helpers.rb
@@ -37,6 +37,7 @@ module StubHelpers
     allow_any_instance_of(FastlaneCI::GitRepo).to receive(:git_config).and_return(fake_git_config)
     allow_any_instance_of(FastlaneCI::GitRepo).to receive(:repo_auth).and_return(fake_repo_auth)
     allow_any_instance_of(FastlaneCI::GitRepo).to receive(:clone)
+    allow_any_instance_of(FastlaneCI::GitRepo).to receive(:local_folder).and_return(fixture_path)
   end
 
   def stub_services


### PR DESCRIPTION
### Changes
- Added specs for the `JSONProjectDataSource` configuration data source.
- `update_project!` and `delete_project!` in the `JSONProjectDataSource` now return `true` if they complete successfuly, like the `JSONUserDataSource`.