### PR TITLE
fix rspec warnings

### DIFF
--- a/app/shared/json_convertible.rb
+++ b/app/shared/json_convertible.rb
@@ -214,7 +214,7 @@ module FastlaneCI
             # classes that include `JSONConvertible` take precedence over custom mapping.
             var_value = attribute_to_type_map[var_name].from_json!(val)
           else
-            raise "#{var_name} does not implement `FastlaneCI::JSONConvertible`"
+            raise TypeError, "#{var_name} does not implement `FastlaneCI::JSONConvertible`"
           end
         elsif is_iterable
           # This is only intended for array properties, it passes the final variable name and a single object of
@@ -231,7 +231,7 @@ module FastlaneCI
                                        .select { |arg| arg[0] == :keyreq }
                                        .map(&:last)
         unless (required_init_params - json_object.keys).empty?
-          raise "Required initialization parameters not found in the object: #{json_object}"
+          raise TypeError, "Required initialization parameters not found in the object: #{json_object}"
         end
         init_params_hash = json_object.select { |key, _value| required_init_params.include?(key) }
         if instance.method(:initialize).parameters.empty?

--- a/spec/services/cofig_data_sources/json_project_data_source_spec.rb
+++ b/spec/services/cofig_data_sources/json_project_data_source_spec.rb
@@ -73,7 +73,7 @@ describe FastlaneCI::JSONProjectDataSource do
 
       it "raises an error message and doesn't write to the `projects.json` file" do
         expect(File).not_to(receive(:write))
-        expect { subject.update_project!(project: project) }.to raise_error
+        expect { subject.update_project!(project: project) }.to raise_error(RuntimeError, "Couldn't update project project-1 because it doesn't exists")
       end
     end
 
@@ -106,7 +106,7 @@ describe FastlaneCI::JSONProjectDataSource do
 
       it "raises an error message and doesn't write to the `projects.json` file" do
         expect(File).not_to(receive(:write))
-        expect { subject.delete_project!(project: project) }.to raise_error
+        expect { subject.delete_project!(project: project) }.to raise_error(RuntimeError)
       end
     end
 

--- a/spec/services/cofig_data_sources/json_project_data_source_spec.rb
+++ b/spec/services/cofig_data_sources/json_project_data_source_spec.rb
@@ -19,7 +19,7 @@ describe FastlaneCI::JSONProjectDataSource do
 
   describe "#project_exist?" do
     before(:each) do
-      subject.stub(:projects).and_return(projects)
+      allow(subject).to receive(:projects).and_return(projects)
     end
 
     context "project doesn't exist" do
@@ -37,7 +37,7 @@ describe FastlaneCI::JSONProjectDataSource do
 
   describe "#create_project!" do
     before(:each) do
-      subject.stub(:projects).and_return(projects)
+      allow(subject).to receive(:projects).and_return(projects)
     end
 
     context "project doesn't exist" do
@@ -68,7 +68,7 @@ describe FastlaneCI::JSONProjectDataSource do
 
     context "project doesn't exist" do
       before(:each) do
-        subject.stub(:projects).and_return([])
+        allow(subject).to receive(:projects).and_return([])
       end
 
       it "raises an error message and doesn't write to the `projects.json` file" do
@@ -79,7 +79,7 @@ describe FastlaneCI::JSONProjectDataSource do
 
     context "project exists" do
       before(:each) do
-        subject.stub(:projects).and_return(projects)
+        allow(subject).to receive(:projects).and_return(projects)
       end
 
       let(:updated_project_name) { "updated_project_name" }
@@ -101,7 +101,7 @@ describe FastlaneCI::JSONProjectDataSource do
 
     context "project doesn't exist" do
       before(:each) do
-        subject.stub(:projects).and_return([])
+        allow(subject).to receive(:projects).and_return([])
       end
 
       it "raises an error message and doesn't write to the `projects.json` file" do
@@ -112,7 +112,7 @@ describe FastlaneCI::JSONProjectDataSource do
 
     context "project exists" do
       before(:each) do
-        subject.stub(:projects).and_return(projects)
+        allow(subject).to receive(:projects).and_return(projects)
       end
 
       it "removes the `project` from the `projects.json` file" do

