### PR TITLE
new authenticated base class for API controllers.

### DIFF
--- a/app/features-json/api_controller.rb
+++ b/app/features-json/api_controller.rb
@@ -1,0 +1,125 @@
+require "sinatra/base"
+require "sinatra/reloader"
+require "jwt"
+
+require_relative "../services/services"
+require_relative "json_params"
+
+module FastlaneCI
+  ##
+  # APIController is designed for state-less API requests servicing the Angular front-end
+  #
+  # Requests are expected to be application/json.
+  # The `params` method can be used to access the JSON body as if it were a hash
+  #
+  # Authentication is enabled by default. It can be disabled for the entire controller,
+  # and individual endpoints can be give an authentication conditions.
+  #
+  # Usage
+  # ===
+  # Subclass the APIController for any controller that you expect JSON requests and responses.
+  #
+  # Settings
+  # ===
+  #
+  # The following settings are provided to subclasses of APIController:
+  #
+  # * `authentiation`- boolean value that makes every request check authentication in a before filter.
+  #    Disable with: `disable :authentication`. Enabled by default.
+  # * `authenticate_via` - which authentication scheme to use. `:jwt` by default.
+  # * `jwt_secret` - The key to use in decoding JWT tokens.
+  #
+  # Per-route Authentication
+  # ===
+  # If you disable authentication for the whole controller, you can enable it on a per-route basis using
+  # a route condition like this:
+  #
+  #   get '/private', authenticate: :jwt do
+  #     json({message: 'secret'})
+  #   end
+  #
+  # User authentication
+  # ===
+  # This controller also provides a few helper methods that return information about the current user
+  # * `user_id` - the user id encoded in the jwt.
+  # * `current_user` - the user model fetched from the data service, or nil if it cannot be found.
+  # * `user_logged_in?` - boolean whether the user is found.
+  #
+  class APIController < Sinatra::Base
+    include JSONParams
+    include Logging
+
+    configure(:development) do
+      register Sinatra::Reloader
+    end
+
+    # to disabled authentication for the entire controller use:
+    # disable(:authentication)
+    set(:authentication, true)
+
+    # the default authentication scheme. We only support `:jwt` at this time.
+    set(:authenticate_via, :jwt)
+
+    # the condition can be added to any route
+    set(:authenticate) do |auth_type|
+      condition { authenticate!(via: auth_type) }
+    end
+
+    # the JWT secret uses the fastlane encryption key
+    set(:jwt_secret, FastlaneCI.dot_keys.encryption_key)
+
+    before do
+      next unless settings.authentication?
+      authenticate!(via: settings.authenticate_via)
+    end
+
+    helpers do
+      # Decode the JWT or halt.
+      def jwt
+        puts(request)
+        authorization = request.env["HTTP_AUTHORIZATION"]
+        bearer_token = authorization && authorization.slice(7..-1) # strip off the `Bearer `
+
+        JWT.decode(
+          bearer_token,
+          settings.jwt_secret,
+          true, # Validate Issuer?
+          { verify_iss: true, verify_iat: true, algorithm: "HS256", iss: "fastlane.ci" } # Options
+        )
+      rescue JWT::InvalidIssuerError
+        halt(403, { "Content-Type" => "text/plain" }, "The token does not have a valid issuer.")
+      rescue JWT::InvalidIatError
+        halt(403, { "Content-Type" => "text/plain" }, 'The token does not have a valid "issued at" time.')
+      rescue JWT::ExpiredSignature
+        halt(401, { "Content-Type" => "text/plain" }, "The token has expired.")
+      rescue JWT::DecodeError
+        halt(401, { "Content-Type" => "text/plain" }, "A token must be passed.")
+      end
+
+      # dispatch to the different authentication schemes available.
+      def authenticate!(via:)
+        case via
+        when :jwt
+          jwt
+        else
+          raise "`#{settings.authenticate_via}` is an un-supported authentication scheme."
+        end
+      end
+
+      # if more `authenticate_via`` options get added, change this method
+      def user_id
+        payload = authenticate!(via: :jwt)
+        return payload["user"]
+      end
+
+      # provides access to the User model.
+      def current_user
+        @current_user ||= FastlaneCI::Services.user_service.find_user(id: user_id)
+      end
+
+      def user_logged_in?
+        current_user != nil
+      end
+    end
+  end
+end

--- a/app/features-json/api_controller.rb
+++ b/app/features-json/api_controller.rb
@@ -101,7 +101,7 @@ module FastlaneCI
         when :jwt
           return jwt
         else
