### PR TITLE
Fixed edge-case with server launch.

### DIFF
--- a/app/services/onboarding_service.rb
+++ b/app/services/onboarding_service.rb
@@ -8,6 +8,11 @@ module FastlaneCI
   class OnboardingService
     include FastlaneCI::Logging
 
+    # File names that should be present in configuration repository.
+    #
+    # @return [Array[String]]
+    CONFIGURATION_FILES = ["users.json", "projects.json", "environment_variables.json"].freeze
+
     # Triggers the initial clone of the remote configuration repository, to the
     # local fastlane configuration repository in `~/.fastlane/ci`
     #
@@ -62,12 +67,20 @@ module FastlaneCI
       return @setup_correctly
     end
 
-    # Returns `true` if the local configuration repository exists
+    # Returns `true` if the local configuration repository exists, and all
+    # required files are present
     #
     # @return [Boolean]
     def local_configuration_repo_exists?
       unless Dir.exist?(Services.ci_config_git_repo_path)
         logger.debug("local configuration repo doesn't exist")
+        return false
+      end
+
+      configuration_repo_contents = Dir[File.join(Services.ci_config_git_repo_path, "*")]
+
+      unless CONFIGURATION_FILES.all? { |f| configuration_repo_contents.include?(f) }
+        logger.debug("local configuration repo doesn't contain required configuration files")
         return false
       end
 

--- a/app/services/onboarding_service.rb
+++ b/app/services/onboarding_service.rb
@@ -78,8 +78,9 @@ module FastlaneCI
       end
 
       configuration_repo_contents = Dir[File.join(Services.ci_config_git_repo_path, "*")]
+      configuration_files = CONFIGURATION_FILES.map { |f| File.join(Services.ci_config_git_repo_path, f) }
 
-      unless CONFIGURATION_FILES.all? { |f| configuration_repo_contents.include?(f) }
+      unless configuration_files.all? { |f| configuration_repo_contents.include?(f) }
         logger.debug("local configuration repo doesn't contain required configuration files")
         return false
       end


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving

### Changes

Fixed edge-case with server launch when `Services.ci_config_git_repo_path` exists, but the directory doesn't have the necessary configuration files.

### Rationale

When setting up `fastlane.ci` again, I ran into an issue where the configuration repository was not cloned properly. The directory for `Services.ci_config_git_repo_path` existed, but it was missing the necessary configuration files: `users.json`, `projects.json`, and `environment_variables.json`.