### PR TITLE
Fix startup issues

### DIFF
--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -201,7 +201,13 @@ module FastlaneCI
       @environment_variables_set = []
 
       # Set the CI specific Environment variables first
-      build_url = File.join(Services.dot_keys_variable_service.ci_base_url, "projects", project.id, "builds", build.number)
+      build_url = File.join(
+        Services.dot_keys_variable_service.keys.ci_base_url,
+        "projects",
+        project.id,
+        "builds",
+        current_build_number.to_s
+      )
 
       # We try to follow the existing formats
       # https://wiki.jenkins.io/display/JENKINS/Building+a+software+project
@@ -212,7 +218,7 @@ module FastlaneCI
         GIT_URL: repo.git_config.git_url,
         GIT_SHA: current_build.sha,
         BUILD_URL: build_url,
-        BUILD_ID: build.number,
+        BUILD_ID: current_build_number.to_s,
         CI_NAME: "fastlane.ci",
         FASTLANE_CI: true,
         CI: true

--- a/app/services/dot_keys_variable_service.rb
+++ b/app/services/dot_keys_variable_service.rb
@@ -1,5 +1,6 @@
 require_relative "./file_writers/keys_writer"
 require_relative "./services"
+require_relative "../shared/dot_keys_variables"
 
 module FastlaneCI
   # Logic pertaining to .keys environment variable configuration, this only includes the .keys file
@@ -23,6 +24,10 @@ module FastlaneCI
       new_dot_key_variables = FastlaneCI.dot_keys.all.merge(non_nil_new_env_variables)
       KeysWriter.new(path: keys_file_path, locals: new_dot_key_variables).write!
       reload_dot_env!
+    end
+
+    def keys
+      return DotKeysVariables.new
     end
 
     # Reloads the dot key variables and resets the memoized services that


### PR DESCRIPTION
- dot key service now has `keys` method that returns a new `DotKeysVariables` object with each call
- some variables were mis-named.

- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
