### PR TITLE
Add new json_error method for API layer

### DIFF
--- a/app/features-json/api_controller.rb
+++ b/app/features-json/api_controller.rb
@@ -148,6 +148,15 @@ module FastlaneCI
         current_user != nil
       end
 
+      def json_error(error_message:, error_key:, error_code: 400)
+        status(error_code)
+
+        return json({
+          error: error_message,
+          error_code: error_key
+        })
+      end
+
       def current_user_provider_credential
         provider_credential = current_user.provider_credential
         halt(404, "Provider Credential not found.") unless provider_credential

--- a/app/features-json/api_controller.rb
+++ b/app/features-json/api_controller.rb
@@ -151,10 +151,10 @@ module FastlaneCI
       def json_error(error_message:, error_key:, error_code: 400)
         status(error_code)
 
-        return json({
+        halt(error_code, json({
           error: error_message,
           error_code: error_key
-        })
+        }))
       end
 
       def current_user_provider_credential

--- a/app/features-json/setting_json_controller.rb
+++ b/app/features-json/setting_json_controller.rb
@@ -16,7 +16,7 @@ module FastlaneCI
       setting = Services.setting_service.find_setting(setting_key: key.to_sym)
 
       if setting.nil?
-        return json_error(
+        json_error(
           error_message: "`#{params[:setting_key]}` not found.",
           error_key: "InvalidParameter.KeyNotFound"
         )
@@ -41,7 +41,7 @@ module FastlaneCI
         Services.setting_service.reset_setting!(setting_key: params[:setting_key])
         return json({ status: :success })
       rescue SettingServiceKeyNotFoundError
-        return json_error(
+        json_error(
           error_message: "`#{params[:setting_key]}` not found.",
           error_key: "InvalidParameter.KeyNotFound"
         )

--- a/app/features-json/setting_json_controller.rb
+++ b/app/features-json/setting_json_controller.rb
@@ -14,8 +14,13 @@ module FastlaneCI
       value = params[:value]
 
       setting = Services.setting_service.find_setting(setting_key: key.to_sym)
-      # TODO: use right exit code below & update tests
-      return json({ error: "`#{params[:setting_key]}` not found." }) if setting.nil?
+
+      if setting.nil?
+        return json_error(
+          error_message: "`#{params[:setting_key]}` not found.",
+          error_key: "InvalidParameter.KeyNotFound"
+        )
+      end
 
       # TODO: security aspect, how do we make sure this can't be abused?
       # We don't want to hash/encrypt all of them, as this would make it harder for
@@ -36,7 +41,10 @@ module FastlaneCI
         Services.setting_service.reset_setting!(setting_key: params[:setting_key])
         return json({ status: :success })
       rescue SettingServiceKeyNotFoundError
-        halt(404, "`#{params[:setting_key]}` not found.")
+        return json_error(
+          error_message: "`#{params[:setting_key]}` not found.",
+          error_key: "InvalidParameter.KeyNotFound"
+        )
       end
     end
   end

--- a/spec/features-json/setting_json_controller_spec.rb
+++ b/spec/features-json/setting_json_controller_spec.rb
@@ -48,9 +48,10 @@ describe FastlaneCI::SettingJSONController do
     it "returns an error if key doesn't exist" do
       non_existent_key = "non_existent_key"
       post("/data/settings/#{non_existent_key}")
-      # expect(last_response).to_not be_ok # TODO: use right exit code
-      expect(json["error"].to_s.length).to be > 0
+
+      expect(last_response).to_not(be_ok)
       expect(json["error"]).to eq("`non_existent_key` not found.")
+      expect(json["error_code"]).to eq("InvalidParameter.KeyNotFound")
     end
   end
 
@@ -65,6 +66,15 @@ describe FastlaneCI::SettingJSONController do
       expect(json).to eq({ "status" => "success" })
 
       expect(FastlaneCI::Services.setting_service.find_setting(setting_key: metrics_key.to_sym).value).to eq(nil)
+    end
+
+    it "returns an error if key can't be found" do
+      non_existent_key = "non_existent_key"
+      delete("/data/settings/#{non_existent_key}")
+
+      expect(last_response).to_not(be_ok)
+      expect(json["error"]).to eq("`non_existent_key` not found.")
+      expect(json["error_code"]).to eq("InvalidParameter.KeyNotFound")
     end
   end
 end

--- a/spec/features-json/setting_json_controller_spec.rb
+++ b/spec/features-json/setting_json_controller_spec.rb
@@ -49,7 +49,7 @@ describe FastlaneCI::SettingJSONController do
       non_existent_key = "non_existent_key"
       post("/data/settings/#{non_existent_key}")
 
-      expect(last_response).to_not(be_ok)
+      expect(last_response.status).to eq(400)
       expect(json["error"]).to eq("`non_existent_key` not found.")
       expect(json["error_code"]).to eq("InvalidParameter.KeyNotFound")
     end
@@ -72,7 +72,7 @@ describe FastlaneCI::SettingJSONController do
       non_existent_key = "non_existent_key"
       delete("/data/settings/#{non_existent_key}")
 
-      expect(last_response).to_not(be_ok)
+      expect(last_response.status).to eq(400)
       expect(json["error"]).to eq("`non_existent_key` not found.")
       expect(json["error_code"]).to eq("InvalidParameter.KeyNotFound")
     end


### PR DESCRIPTION
I really like the way the new AppStore Connect API works when it comes to error_keys, they do something like

```
InvalidParameter.KeyNotFound
```

where as the client can then decide how generic they want to parse the error message.

We could build up Ruby classes to represent those, but it might be overkill, and maybe we want just a markdown file maintained by us for now, listing all the available error codes, grouped by the first layer (e.g. InvalidParameter)

Long term, we probably do want those represented in Ruby classes/constants somehow and auto-generate the markdown file based on that.