### PR TITLE
Remove Agent.spawn

### DIFF
--- a/agent/service.rb
+++ b/agent/service.rb
@@ -8,24 +8,6 @@ module FastlaneCI
     # A simple implementation of the agent service.
     class Service < FastlaneCI::Proto::Agent::Service
       include FastlaneCI::Agent::Logging
-      ##
-      # this class is used to create a lazy enumerator
-      # that will yield back lines from the stdout/err of the process
-      # as well as the exit status when it is complete.
-      class ProcessOutputEnumerator
-        extend Forwardable
-        include Enumerable
-
-        def_delegators :@enumerator, :each, :next
-
-        def initialize(io, thread)
-          @enumerator = Enumerator.new do |yielder|
-            yielder.yield(io.gets) while thread.alive?
-            io.close
-            yielder.yield(EOT_CHAR, thread.value.exitstatus)
-          end
-        end
-      end
 
       ##
       # returns a configured GRPC server ready to listen for connections.

--- a/agent/service.rb
+++ b/agent/service.rb
@@ -27,30 +27,6 @@ module FastlaneCI
         @busy
       end
 
-      ##
-      # spawns a command using popen2e. Merging stdout and stderr,
-      # because its easiest to return the lazy stream when both stdout and stderr pipes are together.
-      # otherwise, we run the risk of deadlock if we dont properly flush both pipes as per:
-      # https://ruby-doc.org/stdlib-2.1.0/libdoc/open3/rdoc/Open3.html#method-c-popen3
-      #
-      # @input FastlaneCI::Agent::Command
-      # @output Enumerable::Lazy<FastlaneCI::Agent::Log> A lazy enumerable with log lines.
-      def spawn(command, _call)
-        logger.info("spawning process with command: #{command.bin} #{command.parameters}, env: #{command.env.to_h}")
-        stdin, stdouterr, wait_thrd = Open3.popen2e(command.env.to_h, command.bin, *command.parameters)
-        stdin.close
-
-        logger.info("spawned process with pid: #{wait_thrd.pid}")
-
-        output_enumerator = ProcessOutputEnumerator.new(stdouterr, wait_thrd)
-        # convert every line from io to a Log object in a lazy stream
-        output_enumerator.lazy.flat_map do |line, status|
-          # proto3 doesn't have nullable fields, afaik
-          log = FastlaneCI::Proto::Log.new(message: (line || NULL_CHAR), status: (status || 0))
-          FastlaneCI::Proto::InvocationResponse.new(log: log)
-        end
-      end
-
       def run_fastlane(invocation_request, _call)
         command = invocation_request.command
         logger.info("RPC run_fastlane: #{command.bin} #{command.parameters}, env: #{command.env.to_h}")

--- a/protos/agent.proto
+++ b/protos/agent.proto
@@ -11,7 +11,6 @@ syntax = "proto3";
 package FastlaneCI.Proto;
 
 service Agent {
-  rpc Spawn(Command) returns (stream InvocationResponse) {}
   rpc RunFastlane(InvocationRequest) returns (stream InvocationResponse) {}
 }
 

--- a/protos/agent_services_pb.rb
+++ b/protos/agent_services_pb.rb
@@ -23,7 +23,6 @@ module FastlaneCI
         self.unmarshal_class_method = :decode
         self.service_name = 'FastlaneCI.Proto.Agent'
 
-        rpc :Spawn, Command, stream(InvocationResponse)
         rpc :RunFastlane, InvocationRequest, stream(InvocationResponse)
       end
 

--- a/spec/agent/service_spec.rb
+++ b/spec/agent/service_spec.rb
@@ -8,27 +8,6 @@ describe FastlaneCI::Agent::Service do
     expect(FastlaneCI::Agent::Service.server).to be_instance_of(GRPC::RpcServer)
   end
 
-  describe "#spawn" do
-    echo_message = "hello world"
-    let(:command) { instance_double("FastlaneCI::Agent::Command", env: {}, bin: "/bin/echo", parameters: [echo_message]) }
-    let(:call) { double("GRP Call") }
-
-    it "spawns a command with the environment and parameters" do
-      expect(Open3).to receive(:popen2e).and_call_original
-      service.spawn(command, call)
-    end
-
-    it "returns a ProcessEnumerator that contains the output of the command" do
-      responses = service.spawn(command, call)
-      expect(responses).to be_instance_of(Enumerator::Lazy)
-      expect(responses.peek.log.message).to start_with(echo_message)
-      responses.each do |response|
-        expect(response).to be_instance_of(FastlaneCI::Proto::InvocationResponse)
-        expect(response.log).to be_instance_of(FastlaneCI::Proto::Log)
-      end
-    end
-  end
-
   describe "#run_fastlane" do
     let(:call) { double("GRP Call") }
     let(:command) { instance_double("FastlaneCI::Agent::Command", env: {}, bin: "/bin/echo", parameters: ["hello world"]) }
@@ -59,39 +38,6 @@ describe FastlaneCI::Agent::Service do
       responses = service.run_fastlane(request, call)
       expect(responses.next.state).not_to(eq(:REJECTED))
       loop { responses.next }
-    end
-  end
-
-  describe FastlaneCI::Agent::Service::ProcessOutputEnumerator do
-    let(:io) { double("IO-like", gets: "this is a line of text\n") }
-
-    let(:thread_value) { double("thread value") }
-    let(:thread) { double("Thread", alive?: true, value: thread_value) }
-
-    let(:output_enumerator) { FastlaneCI::Agent::Service::ProcessOutputEnumerator.new(io, thread) }
-
-    it "will return lines of text from the file" do
-      expect(output_enumerator.next).to eq("this is a line of text\n")
-    end
-
-    it "enumerates lines from a file until the thread dies and returns its status" do
-      allow(thread).to receive(:alive?).and_return(false)
-      allow(thread_value).to receive(:exitstatus).and_return(0)
-      allow(io).to receive(:close)
-
-      expect { |block| output_enumerator.each(&block) }.to yield_with_args("\4", 0)
-    end
-
-    it "closes the file handle when the thread dies" do
-      allow(thread).to receive(:alive?).and_return(false)
-      allow(thread_value).to receive(:exitstatus).and_return(0)
-
-      expect(io).to receive(:close)
-      output_enumerator.next
-    end
-
-    it "can convert to a lazy Enumerator" do
-      expect(output_enumerator.lazy).to be_instance_of(Enumerator::Lazy)
     end
   end
 end


### PR DESCRIPTION
spawn was only a playground for experimenting with gRpc so no longer needed. 

- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build