-          raise "`#{settings.authenticate_via}` is an un-supported authentication scheme."
+          raise "`#{via}` is an un-supported authentication scheme."
         end
       end
 

--- a/app/features-json/api_controller.rb
+++ b/app/features-json/api_controller.rb
@@ -24,7 +24,7 @@ module FastlaneCI
   #
   # The following settings are provided to subclasses of APIController:
   #
-  # * `authentiation`- boolean value that makes every request check authentication in a before filter.
+  # * `authentication`- boolean value that makes every request check authentication in a before filter.
   #    Disable with: `disable :authentication`. Enabled by default.
   # * `authenticate_via` - which authentication scheme to use. `:jwt` by default.
   # * `jwt_secret` - The key to use in decoding JWT tokens.
@@ -34,8 +34,8 @@ module FastlaneCI
   # If you disable authentication for the whole controller, you can enable it on a per-route basis using
   # a route condition like this:
   #
-  #   get '/private', authenticate: :jwt do
-  #     json({message: 'secret'})
+  #   get "/private", authenticate: :jwt do
+  #     json({message: "secret"})
   #   end
   #
   # User authentication

--- a/app/features-json/api_controller.rb
+++ b/app/features-json/api_controller.rb
@@ -76,7 +76,6 @@ module FastlaneCI
     helpers do
       # Decode the JWT or halt.
       def jwt
-        puts(request)
         authorization = request.env["HTTP_AUTHORIZATION"]
         bearer_token = authorization && authorization.slice(7..-1) # strip off the `Bearer `
 
@@ -100,7 +99,7 @@ module FastlaneCI
       def authenticate!(via:)
         case via
         when :jwt
-          jwt
+          return jwt
         else
           raise "`#{settings.authenticate_via}` is an un-supported authentication scheme."
         end

--- a/app/features-json/api_controller.rb
+++ b/app/features-json/api_controller.rb
@@ -69,8 +69,9 @@ module FastlaneCI
     set(:jwt_secret, FastlaneCI.dot_keys.encryption_key)
 
     before do
-      next unless settings.authentication?
-      authenticate!(via: settings.authenticate_via)
+      if settings.authentication?
+        authenticate!(via: settings.authenticate_via)
+      end
     end
 
     helpers do

--- a/app/features-json/api_controller.rb
+++ b/app/features-json/api_controller.rb
@@ -80,12 +80,14 @@ module FastlaneCI
         authorization = request.env["HTTP_AUTHORIZATION"]
         bearer_token = authorization && authorization.slice(7..-1) # strip off the `Bearer `
 
