### PR TITLE
Reset loading state and show error message after failed login attempt

### DIFF
--- a/web/app/common/components/common-components.module.ts
+++ b/web/app/common/components/common-components.module.ts
@@ -1,7 +1,7 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
-import {SharedMaterialModule} from '../../shared_material.module';
+import {SharedMaterialModule} from '../../root/shared_material.module';
 
 import {StatusIconComponent} from './status-icon/status-icon.component';
 

--- a/web/app/dashboard/dashboard.component.spec.ts
+++ b/web/app/dashboard/dashboard.component.spec.ts
@@ -14,7 +14,7 @@ import {BuildStatus} from '../common/constants';
 import {mockProjectSummary, mockProjectSummaryList} from '../common/test_helpers/mock_project_data';
 import {ProjectSummary} from '../models/project_summary';
 import {DataService} from '../services/data.service';
-import {SharedMaterialModule} from '../shared_material.module';
+import {SharedMaterialModule} from '../root/shared_material.module';
 
 import {DashboardComponent} from './dashboard.component';
 

--- a/web/app/dashboard/dashboard.module.ts
+++ b/web/app/dashboard/dashboard.module.ts
@@ -9,7 +9,7 @@ import {CommonComponentsModule} from '../common/components/common-components.mod
 import {DashboardComponent} from '../dashboard/dashboard.component';
 import {ProjectComponent} from '../project/project.component';
 import {DataService} from '../services/data.service';
-import {SharedMaterialModule} from '../shared_material.module';
+import {SharedMaterialModule} from '../root/shared_material.module';
 import {AddProjectDialogComponent} from './add-project-dialog/add-project-dialog.component';
 import {AddProjectDialogModule} from './add-project-dialog/add-project-dialog.modules';
 

--- a/web/app/login/login.component.html
+++ b/web/app/login/login.component.html
@@ -8,6 +8,11 @@
       <label>Password</label>
       <input [(ngModel)]="password" type="password">
     </div>
+
     <button mat-raised-button color="primary" (click)="login()" [disabled]="isLoggingIn">Login</button>
+
+    <span *ngIf="hasError" class="form-error">
+      Could not log you in. Please try again.
+    </span>
   </div>
 </div>

--- a/web/app/login/login.component.scss
+++ b/web/app/login/login.component.scss
@@ -6,4 +6,8 @@
             padding-bottom: 4px;
         }
     }
+
+    .form-error {
+        margin-left: 1rem;
+    }
 }

--- a/web/app/login/login.component.spec.ts
+++ b/web/app/login/login.component.spec.ts
@@ -18,6 +18,7 @@ describe('LoginComponent', () => {
   let loginButtonEl: DebugElement;
   let emailEl: DebugElement;
   let passwordEl: DebugElement;
+  let errorEl: DebugElement;
   let loginSubject: Subject<LoginResponse>;
 
   beforeEach(async(() => {
@@ -85,5 +86,39 @@ describe('LoginComponent', () => {
     fixture.detectChanges();
 
     expect(loginButtonEl.nativeElement.disabled).toBe(false);
+  });
+
+  it('should re-enable login button after a failed login', () => {
+    expect(loginButtonEl.nativeElement.disabled).toBe(false);
+
+    loginButtonEl.triggerEventHandler('click', null);
+    fixture.detectChanges();
+
+    expect(loginButtonEl.nativeElement.disabled).toBe(true);
+
+    loginSubject.error(null);
+    fixture.detectChanges();
+
+    expect(loginButtonEl.nativeElement.disabled).toBe(false);
+  });
+
+  it('should show an error message after a failed login attempt', () => {
+    function getFormErrorEl() {
+      return fixture.debugElement.query(By.css('.form-error'));
+    }
+
+    expect(getFormErrorEl()).toBeNull();
+
+    loginButtonEl.triggerEventHandler('click', null);
+    fixture.detectChanges();
+
+    expect(getFormErrorEl()).toBeNull();
+
+    loginSubject.error(null);
+    fixture.detectChanges();
+
+    errorEl = getFormErrorEl();
+    expect(errorEl).not.toBeNull();
+    expect(errorEl.nativeElement.textContent.trim()).toBe('Could not log you in. Please try again.');
   });
 });

--- a/web/app/login/login.component.ts
+++ b/web/app/login/login.component.ts
@@ -11,20 +11,28 @@ import {AuthService} from '../services/auth.service';
 export class LoginComponent {
   email: string;
   password: string;
+
   isLoggingIn = false;
+  hasError = false;
 
   constructor(
       private readonly authService: AuthService,
       private readonly router: Router) {}
 
   login(): void {
-    this.isLoggingIn = true;
+    this.isLoggingIn = true
+    this.hasError = false
+
     this.authService.login({email: this.email, password: this.password})
         .subscribe(() => {
-          this.isLoggingIn = false;
+          this.isLoggingIn = false
+
           // TODO: preserve user's state and return to that instead
           // Logged-in go back to landing page
           this.router.navigate(['/']);
+        }, () => {
+          this.isLoggingIn = false
+          this.hasError = true
         });
   }
 }

--- a/web/app/login/login.module.ts
+++ b/web/app/login/login.module.ts
@@ -1,3 +1,4 @@
+import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material';
@@ -15,7 +16,7 @@ import {LoginComponent} from './login.component';
   ],
   imports: [
     /** Angular Library Imports */
-    FormsModule,
+    CommonModule, FormsModule,
     /** Internal Imports */
     /** Angular Material Imports */
     MatButtonModule,

--- a/web/app/project/project.component.spec.ts
+++ b/web/app/project/project.component.spec.ts
@@ -13,7 +13,7 @@ import {ToolbarModule} from '../common/components/toolbar/toolbar.module';
 import {mockProject} from '../common/test_helpers/mock_project_data';
 import {Project} from '../models/project';
 import {DataService} from '../services/data.service';
-import {SharedMaterialModule} from '../shared_material.module';
+import {SharedMaterialModule} from '../root/shared_material.module';
 
 import {ProjectComponent} from './project.component';
 


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [ ] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [ ] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving

Failed login attempt kept the login-button disabled. This PR fixes this, so you'll get a very basic error-message and re-enables the login-button. 

❗️ _Includes the same commit as in #968, as I couldn't build the project without it._

![image](https://user-images.githubusercontent.com/2340997/41034249-50bd5858-6989-11e8-9330-4127b9b05609.png)
