### PR TITLE
Added project/build toolbar with initial breadcrumbs

### DIFF
--- a/web/app/app-routing.module.ts
+++ b/web/app/app-routing.module.ts
@@ -8,6 +8,7 @@ import {DashboardModule} from './dashboard/dashboard.module';
 import {LoginComponent} from './login/login.component';
 import {LoginModule} from './login/login.module';
 import {ProjectComponent} from './project/project.component';
+import {ProjectModule} from './project/project.module';
 
 const routes: Routes = [
   {path: '', redirectTo: '/dashboard', pathMatch: 'full'},
@@ -18,8 +19,10 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports:
-      [DashboardModule, BuildModule, LoginModule, RouterModule.forRoot(routes)],
+  imports: [
+    DashboardModule, ProjectModule, BuildModule, LoginModule,
+    RouterModule.forRoot(routes)
+  ],
   exports: [RouterModule]
 })
 

--- a/web/app/app.module.ts
+++ b/web/app/app.module.ts
@@ -6,7 +6,6 @@ import {MomentModule} from 'ngx-moment';
 import {AppRoutingModule} from './/app-routing.module';
 import {AppComponent} from './app.component';
 import {CommonComponentsModule} from './common/components/common-components.module';
-import {ProjectComponent} from './project/project.component';
 import {AuthInterceptor} from './services/auth.interceptor';
 import {DataService} from './services/data.service';
 import {SharedMaterialModule} from './shared_material.module';
