### PR TITLE
redo pending builds on launch

### DIFF
--- a/launch.rb
+++ b/launch.rb
@@ -233,7 +233,7 @@ module FastlaneCI
         # because they could be forks of the main repo, so let's grab all that info
         open_pull_requests = github_service.open_pull_requests(
           repo_full_name: repo_full_name,
-          branches: branches_to_check
+          branches: nil # branches_to_check should be used only for commit-trigger checking, not pr-trigger checking.
         )
 
         # Enqueue each pending build rerun in an asynchronous task queue

--- a/launch.rb
+++ b/launch.rb
@@ -224,17 +224,9 @@ module FastlaneCI
         end
 
         repo_full_name = project.repo_config.full_name
-        branches_to_check = project.job_triggers
-                                   .select { |trigger| trigger.type == FastlaneCI::JobTrigger::TRIGGER_TYPE[:commit] }
-                                   .map(&:branch)
-                                   .uniq
-
         # We have a list of shas that need rebuilding, but we need to know which repo_full_name they belong to
         # because they could be forks of the main repo, so let's grab all that info
-        open_pull_requests = github_service.open_pull_requests(
-          repo_full_name: repo_full_name,
-          branches: nil # branches_to_check should be used only for commit-trigger checking, not pr-trigger checking.
-        )
+        open_pull_requests = github_service.open_pull_requests(repo_full_name: repo_full_name)
 
         # Enqueue each pending build rerun in an asynchronous task queue
         pending_build_shas_needing_rebuilds.each do |sha|
@@ -289,15 +281,9 @@ module FastlaneCI
         # we don't support anything other than GitHub right now
         next unless credential_type == FastlaneCI::ProviderCredential::PROVIDER_CREDENTIAL_TYPES[:github]
 
-        # Collect all the branches from the triggers on this project that are commit-based
-        branches_to_check = project.job_triggers
-                                   .select { |trigger| trigger.type == FastlaneCI::JobTrigger::TRIGGER_TYPE[:commit] }
-                                   .map(&:branch)
-                                   .uniq
-
         repo_full_name = project.repo_config.full_name
         # let's get all commit shas that need a build (no status yet)
-        open_prs = github_service.open_pull_requests(repo_full_name: repo_full_name, branches: branches_to_check)
+        open_prs = github_service.open_pull_requests(repo_full_name: repo_full_name)
 
         # no commit shas need to be switched to `pending` state
         next unless open_prs.count > 0


### PR DESCRIPTION
Passing in a list of branches is actually not what we wanted to do for PR checking. That only should be used when checking for commits. 