### PR TITLE
npm run build uses correct path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --deploy-url=\"/.dist\" --prod",
     "test": "ng test -sm=false -watch=false",
     "test_watch": "ng test -sm=false",
     "lint": "ng lint",


### PR DESCRIPTION
Fixes: #924

```
- [ ] I have run `rspec` and corrected all errors
- [ ] I have run `rubocop` and corrected all errors
- [ ] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```