### PR TITLE
add cop for pessimistic version locking

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - ./lib/bundler_cop.rb
+
 # We're not joking around
 Style/Documentation:
   Enabled: true

--- a/lib/bundler_cop.rb
+++ b/lib/bundler_cop.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Bundler
+      ##
+      # discourage usage of pessimistic version locking
+      #
+      # discussed here: https://github.com/fastlane/ci/pull/905
+      class PessimisticVersionMatcher < Cop
+        MSG = "Please use `<` and `>=` instead of `~>`."
+
+        def_node_matcher :pessimistic_lock?, <<-PATTERN
+          (send nil? :gem _ (str $#pessimistic_lock_string?) ...)
+        PATTERN
+
+        def pessimistic_lock_string?(version_string)
+          version_string.start_with?("~>")
+        end
+
+        def on_send(node)
+          pessimistic_lock?(node) do |source|
+            message = format(MSG, source: source)
+
+            add_offense(
+              node,
+              message: message
+            )
+          end
+        end
+
+        private
+
+        def range(node)
+          range_between(node.begin, node.end)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a custom cop that yells at us for adding pessimistic version locking
Prevents PRs like https://github.com/fastlane/ci/pull/905 having to happen.