@@ -14,7 +13,6 @@ import {SharedMaterialModule} from './shared_material.module';
 @NgModule({
   declarations: [
     AppComponent,
-    ProjectComponent,
   ],
   imports: [
     BrowserModule,

--- a/web/app/build/build.component.html
+++ b/web/app/build/build.component.html
@@ -1,2 +1,4 @@
+<fci-toolbar [breadcrumbs]="breadcrumbs"></fci-toolbar>
+
 <h4>Logs:</h4>
 <pre>{{logs}}</pre>

--- a/web/app/build/build.component.spec.ts
+++ b/web/app/build/build.component.spec.ts
@@ -1,8 +1,11 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
 import {ActivatedRoute, convertToParamMap} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 
+import {ToolbarModule} from '../common/components/toolbar/toolbar.module';
 import {BuildLogMessageEvent, BuildLogWebsocketService} from '../services/build-log-websocket.service';
 
 import {BuildComponent} from './build.component';
@@ -22,6 +25,7 @@ describe('BuildComponent', () => {
     TestBed
         .configureTestingModule({
           declarations: [BuildComponent],
+          imports: [ToolbarModule, RouterTestingModule],
           providers: [
             {
               provide: BuildLogWebsocketService,
@@ -40,18 +44,40 @@ describe('BuildComponent', () => {
 
     fixture = TestBed.createComponent(BuildComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should start socket connection with correct project/build IDs', () => {
+    fixture.detectChanges();
     expect(buildLogWebsocketService.connect).toHaveBeenCalledWith('123', '1');
   });
 
   it('should update logs as they come in', () => {
+    fixture.detectChanges();
     expect(component.logs).toBe('');
     socketSubject.next(new MessageEvent('type', {data: 'log1'}));
     expect(component.logs).toBe('log1');
     socketSubject.next(new MessageEvent('type', {data: 'log2'}));
     expect(component.logs).toBe('log1log2');
+  });
+
+
+  it('should update breadcrumbs after loading params', () => {
+    expect(component.breadcrumbs[1].url).toBeUndefined();
+    fixture.detectChanges();  // onInit()
+
+    expect(component.breadcrumbs[1].url).toBe('/project/123');
+  });
+
+  it('should have toolbar with breadcrumbs', () => {
+    fixture.detectChanges();  // onInit()
+
+    console.log(fixture.debugElement.query(By.css('.fci-crumb')));
+    // toolbar exists
+    expect(fixture.debugElement.queryAll(By.css('.fci-crumb')).length).toBe(3);
+
+    expect(component.breadcrumbs[0].label).toBe('Dashboard');
+    expect(component.breadcrumbs[0].url).toBe('/');
+    expect(component.breadcrumbs[1].hint).toBe('Project');
+    expect(component.breadcrumbs[2].hint).toBe('Build');
   });
 });

--- a/web/app/build/build.component.ts
+++ b/web/app/build/build.component.ts
@@ -3,6 +3,7 @@ import {ActivatedRoute} from '@angular/router';
 import {ParamMap} from '@angular/router/src/shared';
 import {Subject} from 'rxjs/Subject';
 
+import {Breadcrumb} from '../common/components/toolbar/toolbar.component';
 import {BuildLogWebsocketService} from '../services/build-log-websocket.service';
 
 @Component({
@@ -12,6 +13,8 @@ import {BuildLogWebsocketService} from '../services/build-log-websocket.service'
 })
 export class BuildComponent implements OnInit {
   logs = '';
+  readonly breadcrumbs: Breadcrumb[] =
+      [{label: 'Dashboard', url: '/'}, {hint: 'Project'}, {hint: 'Build'}];
 
   constructor(
       private readonly buildLogSocketService: BuildLogWebsocketService,
@@ -19,13 +22,20 @@ export class BuildComponent implements OnInit {
 
   ngOnInit() {
     this.route.paramMap
-        .switchMap(
-            (params: ParamMap) => this.buildLogSocketService.connect(
-                params.get('projectId'), params.get('buildId')))
+        .switchMap((params: ParamMap) => {
+          this.updateBreadcrumbs(params.get('projectId'));
+          return this.buildLogSocketService.connect(
+              params.get('projectId'), params.get('buildId'));
+        })
         .subscribe((message) => {
           // TODO: this will be more than a string later on. Let's define a log
           // line model.
           this.logs += message.data;
         });
+  }
+
+  private updateBreadcrumbs(projectId: string): void {
+    // TODO: update the breadcrumbs to have Project name and Build number
+    this.breadcrumbs[1].url = `/project/${projectId}`;
   }
 }

--- a/web/app/build/build.module.ts
+++ b/web/app/build/build.module.ts
@@ -1,5 +1,8 @@
 import {NgModule} from '@angular/core';
+
+import {ToolbarModule} from '../common/components/toolbar/toolbar.module';
 import {BuildLogWebsocketService} from '../services/build-log-websocket.service';
+
 import {BuildComponent} from './build.component';
 
 @NgModule({
@@ -8,6 +11,7 @@ import {BuildComponent} from './build.component';
   imports: [
     /** Angular Library Imports */
     /** Internal Imports */
+    ToolbarModule
     /** Angular Material Imports */
     /** Third-Party Module Imports */
   ],

--- a/web/app/common/components/toolbar/toolbar.component.html
+++ b/web/app/common/components/toolbar/toolbar.component.html
@@ -1,0 +1,8 @@
+<div>
+  <span>fastlane icon</span>
+  <span class="fci-crumb" *ngFor="let breadcrumb of breadcrumbs; let last = last">
+    <a *ngIf="breadcrumb.url" [routerLink]="breadcrumb.url">{{getDisplayText(breadcrumb)}}</a>
+    <span *ngIf="!breadcrumb.url">{{getDisplayText(breadcrumb)}}</span>
+    <span class="fci-crumb-spacer" *ngIf="!last">></span>
+  </span>
+</div>

--- a/web/app/common/components/toolbar/toolbar.component.spec.ts
+++ b/web/app/common/components/toolbar/toolbar.component.spec.ts
@@ -1,0 +1,84 @@
+import {DebugElement} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {RouterTestingModule} from '@angular/router/testing';
+import {ToolbarComponent} from './toolbar.component';
+
+describe('ToolbarComponent', () => {
+  let component: ToolbarComponent;
+  let fixture: ComponentFixture<ToolbarComponent>;
+
+  function getCrumbs(): DebugElement[] {
+    return fixture.debugElement.queryAll(By.css('.fci-crumb'));
+  }
+
+  function getFirstCrumb(): HTMLElement {
+    const crumbsEl = getCrumbs();
+    expect(crumbsEl.length).toBe(1);
+
+    return crumbsEl[0].query(By.css('a,span')).nativeElement;
+  }
+
+  beforeEach(() => {
+    TestBed
+        .configureTestingModule(
+            {declarations: [ToolbarComponent], imports: [RouterTestingModule]})
+        .compileComponents();
+
+    fixture = TestBed.createComponent(ToolbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should breadcrumbs correctly', () => {
+    component.breadcrumbs = [{label: 'parent'}, {label: 'child'}];
+    fixture.detectChanges();
+
+    const crumbsEl = getCrumbs();
+    expect(crumbsEl.length).toBe(2);
+    expect(crumbsEl[0].nativeElement.innerText).toContain('parent');
+    expect(crumbsEl[1].nativeElement.innerText).toContain('child');
+  });
+
+  it('should have routerLink set up if there is a url on the crumb', () => {
+    component.breadcrumbs = [{label: 'parent', url: 'parent/child'}];
+    fixture.detectChanges();
+
+    const firstCrumbEl = getFirstCrumb();
+    expect(firstCrumbEl.hasAttribute('href')).toBe(true);
+    expect(firstCrumbEl.attributes.getNamedItem('href').value)
+        .toBe('/parent/child');
+  });
+
+  it('should not have routerLink set up if there is not a url on the crumb',
+     () => {
+       component.breadcrumbs = [{label: 'parent'}];
+       fixture.detectChanges();
+
+       const firstCrumbEl = getFirstCrumb();
+       expect(firstCrumbEl.hasAttribute('href')).toBe(false);
+     });
+
+  it('should add arrow between crumbs', () => {
+    component.breadcrumbs = [{label: 'parent'}, {label: 'child'}];
+    fixture.detectChanges();
+
+    const crumbsEl = getCrumbs();
+    expect(crumbsEl.length).toBe(2);
+    expect(crumbsEl[0].nativeElement.innerText).toBe('parent > ');
+    expect(crumbsEl[1].nativeElement.innerText).toBe('child');
+  });
+
+  it('should show hint if the label is not ready yet', () => {
+    component.breadcrumbs = [{hint: 'hint'}];
+    fixture.detectChanges();
+
+    const crumbEl = getFirstCrumb();
+    expect(crumbEl.innerText).toBe('hint');
+
+    component.breadcrumbs[0].label = 'parent';
+    fixture.detectChanges();
+    expect(crumbEl.innerText).toBe('parent');
+  });
+});

--- a/web/app/common/components/toolbar/toolbar.component.ts
+++ b/web/app/common/components/toolbar/toolbar.component.ts
@@ -1,0 +1,33 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {Params} from '@angular/router';
+
+export interface Breadcrumb {
+  hint?: string;
+  label?: string;
+  url?: string;
+}
+
+@Component({
+  selector: 'fci-toolbar',
+  templateUrl: './toolbar.component.html',
+  styleUrls: ['./toolbar.component.scss']
+})
+export class ToolbarComponent {
+  // TODO: This should be redesigned to pull the URL from the Router instead of
+  // having it being manually inputted. The only input needed are the names of
+  // the crumbs. The problem with doing this right now is that it doesn't make
+  // sense to make these routes children of each other. So for now there is no
+  // hierarchy defined anywhere which is why there's a manual input to this
+  // component.
+  @Input() breadcrumbs: Breadcrumb[];
+
+  getDisplayText(breadcrumb: Breadcrumb): string {
+    if (breadcrumb.label) {
+      return breadcrumb.label;
+    } else if (breadcrumb.hint) {
+      return breadcrumb.hint;
+    } else {
+      return 'Loading';
+    }
+  }
+}

--- a/web/app/common/components/toolbar/toolbar.module.ts
+++ b/web/app/common/components/toolbar/toolbar.module.ts
@@ -1,0 +1,13 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {RouterModule} from '@angular/router';
+
+import {ToolbarComponent} from './toolbar.component';
+
+@NgModule({
+  declarations: [ToolbarComponent],
+  imports: [RouterModule, CommonModule],
+  exports: [ToolbarComponent]
+})
+export class ToolbarModule {
+}

--- a/web/app/project/project.component.html
+++ b/web/app/project/project.component.html
@@ -1,8 +1,4 @@
-<mat-toolbar color="primary">
-  <mat-toolbar-row>
-    <span *ngIf="project">{{project.name}}</span>
-  </mat-toolbar-row>
-</mat-toolbar>
+<fci-toolbar [breadcrumbs]="breadcrumbs"></fci-toolbar>
 
 <div fci-grid *ngIf="project">
   <div fci-cell="12">

--- a/web/app/project/project.component.spec.ts
+++ b/web/app/project/project.component.spec.ts
@@ -1,12 +1,15 @@
 import 'rxjs/add/operator/switchMap';
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
 import {ActivatedRoute, convertToParamMap} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
 import {MomentModule} from 'ngx-moment';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 
 import {CommonComponentsModule} from '../common/components/common-components.module';
+import {ToolbarModule} from '../common/components/toolbar/toolbar.module';
 import {mockProject} from '../common/test_helpers/mock_project_data';
 import {Project} from '../models/project';
 import {DataService} from '../services/data.service';
@@ -18,13 +21,21 @@ describe('ProjectComponent', () => {
   let component: ProjectComponent;
   let fixture: ComponentFixture<ProjectComponent>;
   let dataService: jasmine.SpyObj<Partial<DataService>>;
+  let projectSubject: Subject<Project>;
 
   beforeEach(async(() => {
-    dataService = {getProject: jasmine.createSpy()};
+    projectSubject = new Subject<Project>();
+    dataService = {
+      getProject:
+          jasmine.createSpy().and.returnValue(projectSubject.asObservable())
+    };
 
     TestBed
         .configureTestingModule({
-          imports: [CommonComponentsModule, SharedMaterialModule, MomentModule],
+          imports: [
+            CommonComponentsModule, SharedMaterialModule, MomentModule,
+            ToolbarModule, RouterTestingModule
+          ],
           declarations: [
             ProjectComponent,
           ],
@@ -43,19 +54,37 @@ describe('ProjectComponent', () => {
   }));
 
   it('should load project', () => {
-    const subject = new Subject<Project>();
-    dataService.getProject.and.returnValue(subject.asObservable());
-
     expect(component.isLoading).toBe(true);
 
     fixture.detectChanges();  // onInit()
     expect(dataService.getProject).toHaveBeenCalledWith('123');
-    subject.next(mockProject);  // Resolve observable
+    projectSubject.next(mockProject);  // Resolve observable
 
     expect(component.isLoading).toBe(false);
     expect(component.project.id).toBe('12');
     expect(component.project.name).toBe('the most coolest project');
     expect(component.project.builds.length).toBe(2);
     expect(component.project.builds[0].sha).toBe('asdfshzdggfdhdfh4');
+  });
+
+  it('should update breadcrumbs after loading project', () => {
+    fixture.detectChanges();  // onInit()
+    expect(component.breadcrumbs[1].hint).toBe('Project');
+    expect(component.breadcrumbs[1].label).toBeUndefined();
+
+    projectSubject.next(mockProject);  // Resolve observable
+
+    expect(component.breadcrumbs[1].label).toBe('the most coolest project');
+  });
+
+  it('should have toolbar with breadcrumbs', () => {
+    fixture.detectChanges();  // onInit()
+
+    console.log(fixture.debugElement.query(By.css('.fci-crumb')));
+    // toolbar exists
+    expect(fixture.debugElement.queryAll(By.css('.fci-crumb')).length).toBe(2);
+
+    expect(component.breadcrumbs[0].label).toBe('Dashboard');
+    expect(component.breadcrumbs[0].url).toBe('/');
   });
 });

--- a/web/app/project/project.component.ts
+++ b/web/app/project/project.component.ts
@@ -3,6 +3,7 @@ import 'rxjs/add/operator/switchMap';
 import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, ParamMap} from '@angular/router';
 
+import {Breadcrumb} from '../common/components/toolbar/toolbar.component';
 import {Project} from '../models/project';
 import {DataService} from '../services/data.service';
 
@@ -16,6 +17,8 @@ export class ProjectComponent implements OnInit {
   isLoading = true;
   project: Project;
   readonly projectId: string;
+  readonly breadcrumbs: Breadcrumb[] =
+      [{label: 'Dashboard', url: '/'}, {hint: 'Project'}];
 
   constructor(
       private readonly dataService: DataService,
@@ -27,7 +30,12 @@ export class ProjectComponent implements OnInit {
             (params: ParamMap) => this.dataService.getProject(params.get('id')))
         .subscribe((project) => {
           this.project = project;
+          this.updateBreadcrumbs(this.project.name);
           this.isLoading = false;
         });
+  }
+
+  private updateBreadcrumbs(projectName: string) {
+    this.breadcrumbs[1].label = projectName;
   }
 }

--- a/web/app/project/project.module.ts
+++ b/web/app/project/project.module.ts
@@ -1,0 +1,33 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatCardModule, MatTableModule} from '@angular/material';
+import {RouterModule} from '@angular/router';
+import {MomentModule} from 'ngx-moment';
+
+import {CommonComponentsModule} from '../common/components/common-components.module';
+import {ToolbarModule} from '../common/components/toolbar/toolbar.module';
+import {DashboardComponent} from '../dashboard/dashboard.component';
+import {ProjectComponent} from '../project/project.component';
+import {DataService} from '../services/data.service';
+
+@NgModule({
+  declarations: [
+    ProjectComponent,
+  ],
+  entryComponents: [
+    ProjectComponent,
+  ],
+  imports: [
+    /** Angular Library Imports */
+    CommonModule,
+    /** Internal Imports */
+    CommonComponentsModule, ToolbarModule,
+    /** Angular Material Imports */
+    MatCardModule, MatTableModule,
+    /** Third-Party Module Imports */
+    MomentModule,  // For Date relative time pipes
+  ],
+  providers: [DataService],
+})
+export class ProjectModule {
+}


### PR DESCRIPTION
Fixes: #915

I spent some time on this to make it "automatic" but time-boxed it and I couldn't get it going. Opted for a less elegant solution, left the following as a `TODO`.

This should be redesigned to pull the URL from the Router instead having it being manually inputted. The only input needed are the names the crumbs. The problem with doing this right now is that it doesn't sense to make these routes children of each other. So for now there is hierarchy defined anywhere which is why there's a manual input to component.

```
- [ ] I have run `rspec` and corrected all errors
- [ ] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```

#### Screenshot

![image](https://user-images.githubusercontent.com/2754461/40396905-824680ee-5de4-11e8-8d42-1d12ab97784e.png)
