### PR TITLE
Revert "Allow JSONConvertible to decode objects with required initialization parameters (#833)"

### DIFF
--- a/app/shared/json_convertible.rb
+++ b/app/shared/json_convertible.rb
@@ -70,7 +70,7 @@ module FastlaneCI
     # add these as class methods
     module ClassMethods
       def from_json!(json_object)
-        instance, json_object = _initialize_using!(json_object)
+        instance = new
         json_object.each do |var, val|
           # If we encounter with a value that is represented by an array, iterate over it.
           if val.kind_of?(Array)
@@ -223,20 +223,6 @@ module FastlaneCI
         end
 
         return var_name, var_value
-      end
-
-      def _initialize_using!(json_object)
-        instance = allocate
-        required_init_params = instance.method(:initialize).parameters
-                                       .select { |arg| arg[0] == :keyreq }
-                                       .map(&:last)
-        unless (required_init_params - json_object.keys).empty?
-          raise "Required initialization parameters not found in the object: #{json_object}"
-        end
-        init_params_hash = json_object.select { |key, _value| required_init_params.include?(key) }
-        instance.send(:initialize, init_params_hash)
-        clean_json_object = json_object.reject { |key| required_init_params.include?(key) }
-        return instance, clean_json_object
       end
     end
   end

--- a/spec/shared/json_convertible_spec.rb
+++ b/spec/shared/json_convertible_spec.rb
@@ -77,29 +77,6 @@ class MockMultipleAttributeArrayJSONConvertible
   end
 end
 
-class MockJSONConvertibleWithRequiredParams
-  include FastlaneCI::JSONConvertible
-
-  attr_reader :one_attribute
-
-  def initialize(one_attribute:)
-    @one_attribute = one_attribute
-  end
-end
-
-class MockJSONConvertibleWithMixedParams
-  include FastlaneCI::JSONConvertible
-
-  attr_reader :one_attribute
-
-  attr_accessor :other_attribute
-
-  def initialize(one_attribute:, other_attribute: nil)
-    @one_attribute = one_attribute
-    self.other_attribute = other_attribute
-  end
-end
-
 module FastlaneCI
   describe JSONConvertible do
     let (:mock_object) { MockJSONConvertible.new(one_attribute: "Hello", other_attribute: Time.at(0)) }
@@ -256,24 +233,6 @@ module FastlaneCI
       expect(dictionary_object).to eql({ "one_attribute" => "World", "other_attribute" => Time.at(10), "array_attribute" => [
                                          { "one_attribute" => "Inner World", "other_attribute" => Time.at(100) }
                                        ] })
-    end
-
-    it "Allows to decode objects with required initialization parameters" do
-      object_dictionary = { one_attribute: "rocket" }
-      object = MockJSONConvertibleWithRequiredParams.from_json!(object_dictionary)
-      expect(object.one_attribute).to eql("rocket")
-    end
-
-    it "Raises exception when required initialization parameters are not found" do
-      object_dictionary = { not_the_attribute: "taco" }
-      expect { MockJSONConvertibleWithRequiredParams.from_json!(object_dictionary) }.to(raise_exception)
-    end
-
-    it "Allows to decode objects with mixed initialization parameters" do
-      object_dictionary = { one_attribute: "cat", other_attribute: "dog" }
-      object = MockJSONConvertibleWithMixedParams.from_json!(object_dictionary)
-      expect(object.one_attribute).to eql("cat")
-      expect(object.other_attribute).to eql("dog")
     end
   end
 end


### PR DESCRIPTION
This reverts commit 12fac6de24eeb59fdd0082d916775970ed73b465.