### PR TITLE
Fix git execute error when committing on a machine which has no git global config

### DIFF
--- a/app/shared/models/git_repo.rb
+++ b/app/shared/models/git_repo.rb
@@ -245,6 +245,9 @@ module FastlaneCI
           retry if (retry_count += 1) < 5
           raise "Exceeded retry count for #{__method__}. Exception: #{aex}"
         end
+        # Git will not allow to commit with an empty name or empty email
+        # (e.g. on a shared box which has no global git config)
+        setup_author(full_name: repo_auth.full_name, username: repo_auth.username)
         repo = git
         if repo.index.writable?
           # Things are looking legit so far


### PR DESCRIPTION
Fixes the  following error when it tries to sync changes to `fastlane-ci-config` repo:

```
*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'root@abcaefc25291.(none)')
```