### PR TITLE
Agent throttling test and a multithreading fix

### DIFF
--- a/agent/invocation.rb
+++ b/agent/invocation.rb
@@ -12,13 +12,14 @@ module FastlaneCI::Agent
   #
   class Invocation
     include Logging
+    include Recipes
     prepend StateMachine
 
     def initialize(invocation_request, yielder)
       @invocation_request = invocation_request
       @yielder = yielder
       @output_queue = Queue.new
-      Recipes.output_queue = @output_queue
+      self.output_queue = @output_queue
     end
 
     ## 
@@ -35,7 +36,7 @@ module FastlaneCI::Agent
 
       git_url = command_env(:GIT_URL)
 
-      Recipes.setup_repo(git_url)
+      setup_repo(git_url)
 
       # TODO: ensure we are able to satisfy the request
       # unless has_required_xcode_version?
@@ -43,7 +44,7 @@ module FastlaneCI::Agent
       #   return
       # end
 
-      if Recipes.run_fastlane(@invocation_request.command.env.to_h)
+      if run_fastlane(@invocation_request.command.env.to_h)
         finish
       else
         # fail is a keyword, so we must call self.
@@ -56,7 +57,7 @@ module FastlaneCI::Agent
     def finish
       artifact_path = command_env(:FASTLANE_CI_ARTIFACTS)
 
-      file_path = Recipes.archive_artifacts(artifact_path)
+      file_path = archive_artifacts(artifact_path)
       send_file(file_path)
       succeed
     end

--- a/agent/invocation.rb
+++ b/agent/invocation.rb
@@ -22,7 +22,7 @@ module FastlaneCI::Agent
       self.output_queue = @output_queue
     end
 
-    ## 
+    ##
     # StateMachine actions
     # These methods run as hooks whenever a transition was successful.
     ##

--- a/agent/invocation/recipes.rb
+++ b/agent/invocation/recipes.rb
@@ -5,10 +5,7 @@ module FastlaneCI::Agent
   ##
   # stateless invocation recipes go here
   module Recipes
-    extend Logging
-
-    # all method below this are module functions, callable on the module directly.
-    module_function
+    include Logging
 
     ##
     # set up a Queue that is used to push output from stdout/err from commands that shell out.

--- a/agent/service.rb
+++ b/agent/service.rb
@@ -73,17 +73,17 @@ module FastlaneCI
         command = invocation_request.command
         logger.info("RPC run_fastlane: #{command.bin} #{command.parameters}, env: #{command.env.to_h}")
         Enumerator.new do |yielder|
+          invocation = Invocation.new(invocation_request, yielder)
+          if busy?
+            invocation.reject(RuntimeError.new("I am busy"))
+            next
+          end
           begin
-            invocation = Invocation.new(invocation_request, yielder)
-            if busy?
-              invocation.reject(RuntimeError.new("I am busy"))
-              next
-            end
             @busy = true
             invocation.run
-            @busy = false
           rescue StandardError => exception
             invocation.throw(exception)
+          ensure
             @busy = false
           end
         end

--- a/spec/agent/invocation/recipes_spec.rb
+++ b/spec/agent/invocation/recipes_spec.rb
@@ -3,24 +3,27 @@ require "agent/invocation/recipes"
 
 describe FastlaneCI::Agent::Recipes do
   let(:queue) { Queue.new }
-
+  class RecipesIncludingClass
+    include FastlaneCI::Agent::Recipes
+  end
   before do
-    FastlaneCI::Agent::Recipes.output_queue = queue
+    @recipes_including_class = RecipesIncludingClass.new
+    @recipes_including_class.output_queue = queue
   end
 
   it "shell commands put the command, and stdout and stderr on the output queue" do
-    FastlaneCI::Agent::Recipes.sh("echo foo")
+    @recipes_including_class.sh("echo foo")
     expect(queue.pop).to eq("echo foo")
     expect(queue.pop).to eq("foo\n")
 
-    FastlaneCI::Agent::Recipes.sh("echo error 1>&2")
+    @recipes_including_class.sh("echo error 1>&2")
     expect(queue.pop).to eq("echo error 1>&2")
     expect(queue.pop).to eq("error\n")
   end
 
   it "raises an exception if a command exits non-zero" do
     expect do
-      FastlaneCI::Agent::Recipes.sh("false")
+      @recipes_including_class.sh("false")
     end.to raise_error(SystemCallError)
   end
 end

--- a/spec/agent/service_spec.rb
+++ b/spec/agent/service_spec.rb
@@ -29,6 +29,39 @@ describe FastlaneCI::Agent::Service do
     end
   end
 
+  describe "#run_fastlane" do
+    let(:call) { double("GRP Call") }
+    let(:command) { instance_double("FastlaneCI::Agent::Command", env: {}, bin: "/bin/echo", parameters: ["hello world"]) }
+    let(:request) { instance_double("FastlaneCI::Agent::InvocationRequest", command: command) }
+    it "reject all requests while busy" do
+      # stub StateMachine.run to keep the server busy for 3 sec when run_fastlane is called.
+      allow_any_instance_of(FastlaneCI::Agent::StateMachine).to receive(:run) do
+        raise RuntimeError("Exception in mocked StateMachine.run will generate 2 InvocationResponses")
+      end
+
+      # calling run_fastlane will not start the actual work until we start iterating on the response stream
+      responses = service.run_fastlane(request, call)
+
+      # reading the first InvocationResponse puts the agent into busy mode.
+      responses.next
+
+      2.times do 
+        busy_responses = service.run_fastlane(request, call)
+        expect(busy_responses.next.state).to eq(:REJECTED)
+        loop { busy_responses.next }
+      end
+      
+      # Finish the task by reading the rest of the response stream;
+      # This should put the agent back in non-busy mode.
+      loop { responses.next }
+
+      # Let's validate that once the running invocation is done we can accept new requests
+      responses = service.run_fastlane(request, call)
+      expect(responses.next.state).not_to eq(:REJECTED)
+      loop { responses.next }
+    end
+  end
+
   describe FastlaneCI::Agent::Service::ProcessOutputEnumerator do
     let(:io) { double("IO-like", gets: "this is a line of text\n") }
 

--- a/spec/agent/service_spec.rb
+++ b/spec/agent/service_spec.rb
@@ -45,19 +45,19 @@ describe FastlaneCI::Agent::Service do
       # reading the first InvocationResponse puts the agent into busy mode.
       responses.next
 
-      2.times do 
+      2.times do
         busy_responses = service.run_fastlane(request, call)
         expect(busy_responses.next.state).to eq(:REJECTED)
         loop { busy_responses.next }
       end
-      
+
       # Finish the task by reading the rest of the response stream;
       # This should put the agent back in non-busy mode.
       loop { responses.next }
 
       # Let's validate that once the running invocation is done we can accept new requests
       responses = service.run_fastlane(request, call)
-      expect(responses.next.state).not_to eq(:REJECTED)
+      expect(responses.next.state).not_to(eq(:REJECTED))
       loop { responses.next }
     end
   end


### PR DESCRIPTION
This PR: 
- Adds a test for the throttling support on the agent. 
- Fixes a multithreading issue: the Recipes module was using a singleton  output_queue for logs which was getting reset when a parallel call (to be rejected) was received by the Agent, causing the logs to get lost. 
- Simplifies the reseting of the busy status.

- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build