### PR TITLE
Support deployment using Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ fastlane/report.xml
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Vagrant VM
+.vagrant

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Currently, Docker deployment is for Linux projects only.
 1. `docker-compose up`
 1. Up at running at [localhost:8080](http://localhost:8080/)
 
+## Using `fastlane.ci` with Vagrant
+1. Install Vagrant: `brew cask install vagrant`
+1. Install VirtualBox: `brew cask install virtualbox`
+1. `vagrant up`. You will be asked for your password.
+1. `vagrant ssh`
+1. `cd /fastlane-ci`
+1. `bundle exec rake dev`
+1. Up at running at [localhost:8080](http://localhost:8080/)
+
 ### Configure `fastlane.ci`
 
 1. Visit [localhost:8080](http://localhost:8080/)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,37 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "monsenso/macos-10.13"
+  config.vm.box_version = "1.0.0"
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+
+  # Sync the fastlane-ci folder to the guest VM. The type of the synced folder
+  # has to be rsync or nfs, because BSD-based guests do not support the
+  # VirtualBox filesystem at this time.
+  config.vm.synced_folder ".", "/fastlane-ci", type: "nfs"
+
+  # NFS requires a host-only network to be created in order to work. This
+  # requires admin password every time you run `vagrant up`.
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  config.vm.provider "virtualbox" do |vb|
+    # Hide the VirtualBox GUI when booting the machine
+    vb.gui = false
+
+    # Customize the amount of memory on the VM
+    vb.memory = "8192"
+
+    # Because the USB 2.0 controller state is part of the saved VM state, the
+    # VM cannot be started with USB 2.0 support on.
+    vb.customize ["modifyvm", :id, "--usb", "on"]
+    vb.customize ["modifyvm", :id, "--usbehci", "off"]
+  end
+
+  # Bootstrap the VM
+  config.vm.provision "shell",
+    path: "./vagrant-provision.sh",
+    privileged: false
+end

--- a/vagrant-provision.sh
+++ b/vagrant-provision.sh
@@ -1,0 +1,19 @@
+if [ ! -d /usr/local/Homebrew/.git ]; then
+  echo "==> Installing Homebrew ..."
+  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  brew doctor
+else
+  echo "==> Homebrew is already installed"
+fi
+
+echo "==> Installing node and npm ..."
+brew install node
+
+echo "==> Installing Bundler ..."
+sudo gem install bundler -NV
+
+echo "==> Installing all dependencies ..."
+cd /fastlane-ci
+bundle install
+npm install
+npm run build


### PR DESCRIPTION
Since Docker does not support macOS guests, this allows deploying an isolated instance that can be used to build iOS projects.