### PR TITLE
Make scheduled works wait for previous workers

### DIFF
--- a/app/workers/check_for_new_commits_on_github_worker.rb
+++ b/app/workers/check_for_new_commits_on_github_worker.rb
@@ -74,7 +74,9 @@ module FastlaneCI
     end
 
     def work
+      self.busy = true
       check_for_new_commits
+      self.busy = false
     end
   end
 end

--- a/app/workers/nightly_build_github_worker.rb
+++ b/app/workers/nightly_build_github_worker.rb
@@ -24,7 +24,7 @@ module FastlaneCI
       )
     end
 
-    def work
+    def do_build
       logger.debug("Running nightly build for #{project.project_name} (#{repo_full_name})")
       # TODO: build_service could be injected instead of referenced like this
       build_service = FastlaneCI::Services.build_service
@@ -70,6 +70,12 @@ module FastlaneCI
         trigger: project.find_triggers_of_type(trigger_type: :nightly).first,
         notification_service: notification_service
       )
+    end
+
+    def work
+      self.busy = true
+      do_build
+      self.busy = false
     end
   end
 end


### PR DESCRIPTION
- Add ability for workers to set themselves as `busy`
- Scheduler respects `busy` and doesn’t attempt to schedule same repeating task again.
- fixes #802

- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
