### PR TITLE
Add Project Dialog is form with proper validation

### DIFF
--- a/app/features-json/project_json_controller.rb
+++ b/app/features-json/project_json_controller.rb
@@ -102,7 +102,7 @@ module FastlaneCI
 
       repo.checkout_branch(branch: branch)
 
-      return project
+      return ProjectSummaryViewModel.new(project: project, latest_build: project.builds.first).to_json
     end
   end
 end

--- a/web/app/common/test_helpers/mock_project_data.ts
+++ b/web/app/common/test_helpers/mock_project_data.ts
@@ -50,6 +50,9 @@ export const mockProjectListResponse: ProjectSummaryResponse[] = [
 export const mockProjectSummaryList =
     mockProjectListResponse.map((response) => new ProjectSummary(response));
 
+export const mockProjectSummary =
+    new ProjectSummary(mockProjectSummaryResponse);
+
 export const mockProjectResponse: ProjectResponse = {
   id: '12',
   name: 'the most coolest project',

--- a/web/app/dashboard/add-project-dialog/add-project-dialog.component.html
+++ b/web/app/dashboard/add-project-dialog/add-project-dialog.component.html
@@ -1,54 +1,56 @@
 <fci-form-spinner *ngIf="isLoadingRepositories || isAddingProject"></fci-form-spinner>
 <div mat-dialog-title>Add a project</div>
-<div mat-dialog-content>
-  <div class="fci-dialog-form-section fci-input-container">
-    <div class="fci-section-title">For my project</div>
-    <input placeholder="Project Name" [(ngModel)]="project.project_name">
-  </div>
-  <div class="fci-dialog-form-section fci-input-container">
-    <div class="fci-section-title">With the repo</div>
-    <mat-select class="fci-repo-select" [(value)]="project.repo_name" (selectionChange)="loadRepoLanes()">
-      <mat-option *ngFor="let repo of repositories" [value]="repo.fullName">
-        {{repo.fullName}}
-      </mat-option>
-    </mat-select>
-  </div>
-  <div class="fci-dialog-form-section fci-input-container">
-    <div class="fci-section-title">I want to run the lane</div>
-    <div class="fci-lane-form">
-      <mat-select class="fci-lane-select" [(value)]="project.lane" [disabled]="isLoadingLanes || lanes.length === 0">
-        <mat-option *ngFor="let lane of lanes" [value]="lane">
-          {{lane}}
+<form [formGroup]="form" (ngSubmit)="addProject()">
+  <div mat-dialog-content>
+    <div class="fci-dialog-form-section fci-input-container">
+      <div class="fci-section-title">For my project</div>
+      <input #projectNameControl formControlName="name" placeholder="Project Name">
+    </div>
+    <div class="fci-dialog-form-section fci-input-container">
+      <div class="fci-section-title">With the repo</div>
+      <mat-select formControlName="repo" class="fci-repo-select">
+        <mat-option *ngFor="let repo of repositories" [value]="repo.fullName">
+          {{repo.fullName}}
         </mat-option>
       </mat-select>
-      <mat-spinner *ngIf="isLoadingLanes" mode="indeterminate" diameter="25"></mat-spinner>
+    </div>
+    <div class="fci-dialog-form-section fci-input-container">
+      <div class="fci-section-title">I want to run the lane</div>
+      <div class="fci-lane-form">
+        <mat-select formControlName="lane" class="fci-lane-select">
+          <mat-option *ngFor="let lane of lanes" [value]="lane">
+            {{lane}}
+          </mat-option>
+        </mat-select>
+        <mat-spinner *ngIf="isLoadingLanes" mode="indeterminate" diameter="25"></mat-spinner>
+      </div>
+    </div>
+    <div class="fci-dialog-form-section fci-input-container">
+      <div class="fci-section-title">With builds being triggered</div>
+      <mat-select formControlName="trigger" class="fci-trigger-select">
+        <mat-option *ngFor="let triggerOption of TRIGGER_OPTIONS" [value]="triggerOption.value">
+          {{triggerOption.viewValue}}
+        </mat-option>
+      </mat-select>
+      <ng-container *ngIf="form.get('trigger').value === 'nightly'">
+        <span class="fci-at-time">at</span>
+        <mat-select formControlName="hour" class="fci-hour-select">
+          <mat-option *ngFor="let hour of HOURS" [value]="hour">
+            {{hour}}
+          </mat-option>
+        </mat-select>
+        <mat-select formControlName="amPm" class="fci-am-pm-select">
+          <mat-option value="AM">AM</mat-option>
+          <mat-option value="PM">PM</mat-option>
+        </mat-select>
+      </ng-container>
     </div>
   </div>
-  <div class="fci-dialog-form-section fci-input-container">
-    <div class="fci-section-title">With builds being triggered</div>
-    <mat-select class="fci-trigger-select" [(value)]="project.trigger_type">
-      <mat-option *ngFor="let triggerOption of TRIGGER_OPTIONS" [value]="triggerOption.value">
-        {{triggerOption.viewValue}}
-      </mat-option>
-    </mat-select>
-    <ng-container *ngIf="project.trigger_type === 'nightly'">
-      <span class="fci-at-time">at</span>
-      <mat-select class="fci-hour-select" [(value)]="timeSelectorData.hour">
-        <mat-option *ngFor="let hour of HOURS" [value]="hour">
-          {{hour}}
-        </mat-option>
-      </mat-select>
-      <mat-select class="fci-am-pm-select" [(value)]="timeSelectorData.isAm">
-        <mat-option [value]="true">AM</mat-option>
-        <mat-option [value]="false">PM</mat-option>
-      </mat-select>
-    </ng-container>
+  <div mat-dialog-actions>
+    <button mat-button (click)="closeDialog()" type="button">Close</button>
+    <button mat-raised-button color="primary" type="submit" [disabled]="!form.valid">Add Project</button>
   </div>
-</div>
-<div mat-dialog-actions>
-  <button mat-button (click)="closeDialog()">Close</button>
-  <button mat-raised-button color="primary" (click)="addProject()">Add Project</button>
-</div>
-<button mat-icon-button class="fci-dialog-icon-close-button" (click)="closeDialog()">
+</form>
+<button mat-icon-button class="fci-dialog-icon-close-button" (click)="closeDialog()" type="button">
   <mat-icon>close</mat-icon>
 </button>

--- a/web/app/dashboard/add-project-dialog/add-project-dialog.component.spec.ts
+++ b/web/app/dashboard/add-project-dialog/add-project-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import {CommonModule} from '@angular/common';
 import {async, ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
-import {FormsModule} from '@angular/forms';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule, MatDialogModule, MatDialogRef, MatIconModule, MatProgressSpinnerModule, MatSelectModule} from '@angular/material';
 import {MAT_DIALOG_DATA} from '@angular/material';
 import {By} from '@angular/platform-browser';
@@ -9,10 +9,10 @@ import {Subject} from 'rxjs/Subject';
 
 import {FormSpinnerModule} from '../../common/components/form-spinner/form-spinner.module';
 import {mockLanes, mockLanesResponse} from '../../common/test_helpers/mock_lane_data';
-import {mockProject} from '../../common/test_helpers/mock_project_data';
+import {mockProjectSummary} from '../../common/test_helpers/mock_project_data';
 import {mockRepositoryList} from '../../common/test_helpers/mock_repository_data';
 import {Lane} from '../../models/lane';
-import {Project} from '../../models/project';
+import {ProjectSummary} from '../../models/project_summary';
 import {Repository} from '../../models/repository';
 import {DataService} from '../../services/data.service';
 
@@ -22,20 +22,19 @@ describe('AddProjectDialogComponent', () => {
   let component: AddProjectDialogComponent;
   let fixture: ComponentFixture<AddProjectDialogComponent>;
   let reposSubject: Subject<Repository[]>;
-  let projectSubject: Subject<Project>;
+  let projectSubject: Subject<ProjectSummary>;
   let lanesSubject: Subject<Lane[]>;
   let dataService: jasmine.SpyObj<Partial<DataService>>;
   let projectNameEl: HTMLInputElement;
   let repoSelectEl: HTMLElement;
   let laneSelectEl: HTMLElement;
   let triggerSelectEl: HTMLElement;
-  let addProjectButtonEl: HTMLButtonElement;
   let dialogRef:
       jasmine.SpyObj<Partial<MatDialogRef<AddProjectDialogComponent>>>;
 
   beforeEach(async(() => {
     reposSubject = new Subject<Repository[]>();
-    projectSubject = new Subject<Project>();
+    projectSubject = new Subject<ProjectSummary>();
     lanesSubject = new Subject<Lane[]>();
     dataService = {
       addProject:
@@ -58,7 +57,7 @@ describe('AddProjectDialogComponent', () => {
           ],
           imports: [
             MatDialogModule, MatButtonModule, MatSelectModule, MatIconModule,
-            CommonModule, FormsModule, FormSpinnerModule,
+            CommonModule, ReactiveFormsModule, FormSpinnerModule,
             MatProgressSpinnerModule, BrowserAnimationsModule
           ]
         })
@@ -77,8 +76,6 @@ describe('AddProjectDialogComponent', () => {
         fixture.debugElement.query(By.css('.fci-lane-select')).nativeElement;
     triggerSelectEl =
         fixture.debugElement.query(By.css('.fci-trigger-select')).nativeElement;
-    addProjectButtonEl =
-        fixture.debugElement.query(By.css('button.mat-primary')).nativeElement;
   }));
 
   it('Should close dialog when close button is clicked', () => {
@@ -93,6 +90,33 @@ describe('AddProjectDialogComponent', () => {
     expect(dialogRef.close).toHaveBeenCalled();
   });
 
+  describe('initialization', () => {
+    it('should enable controls once repo data is loaded', async(() => {
+         expect(component.form.get('repo').enabled).toBe(false);
+         expect(component.form.get('name').enabled).toBe(false);
+         expect(component.form.get('trigger').enabled).toBe(false);
+
+         // Load Repos
+         reposSubject.next(mockRepositoryList);
+
+         expect(component.form.get('repo').enabled).toBe(true);
+         expect(component.form.get('name').enabled).toBe(true);
+         expect(component.form.get('trigger').enabled).toBe(true);
+       }));
+
+    it('should enable lane once lane data is loaded', async(() => {
+         expect(component.form.get('lane').enabled).toBe(false);
+
+         // Load Repos and Lanes
+         reposSubject.next(mockRepositoryList);
+         lanesSubject.next(mockLanes);
+
+         expect(component.form.get('repo').enabled).toBe(true);
+         expect(component.form.get('name').enabled).toBe(true);
+         expect(component.form.get('trigger').enabled).toBe(true);
+       }));
+  });
+
   describe('repo, lane, project name form controls', () => {
     beforeEach(() => {
       // Load Repos
@@ -100,13 +124,10 @@ describe('AddProjectDialogComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should two way bind the project name input', async(() => {
-         const projectInput = fixture.debugElement.query(
-             By.css('input[placeholder="Project Name"]'));
-         component.project.project_name = 'ProjectX';
+    it('should bind the project name input', async(() => {
+         component.form.patchValue({'name': 'ProjectX'});
          fixture.detectChanges();
 
-         // ngModel is async, need to wait for it to stabilize
          fixture.whenStable().then(() => {
            expect(projectNameEl.value).toBe('ProjectX');
 
@@ -114,17 +135,17 @@ describe('AddProjectDialogComponent', () => {
            projectNameEl.dispatchEvent(new Event('input'));
            fixture.detectChanges();
 
-           expect(component.project.project_name).toBe('ProjectY');
+           expect(component.form.get('name').value).toBe('ProjectY');
          });
        }));
 
     it('should set repo option', () => {
-      component.project.repo_name = 'fastlane/fastlane';
+      component.form.patchValue({'repo': 'fastlane/fastlane'});
       fixture.detectChanges();
 
       expect(repoSelectEl.textContent).toBe('fastlane/fastlane');
 
-      component.project.repo_name = 'fastlane/ci';
+      component.form.patchValue({'repo': 'fastlane/ci'});
       fixture.detectChanges();
 
       expect(repoSelectEl.textContent).toBe('fastlane/ci');
@@ -136,50 +157,33 @@ describe('AddProjectDialogComponent', () => {
          fixture.detectChanges();
 
          fixture.whenStable().then(() => {
-           component.project.lane = 'ios test';
+           component.form.patchValue({'lane': 'ios test'});
            fixture.detectChanges();
 
            expect(laneSelectEl.textContent).toBe('ios test');
 
-           component.project.lane = 'android beta';
+           component.form.patchValue({'lane': 'android beta'});
            fixture.detectChanges();
 
            expect(laneSelectEl.textContent).toBe('android beta');
          });
        }));
 
-    it('should reload lanes if repo changes', async(() => {
-         // Load Lanes
-         lanesSubject.next(mockLanes);
-         expect(component.isLoadingLanes).toBe(false);
-         expect(component.lanes.length).toBe(2);
+    it('should reload lanes if repo changes', () => {
+      // Load Lanes
+      lanesSubject.next(mockLanes);
+      expect(component.isLoadingLanes).toBe(false);
+      expect(component.lanes.length).toBe(2);
 
-         fixture.whenStable().then(() => {
-           fixture.detectChanges();
-           // Open select options
-           const repoSelectTriggerEl =
-               fixture.debugElement
-                   .query(By.css('.fci-repo-select .mat-select-trigger'))
-                   .nativeElement;
-           repoSelectTriggerEl.click();
-           fixture.detectChanges();
+      // Select the third repo
+      component.form.patchValue({'repo': component.repositories[2]});
 
-           // Select the third option
-           const repoSelectOptionsEl =
-               fixture.debugElement.queryAll(By.css('.mat-option'));
-           expect(repoSelectOptionsEl.length).toBe(3);
-           repoSelectOptionsEl[2].nativeElement.click();
-           fixture.detectChanges();
-
-           expect(repoSelectEl.textContent).toBe('fastlane/onboarding');
-
-           // Assert that the new lanes are loaded
-           expect(component.isLoadingLanes).toBe(true);
-           lanesSubject.next([mockLanes[0]]);
-           expect(component.isLoadingLanes).toBe(false);
-           expect(component.lanes.length).toBe(1);
-         });
-       }));
+      // Assert that the new lanes are loaded
+      expect(component.isLoadingLanes).toBe(true);
+      lanesSubject.next([mockLanes[0]]);
+      expect(component.isLoadingLanes).toBe(false);
+      expect(component.lanes.length).toBe(1);
+    });
 
     it('should show spinner when lanes are loading', () => {
       expect(component.isLoadingLanes).toBe(true);
@@ -207,21 +211,21 @@ describe('AddProjectDialogComponent', () => {
     });
 
     it('should show correct nightly trigger option name', () => {
-      component.project.trigger_type = 'nightly';
+      component.form.patchValue({'trigger': 'nightly'});
       fixture.detectChanges();
 
       expect(triggerSelectEl.textContent).toBe('nightly');
     });
 
     it('should show correct nightly commit and PR option name', () => {
-      component.project.trigger_type = 'commit';
+      component.form.patchValue({'trigger': 'commit'});
       fixture.detectChanges();
 
       expect(triggerSelectEl.textContent).toBe('for every commit and PR');
     });
 
     it('should show time selection when trigger is nightly', () => {
-      component.project.trigger_type = 'nightly';
+      component.form.patchValue({'trigger': 'nightly'});
       fixture.detectChanges();
 
       expect(fixture.debugElement.queryAll(By.css('.fci-hour-select')).length)
@@ -231,7 +235,7 @@ describe('AddProjectDialogComponent', () => {
     });
 
     it('should not show time selection when trigger is not nightly', () => {
-      component.project.trigger_type = 'commit';
+      component.form.patchValue({'trigger': 'commit'});
       fixture.detectChanges();
 
       expect(fixture.debugElement.queryAll(By.css('.fci-hour-select')).length)
@@ -241,7 +245,7 @@ describe('AddProjectDialogComponent', () => {
     });
 
     it('should set nightly time correctly', async(() => {
-         component.project.trigger_type = 'nightly';
+         component.form.patchValue({'trigger': 'nightly'});
          fixture.detectChanges();
 
          const hourEl: HTMLElement =
@@ -257,8 +261,7 @@ describe('AddProjectDialogComponent', () => {
            expect(hourEl.textContent).toBe('12');
            expect(amPmEl.textContent).toBe('AM');
 
-           component.timeSelectorData.hour = 2;
-           component.timeSelectorData.isAm = false;
+           component.form.patchValue({'hour': 2, 'amPm': 'PM'});
            fixture.detectChanges();
 
            expect(hourEl.textContent).toBe('2');
@@ -275,27 +278,71 @@ describe('AddProjectDialogComponent', () => {
       // Load Lanes
       lanesSubject.next(mockLanes);
       fixture.detectChanges();
+
+      // Set the name control so the form is valid
+      component.form.patchValue({'name': 'fake project'});
+    });
+
+    it('should not add project if form is invalid', () => {
+      // invalidate form
+      component.form.patchValue({'name': ''});
+      expect(component.form.valid).toBe(false);
+
+      component.addProject();
+      expect(dataService.addProject).not.toHaveBeenCalled();
+    });
+
+    it('should add project with correct form data', () => {
+      component.form.setValue({
+        'name': 'fake name',
+        'lane': 'fake lane',
+        'repo': 'fake repo',
+        'trigger': 'nightly',
+        'hour': 2,
+        'amPm': 'PM'
+      });
+
+      expect(component.form.valid).toBe(true);
+      component.addProject();
+      expect(dataService.addProject).toHaveBeenCalledWith({
+        'project_name': 'fake name',
+        'lane': 'fake lane',
+        'repo_org': '',
+        'repo_name': 'fake repo',
+        'trigger_type': 'nightly',
+        'branch': 'master',
+        'hour': 14,
+      });
+    });
+
+    it('should emit add project event when project is added', () => {
+      let projectSummary: ProjectSummary;
+      component.addProject();
+
+      component.projectAdded.subscribe((summary: ProjectSummary) => {
+        projectSummary = summary;
+      });
+
+      projectSubject.next(mockProjectSummary);
+      expect(projectSummary).toBe(mockProjectSummary);
     });
 
     it('should add the project hour in military time when nightly trigger',
        () => {
-         component.project.trigger_type = 'nightly';
+         component.form.patchValue({'trigger': 'nightly'});
 
          // 1PM or 13:00
-         component.timeSelectorData.hour = 1;
-         component.timeSelectorData.isAm = false;
+         component.form.patchValue({'hour': 1, 'amPm': 'PM'});
+         component.addProject();
 
-         addProjectButtonEl.click();
-
-         expect(component.project.hour).toBe(13);
+         expect(dataService.addProject.calls.mostRecent().args[0].hour)
+             .toBe(13);
 
          // Midnight or 0:00
-         component.timeSelectorData.hour = 12;
-         component.timeSelectorData.isAm = true;
+         component.form.patchValue({'hour': 12, 'amPm': 'AM'});
+         component.addProject();
 
-         addProjectButtonEl.click();
-
-         expect(component.project.hour).toBe(0);
+         expect(dataService.addProject.calls.mostRecent().args[0].hour).toBe(0);
        });
 
     it('should show spinner while adding project', () => {
@@ -303,24 +350,26 @@ describe('AddProjectDialogComponent', () => {
       expect(fixture.debugElement.queryAll(By.css('.mat-spinner')).length)
           .toBe(0);
 
-      addProjectButtonEl.click();
+      component.addProject();
       fixture.detectChanges();
 
       expect(fixture.debugElement.queryAll(By.css('.mat-spinner')).length)
           .toBe(1);
 
-      projectSubject.next(mockProject);
+      projectSubject.next(mockProjectSummary);
       fixture.detectChanges();
 
       expect(fixture.debugElement.queryAll(By.css('.mat-spinner')).length)
           .toBe(0);
     });
 
-    it('should close dialog on success', () => {
-      addProjectButtonEl.click();
-      projectSubject.next(mockProject);
+    it('should close dialog on success', async(() => {
+         // TODO: figure out how to submit the test from clicking the UI
+         // button
+         component.addProject();
+         projectSubject.next(mockProjectSummary);
 
-      expect(dialogRef.close).toHaveBeenCalled();
-    });
+         expect(dialogRef.close).toHaveBeenCalled();
+       }));
   });
 });

--- a/web/app/dashboard/add-project-dialog/add-project-dialog.modules.ts
+++ b/web/app/dashboard/add-project-dialog/add-project-dialog.modules.ts
@@ -1,6 +1,6 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {FormsModule} from '@angular/forms';
+import {ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule, MatDialogModule, MatIconModule, MatProgressSpinnerModule, MatSelectModule} from '@angular/material';
 
 import {FormSpinnerModule} from '../../common/components/form-spinner/form-spinner.module';
@@ -17,7 +17,7 @@ import {AddProjectDialogComponent} from './add-project-dialog.component';
   ],
   imports: [
     /** Angular Library Imports */
-    CommonModule, FormsModule,
+    CommonModule, ReactiveFormsModule,
     /** Internal Imports */
     FormSpinnerModule,
     /** Angular Material Imports */

--- a/web/app/dashboard/dashboard.component.html
+++ b/web/app/dashboard/dashboard.component.html
@@ -12,7 +12,7 @@
 
 <div fci-grid>
   <div fci-cell="12">
-    <mat-table class="fci-project-table" [dataSource]="projects">
+    <mat-table #projectsTable class="fci-project-table" [dataSource]="projects">
       <!-- Name Column -->
       <ng-container matColumnDef="name">
         <mat-header-cell *matHeaderCellDef>Project Name</mat-header-cell>

--- a/web/app/dashboard/dashboard.component.spec.ts
+++ b/web/app/dashboard/dashboard.component.spec.ts
@@ -1,15 +1,17 @@
 import 'rxjs/add/observable/of';
 
 import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {MatDialogModule} from '@angular/material';
+import {MatDialog, MatDialogModule} from '@angular/material';
+import {By} from '@angular/platform-browser';
 import {RouterModule} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
 import {MomentModule} from 'ngx-moment';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 
 import {CommonComponentsModule} from '../common/components/common-components.module';
 import {BuildStatus} from '../common/constants';
-import {mockProjectSummaryList} from '../common/test_helpers/mock_project_data';
+import {mockProjectSummary, mockProjectSummaryList} from '../common/test_helpers/mock_project_data';
 import {ProjectSummary} from '../models/project_summary';
 import {DataService} from '../services/data.service';
 import {SharedMaterialModule} from '../shared_material.module';
@@ -20,23 +22,43 @@ describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let fixture: ComponentFixture<DashboardComponent>;
   let dataService: jasmine.SpyObj<Partial<DataService>>;
+  let dialog: jasmine.SpyObj<Partial<MatDialog>>;
+  let projectListSubject: Subject<ProjectSummary[]>;
+  let projectAddedSubject: Subject<ProjectSummary>;
 
   beforeEach(() => {
+    projectListSubject = new Subject<ProjectSummary[]>();
+    projectAddedSubject = new Subject<ProjectSummary>();
+
     dataService = {
-      getProjects: jasmine.createSpy(),
+      getProjects: jasmine.createSpy().and.returnValue(
+          projectListSubject.asObservable()),
       getRepos: jasmine.createSpy()
+    };
+
+    dialog = {
+      open: jasmine.createSpy().and.returnValue({
+        componentInstance:
+            {projectAdded: projectAddedSubject.asObservable()}
+      })
     };
 
     TestBed
         .configureTestingModule({
           imports: [
-            MatDialogModule, SharedMaterialModule, CommonComponentsModule,
-            MomentModule, RouterModule
+            SharedMaterialModule,
+            CommonComponentsModule,
+            MomentModule,
+            RouterModule,
+            RouterTestingModule,
           ],
           declarations: [
             DashboardComponent,
           ],
-          providers: [{provide: DataService, useValue: dataService}],
+          providers: [
+            {provide: DataService, useValue: dataService},
+            {provide: MatDialog, useValue: dialog}
+          ],
         })
         .compileComponents();
 
@@ -44,22 +66,47 @@ describe('DashboardComponent', () => {
     component = fixture.componentInstance;
   });
 
-  it('should load project summaries', () => {
-    const subject = new Subject<ProjectSummary[]>();
-    dataService.getProjects.and.returnValue(subject.asObservable());
+  describe('intitliazation', () => {
+    it('should load project summaries', () => {
+      expect(component.isLoading).toBe(true);
 
-    expect(component.isLoading).toBe(true);
+      projectListSubject.next(mockProjectSummaryList);  // Resolve observable
 
-    fixture.detectChanges();               // onInit()
-    subject.next(mockProjectSummaryList);  // Resolve observable
+      expect(component.isLoading).toBe(false);
+      expect(component.projects.length).toBe(4);
+      expect(component.projects[0].id).toBe('1');
+      expect(component.projects[0].name).toBe('the coolest project');
+      expect(component.projects[1].latestStatus).toBe(BuildStatus.SUCCESS);
+      expect(component.projects[2].latestStatus).toBe(BuildStatus.FAILED);
+      expect(component.projects[3].latestDate).toBeUndefined();
+      expect(component.projects[3].latestStatus).toBeUndefined();
+    });
+  });
 
-    expect(component.isLoading).toBe(false);
-    expect(component.projects.length).toBe(4);
-    expect(component.projects[0].id).toBe('1');
-    expect(component.projects[0].name).toBe('the coolest project');
-    expect(component.projects[1].latestStatus).toBe(BuildStatus.SUCCESS);
-    expect(component.projects[2].latestStatus).toBe(BuildStatus.FAILED);
-    expect(component.projects[3].latestDate).toBeUndefined();
-    expect(component.projects[3].latestStatus).toBeUndefined();
+  describe('after intitliazation', () => {
+    beforeEach(() => {
+      projectListSubject.next(mockProjectSummaryList);  // Resolve observable
+      fixture.detectChanges();
+    });
+
+    it('should add new project to project table', () => {
+      let tableRowsEl = fixture.debugElement.queryAll(By.css('.mat-row'));
+      expect(tableRowsEl.length).toBe(4);
+
+      component.openAddProjectDialog();
+      projectAddedSubject.next(mockProjectSummary);
+      fixture.detectChanges();
+
+      tableRowsEl = fixture.debugElement.queryAll(By.css('.mat-row'));
+      expect(tableRowsEl.length).toBe(5);
+      expect(tableRowsEl[4].nativeElement.innerText)
+          .toContain('the coolest project');
+    });
+
+    it('should open add project dialog when new project is clicked', () => {
+      fixture.debugElement.query(By.css('.fci-dashboard-welcome button'))
+          .nativeElement.click();
+      expect(dialog.open).toHaveBeenCalled();
+    });
   });
 });

--- a/web/app/dashboard/dashboard.component.ts
+++ b/web/app/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
-import {Component, OnInit} from '@angular/core';
-import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material';
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialog, MatDialogRef, MatTable} from '@angular/material';
 import {Observable} from 'rxjs/Observable';
 
 import {ProjectSummary, ProjectSummaryResponse} from '../models/project_summary';
@@ -14,7 +14,8 @@ import {AddProjectDialogComponent, AddProjectDialogConfig} from './add-project-d
   styleUrls: ['./dashboard.component.scss']
 })
 
-export class DashboardComponent implements OnInit {
+export class DashboardComponent {
+  @ViewChild('projectsTable') table: MatTable<ProjectSummary>;
   readonly DISPLAYED_COLUMNS: string[] =
       ['name', 'latestBuild', 'repo', 'lane'];
   isLoading = true;
@@ -23,9 +24,7 @@ export class DashboardComponent implements OnInit {
 
   constructor(
       private readonly dataService: DataService,
-      private readonly dialog: MatDialog) {}
-
-  ngOnInit() {
+      private readonly dialog: MatDialog) {
     this.dataService.getProjects().subscribe((projects) => {
       this.projects = projects;
       this.isLoading = false;
@@ -45,8 +44,11 @@ export class DashboardComponent implements OnInit {
               data: {repositories: this.repositories}
             });
 
-    dialogRef.afterClosed().subscribe(result => {
-      console.log('The dialog was closed');
-    });
+    dialogRef.componentInstance.projectAdded.subscribe(
+        (newProject: ProjectSummary) => {
+          this.projects.push(newProject);
+          // Need to re-render rows now that new data is added.
+          this.table.renderRows();
+        });
   }
 }

--- a/web/app/services/data.service.spec.ts
+++ b/web/app/services/data.service.spec.ts
@@ -3,7 +3,7 @@ import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {BuildStatus} from '../common/constants';
 import {mockLanesResponse} from '../common/test_helpers/mock_lane_data';
-import {mockProjectListResponse, mockProjectResponse} from '../common/test_helpers/mock_project_data';
+import {mockProjectListResponse, mockProjectResponse, mockProjectSummaryResponse} from '../common/test_helpers/mock_project_data';
 import {mockRepositoryListResponse, mockRepositoryResponse} from '../common/test_helpers/mock_repository_data';
 import {Lane} from '../models/lane';
 import {Project} from '../models/project';
@@ -93,7 +93,7 @@ describe('DataService', () => {
 
   describe('#addProject', () => {
     it('should add project with commit trigger', () => {
-      let project: Project;
+      let project: ProjectSummary;
       dataService.addProject(COMMIT_TRIGGER_PROJECT_REQUEST)
           .subscribe((projectRespone) => {
             project = projectRespone;
@@ -101,12 +101,11 @@ describe('DataService', () => {
 
       const projectsRequest = mockHttp.expectOne('/data/projects');
       expect(projectsRequest.request.body).toBe(COMMIT_TRIGGER_PROJECT_REQUEST);
-      projectsRequest.flush(mockProjectResponse);
+      projectsRequest.flush(mockProjectSummaryResponse);
 
-      expect(project.id).toBe('12');
-      expect(project.builds.length).toBe(2);
-      expect(project.builds[0].status).toBe(BuildStatus.SUCCESS);
-      expect(project.builds[1].status).toBe(BuildStatus.FAILED);
+      expect(project.id).toBe('1');
+      expect(project.name).toBe('the coolest project');
+      expect(project.lane).toBe('ios test');
     });
   });
 

--- a/web/app/services/data.service.ts
+++ b/web/app/services/data.service.ts
@@ -46,10 +46,10 @@ export class DataService {
         map((lanes) => lanes.map((lane) => new Lane(lane))));
   }
 
-  addProject(request: AddProjectRequest): Observable<Project> {
+  addProject(request: AddProjectRequest): Observable<ProjectSummary> {
     const url = `${HOSTNAME}/projects`;
-    return this.http.post<ProjectResponse>(url, request)
-        .pipe(map((project) => new Project(project)));
+    return this.http.post<ProjectSummaryResponse>(url, request)
+        .pipe(map((project) => new ProjectSummary(project)));
   }
 
   getRepos(): Observable<Repository[]> {


### PR DESCRIPTION
Fixes: #713

- Adds Angular reactive forms to disable the forms until it is fully loaded and to add validation.
- Project table adds new project to the table
- add project endpoint returns the project's summary
- quite a bit of testing

I ran rubocop, but the issues are in non-staged files.

```
- [x] I have run `rspec` and corrected all errors
- [ ] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```