### PR TITLE
Use correct provider type when looking up providers

### DIFF
--- a/app/features-json/api_controller.rb
+++ b/app/features-json/api_controller.rb
@@ -142,7 +142,7 @@ module FastlaneCI
       end
 
       def current_user_provider_credential
-        provider_credential = current_user.provider_credential(type: :github)
+        provider_credential = current_user.provider_credential
         halt(404) unless provider_credential
 
         return provider_credential


### PR DESCRIPTION
This is blocking all the API request from working.

```
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```