### PR TITLE
 Allow JSONConvertible to decode objects with required initialization parameters (v2.0)

### DIFF
--- a/app/shared/json_convertible.rb
+++ b/app/shared/json_convertible.rb
@@ -234,7 +234,11 @@ module FastlaneCI
           raise "Required initialization parameters not found in the object: #{json_object}"
         end
         init_params_hash = json_object.select { |key, _value| required_init_params.include?(key) }
-        instance.send(:initialize, init_params_hash)
+        if instance.method(:initialize).parameters.empty?
+          instance.send(:initialize)
+        else
+          instance.send(:initialize, init_params_hash)
+        end
         clean_json_object = json_object.reject { |key| required_init_params.include?(key) }
         return instance, clean_json_object
       end

--- a/app/shared/json_convertible.rb
+++ b/app/shared/json_convertible.rb
@@ -233,7 +233,7 @@ module FastlaneCI
         unless (required_init_params - json_object.keys).empty?
           raise "Required initialization parameters not found in the object: #{json_object}"
         end
-        init_params_hash = json_object.select { |key, value| required_init_params.include?(key) }
+        init_params_hash = json_object.select { |key, _value| required_init_params.include?(key) }
         instance.send(:initialize, init_params_hash)
         clean_json_object = json_object.reject { |key| required_init_params.include?(key) }
         return instance, clean_json_object

--- a/spec/shared/json_convertible_spec.rb
+++ b/spec/shared/json_convertible_spec.rb
@@ -100,6 +100,15 @@ class MockJSONConvertibleWithMixedParams
   end
 end
 
+class MockJSONConvertibleWithNoParams
+  include FastlaneCI::JSONConvertible
+
+  attr_accessor :one_attribute
+
+  def initialize
+  end
+end
+
 module FastlaneCI
   describe JSONConvertible do
     let (:mock_object) { MockJSONConvertible.new(one_attribute: "Hello", other_attribute: Time.at(0)) }
@@ -274,6 +283,12 @@ module FastlaneCI
       object = MockJSONConvertibleWithMixedParams.from_json!(object_dictionary)
       expect(object.one_attribute).to eql("cat")
       expect(object.other_attribute).to eql("dog")
+    end
+
+    it "Allows to decode objects with no initialization parameters" do
+      object_dictionary = { one_attribute: "robot" }
+      object = MockJSONConvertibleWithNoParams.from_json!(object_dictionary)
+      expect(object.one_attribute).to eql("robot")
     end
   end
 end

--- a/spec/shared/json_convertible_spec.rb
+++ b/spec/shared/json_convertible_spec.rb
@@ -87,6 +87,19 @@ class MockJSONConvertibleWithRequiredParams
   end
 end
 
+class MockJSONConvertibleWithMixedParams
+  include FastlaneCI::JSONConvertible
+
+  attr_reader :one_attribute
+
+  attr_accessor :other_attribute
+
+  def initialize(one_attribute:, other_attribute: nil)
+    @one_attribute = one_attribute
+    self.other_attribute = other_attribute
+  end
+end
+
 module FastlaneCI
   describe JSONConvertible do
     let (:mock_object) { MockJSONConvertible.new(one_attribute: "Hello", other_attribute: Time.at(0)) }
@@ -249,6 +262,18 @@ module FastlaneCI
       object_dictionary = { one_attribute: "rocket" }
       object = MockJSONConvertibleWithRequiredParams.from_json!(object_dictionary)
       expect(object.one_attribute).to eql("rocket")
+    end
+
+    it "Raises exception when required initialization parameters are not found" do
+      object_dictionary = { not_the_attribute: "taco" }
+      expect { MockJSONConvertibleWithRequiredParams.from_json!(object_dictionary) }.to(raise_exception)
+    end
+
+    it "Allows to decode objects with mixed initialization parameters" do
+      object_dictionary = { one_attribute: "cat", other_attribute: "dog" }
+      object = MockJSONConvertibleWithMixedParams.from_json!(object_dictionary)
+      expect(object.one_attribute).to eql("cat")
+      expect(object.other_attribute).to eql("dog")
     end
   end
 end

--- a/spec/shared/json_convertible_spec.rb
+++ b/spec/shared/json_convertible_spec.rb
@@ -77,6 +77,16 @@ class MockMultipleAttributeArrayJSONConvertible
   end
 end
 
+class MockJSONConvertibleWithRequiredParams
+  include FastlaneCI::JSONConvertible
+
+  attr_reader :one_attribute
+
+  def initialize(one_attribute:)
+    @one_attribute = one_attribute
+  end
+end
+
 module FastlaneCI
   describe JSONConvertible do
     let (:mock_object) { MockJSONConvertible.new(one_attribute: "Hello", other_attribute: Time.at(0)) }
@@ -233,6 +243,12 @@ module FastlaneCI
       expect(dictionary_object).to eql({ "one_attribute" => "World", "other_attribute" => Time.at(10), "array_attribute" => [
                                          { "one_attribute" => "Inner World", "other_attribute" => Time.at(100) }
                                        ] })
+    end
+
+    it "Allows to decode objects with required initialization parameters" do
+      object_dictionary = { one_attribute: "rocket" }
+      object = MockJSONConvertibleWithRequiredParams.from_json!(object_dictionary)
+      expect(object.one_attribute).to eql("rocket")
     end
   end
 end


### PR DESCRIPTION
Fixes #860 and adds test case covering the error being raised.