### PR TITLE
Support any hostname that points to localhost

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 task :dev do
-  sh "bundle exec rackup -p 8080 --env development"
+  sh "bundle exec rackup -o 0.0.0.0 -p 8080 --env development"
 end
 
 task :prod do


### PR DESCRIPTION
Fixes #210.

Enable this in order to run fastlane.ci inside a VM and allow accessing
to it from the host machine.