### PR TITLE
Revert "Update Sinatra to >=2.0.2 for vulnerability"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ source("https://rubygems.org")
 
 # Sinatra
 gem "faye-websocket", ">= 0.10.7", "< 1.0.0" # web socket connection for Sinatra
-gem "sinatra", ">= 2.0.2", "< 3.0.0" # Our web application library
-gem "sinatra-contrib", ">= 2.0.2", "< 3.0.0" # includes some Sinatra helper methods
+gem "sinatra", ">= 2.0.1", "< 3.0.0" # Our web application library
+gem "sinatra-contrib", ">= 2.0.0", "< 3.0.0" # includes some Sinatra helper methods
 gem "sinatra-flash" # renders error messages in the browser - remove once we switched to new frontend
 
 # web server that we need to support web socket connections with sinatra

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     ast (2.4.0)
     atomos (0.1.2)
     babosa (1.0.2)
-    backports (2.8.2)
+    backports (3.11.3)
     bcrypt (3.1.12)
     byebug (10.0.2)
     claide (1.0.2)
@@ -210,7 +210,7 @@ GEM
     public_suffix (2.0.5)
     raabro (1.1.5)
     rack (2.0.5)
-    rack-protection (2.0.2)
+    rack-protection (2.0.1)
       rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -264,17 +264,17 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (2.0.2)
+    sinatra (2.0.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.2)
+      rack-protection (= 2.0.1)
       tilt (~> 2.0)
-    sinatra-contrib (2.0.2)
-      backports (~> 2.8.2)
+    sinatra-contrib (2.0.1)
+      backports (>= 2.0)
       multi_json
       mustermann (~> 1.0)
-      rack-protection (= 2.0.2)
-      sinatra (= 2.0.2)
+      rack-protection (= 2.0.1)
+      sinatra (= 2.0.1)
       tilt (>= 1.3, < 3)
     sinatra-flash (0.3.0)
       sinatra (>= 1.0.0)
@@ -361,8 +361,8 @@ DEPENDENCIES
   rspec
   rubocop
   rufus-scheduler (>= 3.5.0, < 4.0.0)
-  sinatra (>= 2.0.2, < 3.0.0)
-  sinatra-contrib (>= 2.0.2, < 3.0.0)
+  sinatra (>= 2.0.1, < 3.0.0)
+  sinatra-contrib (>= 2.0.0, < 3.0.0)
   sinatra-flash
   taskqueue!
   thin (>= 1.7.2, < 2.0.0)


### PR DESCRIPTION
Reverts fastlane/ci#970

2.0.2 crashes on startup due to

```
NoMethodError: Failed to open TCP connection to api.github.com:443 (undefined method `[]' for nil:NilClass)
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:882:in `rescue in block in connect'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:879:in `block in connect'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/2.3.0/timeout.rb:91:in `block in timeout'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/2.3.0/timeout.rb:101:in `timeout'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:878:in `connect'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:863:in `do_start'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:852:in `start'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:1398:in `request'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb:1156:in `get'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.2/lib/faraday/adapter/net_http.rb:85:in `perform_request'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.2/lib/faraday/adapter/net_http.rb:43:in `block in call'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.2/lib/faraday/adapter/net_http.rb:92:in `with_net_http_connection'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.2/lib/faraday/adapter/net_http.rb:38:in `call'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.2/lib/faraday/response.rb:8:in `call'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.2/lib/faraday/response.rb:8:in `call'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/octokit-4.9.0/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/octokit-4.9.0/lib/octokit/middleware/follow_redirects.rb:61:in `call'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.2/lib/faraday/rack_builder.rb:143:in `build_response'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.2/lib/faraday/connection.rb:387:in `run_request'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.2/lib/faraday/connection.rb:138:in `get'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sawyer-0.8.1/lib/sawyer/agent.rb:94:in `call'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/octokit-4.9.0/lib/octokit/connection.rb:156:in `request'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/octokit-4.9.0/lib/octokit/connection.rb:84:in `paginate'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/octokit-4.9.0/lib/octokit/client/users.rb:300:in `emails'
  /Users/liebowitz/dev/ci/app/services/services.rb:115:in `provider_credential'
  /Users/liebowitz/dev/ci/app/services/services.rb:182:in `configuration_repository_service'
  /Users/liebowitz/dev/ci/app/services/onboarding_service.rb:81:in `remote_configuration_repository_valid?'
  /Users/liebowitz/dev/ci/app/services/onboarding_service.rb:56:in `required_keys_and_proper_remote_configuration_repo?'
  /Users/liebowitz/dev/ci/app/services/onboarding_service.rb:37:in `correct_setup?'
  /Users/liebowitz/dev/ci/launch.rb:161:in `start_github_workers'
  /Users/liebowitz/dev/ci/launch.rb:37:in `take_off'
  /Users/liebowitz/dev/ci/config.ru:8:in `block in <main>'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/lib/rack/builder.rb:55:in `instance_eval'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/lib/rack/builder.rb:55:in `initialize'
  /Users/liebowitz/dev/ci/config.ru:in `new'
  /Users/liebowitz/dev/ci/config.ru:in `<main>'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/lib/rack/builder.rb:49:in `eval'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/lib/rack/builder.rb:49:in `new_from_string'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/lib/rack/builder.rb:40:in `parse_file'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/lib/rack/server.rb:319:in `build_app_and_options_from_config'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/lib/rack/server.rb:219:in `app'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/lib/rack/server.rb:354:in `wrapped_app'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/lib/rack/server.rb:283:in `start'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/lib/rack/server.rb:148:in `start'
  /Users/liebowitz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.5/bin/rackup:4:in `<top (required)>'
  /Users/liebowitz/.rbenv/versions/2.3.3/bin/rackup:22:in `load'
  /Users/liebowitz/.rbenv/versions/2.3.3/bin/rackup:22:in `<top (required)>'
```