### PR TITLE
notification service was missing from config-repo

### DIFF
--- a/app/services/services.rb
+++ b/app/services/services.rb
@@ -127,7 +127,8 @@ module FastlaneCI
         project_data_source: FastlaneCI::JSONProjectDataSource.create(
           ci_config_git_repo_path,
           git_config: ci_config_repo,
-          user: ci_user
+          user: ci_user,
+          notification_service: Services.notification_service
         )
       )
     end


### PR DESCRIPTION
Fixes #974 

- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
