### PR TITLE
Remove `environment_variables.json` from list of required configuration files in `OnboardingService`.

### DIFF
--- a/app/services/onboarding_service.rb
+++ b/app/services/onboarding_service.rb
@@ -11,7 +11,7 @@ module FastlaneCI
     # File names that should be present in configuration repository.
     #
     # @return [Array[String]]
-    CONFIGURATION_FILES = ["users.json", "projects.json", "environment_variables.json"].freeze
+    CONFIGURATION_FILES = ["users.json", "projects.json"].freeze
 
     # Triggers the initial clone of the remote configuration repository, to the
     # local fastlane configuration repository in `~/.fastlane/ci`


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving

Fixes #996 