-        JWT.decode(
+        payload, _header = JWT.decode(
           bearer_token,
           settings.jwt_secret,
           true, # Validate Issuer?
           { verify_iss: true, verify_iat: true, algorithm: "HS256", iss: "fastlane.ci" } # Options
         )
+
+        return payload
       rescue JWT::InvalidIssuerError
         halt(403, { "Content-Type" => "text/plain" }, "The token does not have a valid issuer.")
       rescue JWT::InvalidIatError

--- a/app/features-json/json_params.rb
+++ b/app/features-json/json_params.rb
@@ -2,17 +2,9 @@ require "sinatra/json"
 
 module FastlaneCI
   ##
-  # JSONController mixin allows `params` method to return the params from the parsed request body
+  # JSONParams mixin allows `params` method to return the params from the parsed request body
   #
-  module JSONController
-    def self.included(mod)
-      mod.before do
-        if request.content_type != "application/json"
-          logger.warn("JSON Controller expected json requests, but got `#{request.content_type}`")
-        end
-      end
-    end
-
+  module JSONParams
     def params
       return @json_params if defined?(@json_params)
 

--- a/app/features-json/login_json_controller.rb
+++ b/app/features-json/login_json_controller.rb
@@ -1,7 +1,7 @@
 require_relative "../shared/controller_base"
 require_relative "../services/user_service"
 require_relative "../services/dot_keys_variable_service"
-require_relative "json_controller"
+require_relative "json_params"
 
 require "jwt"
 require "json"
@@ -9,7 +9,7 @@ require "json"
 module FastlaneCI
   # Controller responsible of handling the login process using JWT token.
   class LoginJSONController < ControllerBase
-    include JSONController
+    include JSONParams
 
     HOME = "/api/login"
 

--- a/spec/features-json/api_controller_spec.rb
+++ b/spec/features-json/api_controller_spec.rb
@@ -1,0 +1,126 @@
+require "spec_helper"
+require "app/features-json/api_controller"
+
+describe FastlaneCI::APIController do
+  ##
+  # some example usages of APIController, with default authentication and with authentication disabled.
+  #
+  let(:bearer_token) do
+    "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlciI6IjEiLCJpYXQiOjEsImlzcyI6ImZhc3RsYW5lLmNpIn0.m2uYMjhLlRuA2TVr_5c5-xdWjSf3r7Ge0b53-cgJtdg"
+  end
+
+  describe "by default" do
+    class MySecureApiController < FastlaneCI::APIController
+      set(:jwt_secret, "fastlane-ci-test")
+
+      get("/") do
+        json({ message: "ok" })
+      end
+
+      get("/private") do
+        json({ message: "secret" })
+      end
+    end
+
+    let(:app) { MySecureApiController.new }
+
+    describe "unathenticated request" do
+      it "index is not successful" do
+        get("/")
+        expect(last_response).to_not(be_ok)
+        expect(last_response.body).to eq("A token must be passed.")
+      end
+
+      it "private is not successful" do
+        get("/private")
+        expect(last_response).to_not(be_ok)
+        expect(last_response.body).to eq("A token must be passed.")
+      end
+    end
+
+    describe "authenticated request" do
+      before do
+        header("Authorization", bearer_token)
+      end
+
+      it "index is successful" do
+        get("/")
+        expect(last_response).to be_ok
+        expect(last_response.body).to eq('{"message":"ok"}')
+      end
+
+      it "private is successful" do
+        get("/private")
+        expect(last_response).to be_ok
+        expect(last_response.body).to eq('{"message":"secret"}')
+      end
+    end
+  end
+
+  describe "with authentication disabled" do
+    class MyMixedAuthApiController < FastlaneCI::APIController
+      set(:jwt_secret, "fastlane-ci-test")
+      disable(:authentication)
+
+      get("/") do
+        json({ message: "ok" })
+      end
+
+      get("/private", authenticate: :jwt) do
+        json({ message: "secret" })
+      end
+    end
+
+    let(:app) { MyMixedAuthApiController.new }
+
+    describe "unathenticated request" do
+      it "index is successful" do
+        get("/")
+        expect(last_response).to be_ok
+        expect(last_response.body).to eq('{"message":"ok"}')
+      end
+
+      it "private is not successful" do
+        get("/private")
+        expect(last_response).to_not(be_ok)
+        expect(last_response.body).to eq("A token must be passed.")
+      end
+    end
+
+    describe "authenticated request" do
+      before do
+        header("Authorization", bearer_token)
+      end
+
+      it "index is successful" do
+        get("/")
+        expect(last_response).to be_ok
+        expect(last_response.body).to eq('{"message":"ok"}')
+      end
+
+      it "private is successful" do
+        get("/private")
+        expect(last_response).to be_ok
+        expect(last_response.body).to eq('{"message":"secret"}')
+      end
+    end
+  end
+
+  describe "jwt authentication" do
+    xit "will successfully decode a token"
+    xit "will halt with an error if the token is not valid"
+  end
+
+  describe "user authentication methods" do
+    let(:app) { FastlaneCI::APIController.new }
+
+    before do
+      app.settings.jwt_secret = "fastlane-ci-test"
+    end
+
+    xit "returns the `user` from the JWT token" do
+      header("Authorization", bearer_token)
+      expect(app.helpers.user_id).to eq("abc123")
+    end
+  end
+end


### PR DESCRIPTION
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to refernece the issue you're solving

Context
---
fastlane.ci is developing an Angular SPA for it's UI. The app will talk to the backend via JSON APIs and will use JWT for it's authentication.

Why a new API Controller base class vs `ControllerBase` ?

API requests are very different from regular browser based requests. The `ControllerBase` assumes we are serving to regular browser traffic. For APIs we want:
* no flash
* no templates and views
* no session
* JSON requests and responses by default

For these reasons, it makes sense to just create a new base class from `Sinatra::Base` than to try to make `ControllerBase` more generic.

Why not check authentication in a Rack middleware?

Using a Rack middleware makes selective authentication on endpoints tricky. We want security by default for a given controller, but we also want to allow controllers that have some endpoints secure and some public. It feels brittle to couple the authentication to specific routes or route patterns. We also want to make sure it's easy for developers to do the right thing. For example, if a developer changes a route for an endpoint, they shouldn't have to remember to update an authentication route list in another file.

Check the specs for some example usage.

Remaining tasks
- [x] add specs for user authentication methods `current_user` and `user_id`