--- a/spec/services/data_sources/json_notification_data_source_spec.rb
+++ b/spec/services/data_sources/json_notification_data_source_spec.rb
@@ -50,7 +50,7 @@ describe FastlaneCI::JSONNotificationDataSource do
 
       it "raises an error message and doesn't write to the `notifications.json` file" do
         expect(File).not_to(receive(:write))
-        expect { json_notification_data_source.update_notification!(notification: notification) }.to raise_error
+        expect { json_notification_data_source.update_notification!(notification: notification) }.to raise_error(RuntimeError)
       end
     end
 

--- a/spec/services/data_sources/json_user_data_source_spec.rb
+++ b/spec/services/data_sources/json_user_data_source_spec.rb
@@ -31,7 +31,7 @@ describe FastlaneCI::JSONUserDataSource do
     end
 
     before(:each) do
-      subject.stub(:users).and_return(users)
+      allow(subject).to receive(:users).and_return(users)
     end
 
     context "user doesn't exist" do
@@ -73,12 +73,12 @@ describe FastlaneCI::JSONUserDataSource do
 
     context "user doesn't exist" do
       before(:each) do
-        subject.stub(:users).and_return([])
+        allow(subject).to receive(:users).and_return([])
       end
 
       it "raises an error message and doesn't write to the `users.json` file" do
         expect(File).not_to(receive(:write))
-        expect { subject.update_user!(user: user) }.to raise_error
+        expect { subject.update_user!(user: user) }.to raise_error(RuntimeError, "Couldn't update user test.user1@gmail.com because they don't exist")
       end
     end
 
@@ -87,7 +87,7 @@ describe FastlaneCI::JSONUserDataSource do
       let(:new_user) { FastlaneCI::User.new(user_params.first.merge(email: new_user_email)) }
 
       before(:each) do
-        subject.stub(:users).and_return(users)
+        allow(subject).to receive(:users).and_return(users)
       end
 
       it "updates the `user` email in the `users.json` file" do
@@ -103,18 +103,18 @@ describe FastlaneCI::JSONUserDataSource do
 
     context "user doesn't exist" do
       before(:each) do
-        subject.stub(:users).and_return([])
+        allow(subject).to receive(:users).and_return([])
       end
 
       it "raises an error message and doesn't write to the `users.json` file" do
         expect(File).not_to(receive(:write))
-        expect { subject.delete_user!(user: user) }.to raise_error
+        expect { subject.delete_user!(user: user) }.to raise_error(RuntimeError, "Couldn't delete user test.user1@gmail.com because they don't exist")
       end
     end
 
     context "user exists" do
       before(:each) do
-        subject.stub(:users).and_return(users)
+        allow(subject).to receive(:users).and_return(users)
       end
 
       it "removes the `user` from the `users.json` file" do

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -53,8 +53,8 @@ describe FastlaneCI::UserService do
 
     context "user exists" do
       before(:each) do
-        subject.stub(:find_user).with(id: user_id) { user }
-        subject.stub(:update_user!).with(user: updated_user)
+        allow(subject).to receive(:find_user).with(id: user_id) { user }
+        allow(subject).to receive(:update_user!).with(user: updated_user)
       end
 
       # TODO: Need to rethink how to accomplish this now that we're not returning exactly the same object,

--- a/spec/shared/json_convertible_spec.rb
+++ b/spec/shared/json_convertible_spec.rb
@@ -275,7 +275,7 @@ module FastlaneCI
 
     it "Raises exception when required initialization parameters are not found" do
       object_dictionary = { not_the_attribute: "taco" }
-      expect { MockJSONConvertibleWithRequiredParams.from_json!(object_dictionary) }.to(raise_exception)
+      expect { MockJSONConvertibleWithRequiredParams.from_json!(object_dictionary) }.to(raise_exception(TypeError))
     end
 
     it "Allows to decode objects with mixed initialization parameters" do


### PR DESCRIPTION
This PR fixes a few rspec deprecations and warnings. The noisiest warning is caused by: https://github.com/fastlane/ci/blob/fix-spec-warnings/spec/stub_helpers.rb#L34

Basically, rspec complains if you stub `initialize` and I do agree that we shouldn't be stubbing that method. It will take some refactoring to allow initialize to be called without the side-effects, which is why this PR is marked as WIP.