### PR TITLE
Don't strip value of ENV variable

### DIFF
--- a/app/services/environment_variable_service.rb
+++ b/app/services/environment_variable_service.rb
@@ -40,7 +40,6 @@ module FastlaneCI
 
     def create_environment_variable!(key: nil, value: nil)
       key.strip!
-      value.strip!
 
       if environment_variable_data_source.find_environment_variable(environment_variable_key: key).nil?
         logger.info("Creating ENV variable with key #{key}")


### PR DESCRIPTION
This would cause errors if e.g. a password is passed via an ENV variable and it starts or end with a space