### PR TITLE
Correctly reference SharedMaterialModule in /web/root folder

### DIFF
--- a/web/app/common/components/common-components.module.ts
+++ b/web/app/common/components/common-components.module.ts
@@ -1,7 +1,7 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
-import {SharedMaterialModule} from '../../shared_material.module';
+import {SharedMaterialModule} from '../../root/shared_material.module';
 
 import {StatusIconComponent} from './status-icon/status-icon.component';
 

--- a/web/app/dashboard/dashboard.component.spec.ts
+++ b/web/app/dashboard/dashboard.component.spec.ts
@@ -14,7 +14,7 @@ import {BuildStatus} from '../common/constants';
 import {mockProjectSummary, mockProjectSummaryList} from '../common/test_helpers/mock_project_data';
 import {ProjectSummary} from '../models/project_summary';
 import {DataService} from '../services/data.service';
-import {SharedMaterialModule} from '../shared_material.module';
+import {SharedMaterialModule} from '../root/shared_material.module';
 
 import {DashboardComponent} from './dashboard.component';
 

--- a/web/app/dashboard/dashboard.module.ts
+++ b/web/app/dashboard/dashboard.module.ts
@@ -9,7 +9,7 @@ import {CommonComponentsModule} from '../common/components/common-components.mod
 import {DashboardComponent} from '../dashboard/dashboard.component';
 import {ProjectComponent} from '../project/project.component';
 import {DataService} from '../services/data.service';
-import {SharedMaterialModule} from '../shared_material.module';
+import {SharedMaterialModule} from '../root/shared_material.module';
 import {AddProjectDialogComponent} from './add-project-dialog/add-project-dialog.component';
 import {AddProjectDialogModule} from './add-project-dialog/add-project-dialog.modules';
 

--- a/web/app/project/project.component.spec.ts
+++ b/web/app/project/project.component.spec.ts
@@ -13,7 +13,7 @@ import {ToolbarModule} from '../common/components/toolbar/toolbar.module';
 import {mockProject} from '../common/test_helpers/mock_project_data';
 import {Project} from '../models/project';
 import {DataService} from '../services/data.service';
-import {SharedMaterialModule} from '../shared_material.module';
+import {SharedMaterialModule} from '../root/shared_material.module';
 
 import {ProjectComponent} from './project.component';
 


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [ ] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [ ] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving

`ng test` and `ng build --deploy-url="/.dist" --dev -w` produced multiple errors (like `ERROR in web/app/dashboard/dashboard.component.spec.ts(17,36): error TS2307: Cannot find module '../shared_material.module'.`) because it referenced a file that did not exist (or has moved earlier?). After changing the path, tests and build resumed working.