### PR TITLE
Build Runner Change Listeners now get their own class

### DIFF
--- a/app/features/build/build_websocket_backend.rb
+++ b/app/features/build/build_websocket_backend.rb
@@ -43,7 +43,7 @@ module FastlaneCI
       end
 
       ws = Faye::WebSocket.new(env, nil, { ping: KEEPALIVE_TIME })
-      web_socket_build_runner_change_listener = WebSocketBuildRunnerChangeListener(web_socket: ws)
+      web_socket_build_runner_change_listener = WebSocketBuildRunnerChangeListener.new(web_socket: ws)
 
       ws.on(:open) do |event|
         logger.debug([:open, ws.object_id])
@@ -73,7 +73,6 @@ module FastlaneCI
       end
 
       ws.on(:close) do |event|
-        web_socket_build_change_listener.connection_closed
         logger.debug([:close, ws.object_id, event.code, event.reason])
 
         url_details = fetch_build_details(event)
@@ -81,6 +80,7 @@ module FastlaneCI
         project_id = url_details[:project_id]
 
         websocket_clients[project_id][build_number].delete(ws)
+        web_socket_build_runner_change_listener.connection_closed
         ws = nil
       end
 

--- a/app/features/build/build_websocket_backend.rb
+++ b/app/features/build/build_websocket_backend.rb
@@ -1,5 +1,6 @@
 require "faye/websocket"
 require_relative "../../shared/logging_module"
+require_relative "../build_runner/web_socket_build_runner_change_listener"
 
 Faye::WebSocket.load_adapter("thin")
 
@@ -42,6 +43,8 @@ module FastlaneCI
       end
 
       ws = Faye::WebSocket.new(env, nil, { ping: KEEPALIVE_TIME })
+      web_socket_build_runner_change_listener = WebSocketBuildRunnerChangeListener(web_socket: ws)
+
       ws.on(:open) do |event|
         logger.debug([:open, ws.object_id])
 
@@ -61,12 +64,7 @@ module FastlaneCI
 
         # TODO: Think this through, do we properly add new listener, and notify them of line changes, etc.
         #       Also how does the "offboarding" of runners work once the tests are finished
-        current_build_runner.add_listener(proc do |row|
-          # TODO: Add auth check here, so a user isn't able to get the log from another build
-          unless ws.send(row.to_json)
-            logger.error("Something failed when sending the current row via a web socket connection")
-          end
-        end)
+        current_build_runner.add_build_change_listener(web_socket_build_runner_change_listener)
       end
 
       ws.on(:message) do |event|
@@ -75,6 +73,7 @@ module FastlaneCI
       end
 
       ws.on(:close) do |event|
+        web_socket_build_change_listener.connection_closed
         logger.debug([:close, ws.object_id, event.code, event.reason])
 
         url_details = fetch_build_details(event)

--- a/app/features/build_runner/README.md
+++ b/app/features/build_runner/README.md
@@ -2,4 +2,4 @@
 
 This directory includes the classes to represent a `BuildRunner`. A `BuildRunner` is responsible for running a given build (e.g. running unit tests) and reporting its status back to the `BuildRunnerService`.
 
-As a user of the classes here, you can register yourself as a listener (`add_listener`) to be updated in real-time.
+As a user of the classes here, you can register yourself as a listener (`add_build_change_listener`) to be updated in real-time.

--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -41,8 +41,8 @@ module FastlaneCI
     # This is an array of hashes
     attr_accessor :all_build_output_log_rows
 
-    # All blocks listening to changes for this build
-    attr_accessor :build_change_observer_blocks
+    # All build change observers that are listening to changes for this build
+    attr_accessor :build_change_listeners
 
     # Work queue where builds should be run
     attr_reader :work_queue
@@ -69,7 +69,7 @@ module FastlaneCI
       @git_fork_config = git_fork_config
 
       self.all_build_output_log_rows = []
-      self.build_change_observer_blocks = []
+      self.build_change_listeners = []
 
       # TODO: provider credential should determine what exact CodeHostingService gets instantiated
       @code_hosting_service = github_service
@@ -365,15 +365,24 @@ module FastlaneCI
       all_build_output_log_rows << row
 
       # 2) Report back to all listeners, usually socket connections
-      build_change_observer_blocks.each do |current_block|
-        current_block.call(row)
+      listeners_done_listening = []
+      build_change_listeners.each do |current_listener|
+        if current_listener.done_listening?
+          listeners_done_listening << current_listener
+          next
+        end
+
+        current_listener.row_received(row)
       end
+
+      # remove any listeners that are done listening
+      self.build_change_listeners -= listeners_done_listening
     end
 
     # Add a listener to get real time updates on new rows (see `new_row`)
     # This is used for the socket connection to the user's browser
-    def add_listener(block)
-      build_change_observer_blocks << block
+    def add_build_change_listener(listener)
+      build_change_listeners << listener
     end
 
     def prepare_build_object(trigger:)

--- a/app/features/build_runner/build_runner_change_listener.rb
+++ b/app/features/build_runner/build_runner_change_listener.rb
@@ -1,0 +1,16 @@
+module FastlaneCI
+  # Base class for all build runner change listeners
+  class BuildRunnerChangeListener
+    # If the listener is no longer listening, return true.
+    # Once this returns `true` the build runner will never attempt to use it again.
+    # That means that the first time an instance returns `true`, it will never be used again unless
+    # explicitly re-added as a listener to the BuildRunner (not recommended)
+    def done_listening?
+      not_implemented(__method__)
+    end
+
+    def row_received(row)
+      not_implemented(__method__)
+    end
+  end
+end

--- a/app/features/build_runner/web_socket_build_runner_change_listener.rb
+++ b/app/features/build_runner/web_socket_build_runner_change_listener.rb
@@ -1,0 +1,36 @@
+require_relative "../../shared/logging_module"
+require_relative "build_runner_change_listener"
+module FastlaneCI
+  # Build Runner Change Listener for websocket connection (expecting `faye/websocket`)
+  class WebSocketBuildRunnerChangeListener < BuildRunnerChangeListener
+    include FastlaneCI::Logging
+
+    def initialize(web_socket:)
+      @web_socket = web_socket
+      @done_listening = false
+    end
+
+    def done_listening?
+      return @done_listening
+    end
+
+    def connection_closed
+      @done_listening = true
+      @web_socket = nil
+    end
+
+    def row_received(row)
+      if @web_socket.nil?
+        logger.error("@web_socket is nil, we can't send anything to it")
+        connection_closed
+        return
+      end
+
+      unless @web_socket.send(row.to_json)
+        # TODO: CRITICAL: Add auth check here, so a user isn't able to get the log from another build
+        # TODO: should we call `connection_closed` or is this recoverable?
+        logger.error("Something failed when sending the current row via a web socket connection")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Subclass BuildRunnerChangeListener and implement done_listening? and
row_received
- BuildRunner now cleans up the list of BuildRunnerChangeListeners when needed
- Implemented WebSocketBuildRunnerChangeListener
- Fixes #826

- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
