### PR TITLE
Project Detail page

### DIFF
--- a/app/features-json/build_json_controller.rb
+++ b/app/features-json/build_json_controller.rb
@@ -1,4 +1,5 @@
 require_relative "api_controller"
+require_relative "./view_models/build_summary_view_model"
 require_relative "./view_models/build_view_model"
 
 module FastlaneCI
@@ -87,8 +88,8 @@ module FastlaneCI
       build_runner.setup(parameters: nil)
       Services.build_runner_service.add_build_runner(build_runner: build_runner)
 
-      build_view_model = BuildViewModel.new(build: build_runner.current_build)
-      json(build_view_model)
+      build_summary_view_model = BuildSummaryViewModel.new(build: build_runner.current_build)
+      json(build_summary_view_model)
     end
 
     def current_project

--- a/app/features-json/view_models/build_summary_view_model.rb
+++ b/app/features-json/view_models/build_summary_view_model.rb
@@ -24,6 +24,9 @@ module FastlaneCI
     # @return [DateTime] Start time
     attr_reader :timestamp
 
+    # @return [String] The git branch
+    attr_reader :branch
+
     def initialize(build:)
       raise "Incorrect object type. Expected Build, got #{build.class}" unless build.kind_of?(Build)
 
@@ -33,6 +36,7 @@ module FastlaneCI
       @sha = build.sha
       @link_to_sha = build.link_to_remote_commit
       @timestamp = build.timestamp
+      @branch = build.git_fork_config.branch
     end
   end
 end

--- a/app/features-json/view_models/project_view_model.rb
+++ b/app/features-json/view_models/project_view_model.rb
@@ -13,6 +13,12 @@ module FastlaneCI
     # @return [String] Is a UUID so we're not open to ID guessing attacks
     attr_reader :id
 
+    # @return [String]
+    attr_reader :repo_name
+
+    # @return [String] lane name to run
+    attr_accessor :lane
+
     # @return [Array[BuildSummaryViewModel]]
     attr_reader :builds
 
@@ -21,7 +27,9 @@ module FastlaneCI
 
       @name = project.project_name
       @id = project.id
+      @lane = project.lane
       @builds = project.builds.map { |build| BuildSummaryViewModel.new(build: build) }
+      @repo_name = project.repo_config.name
     end
   end
 end

--- a/web/app/common/components/status-icon/status-icon.component.scss
+++ b/web/app/common/components/status-icon/status-icon.component.scss
@@ -1,3 +1,14 @@
+:host {
+    font-size: 24px;
+    width: 24px;
+    height: 24px;
+    .mat-icon {
+        width: inherit;
+        height: inherit;
+        font-size: inherit;
+    }
+}
+
 .fci-status-icon-success {
     color: #00897b;
 }

--- a/web/app/common/test_helpers/dummy.component.ts
+++ b/web/app/common/test_helpers/dummy.component.ts
@@ -1,0 +1,5 @@
+import {Component, OnInit, ViewChild} from '@angular/core';
+@Component({selector: 'fci-dummy', template: ''})
+
+export class DummyComponent {
+}

--- a/web/app/common/test_helpers/mock_build_data.ts
+++ b/web/app/common/test_helpers/mock_build_data.ts
@@ -7,6 +7,7 @@ export const mockBuildSummaryResponse_failure: BuildSummaryResponse = {
   status: 'failure',
   duration: 1234,
   sha: 'cjsh4',
+  branch: 'master',
   link_to_sha:
       'https://github.com/fastlane/ci/commit/1015c506762b1396a5d63fff6fe0f1de43c8de80',
   timestamp: '2018-04-04 16:11:58 -0700'
@@ -16,6 +17,7 @@ export const mockBuildSummaryResponse_success: BuildSummaryResponse = {
   number: 2,
   status: 'success',
   duration: 221234,
+  branch: 'master',
   sha: 'asdfshzdggfdhdfh4',
   link_to_sha:
       'https://github.com/fastlane/ci/commit/1015c506762b1396a5d63fff6fe0f1de43c8de80',

--- a/web/app/common/test_helpers/mock_build_data.ts
+++ b/web/app/common/test_helpers/mock_build_data.ts
@@ -1,5 +1,5 @@
 import {Build, BuildArtifactResponse, BuildResponse} from '../../models/build';
-import {BuildSummaryResponse} from '../../models/build_summary';
+import {BuildSummary, BuildSummaryResponse} from '../../models/build_summary';
 
 // TODO: move all these mocks to common/ since they're being re-used.
 export const mockBuildSummaryResponse_failure: BuildSummaryResponse = {
@@ -50,3 +50,6 @@ export const mockBuildResponse: BuildResponse = {
 };
 
 export const mockBuild: Build = new Build(mockBuildResponse);
+
+export const mockBuildSummary_success =
+    new BuildSummary(mockBuildSummaryResponse_success);

--- a/web/app/common/test_helpers/mock_project_data.ts
+++ b/web/app/common/test_helpers/mock_project_data.ts
@@ -55,6 +55,8 @@ export const mockProjectSummary =
 
 export const mockProjectResponse: ProjectResponse = {
   id: '12',
+  repo_name: 'fastlane/TacoRocat',
+  lane: 'ios test',
   name: 'the most coolest project',
   builds: [mockBuildSummaryResponse_success, mockBuildSummaryResponse_failure]
 };

--- a/web/app/common/test_helpers/mock_project_data.ts
+++ b/web/app/common/test_helpers/mock_project_data.ts
@@ -61,4 +61,4 @@ export const mockProjectResponse: ProjectResponse = {
   builds: [mockBuildSummaryResponse_success, mockBuildSummaryResponse_failure]
 };
 
-export const mockProject = new Project(mockProjectResponse);
+export const getMockProject = () => new Project(mockProjectResponse);

--- a/web/app/dashboard/dashboard.component.scss
+++ b/web/app/dashboard/dashboard.component.scss
@@ -33,7 +33,7 @@
     .mat-row {
         cursor: pointer;
         &:hover {
-            background-color: #F3E5F5
+            background-color: #F3E5F5;
         }
         .mat-cell {
             white-space: nowrap;

--- a/web/app/models/build_summary.spec.ts
+++ b/web/app/models/build_summary.spec.ts
@@ -20,7 +20,7 @@ describe('Build Summary Model', () => {
     const FAILED_STATUSES: FastlaneStatus[] =
         ['failure', 'missing_fastfile', 'ci_problem'];
 
-    for (let status of FAILED_STATUSES) {
+    for (const status of FAILED_STATUSES) {
       it(`should be true for status: ${status}`, () => {
         const summaryResponse =
             Object.assign({}, mockBuildSummaryResponse_success);

--- a/web/app/models/build_summary.spec.ts
+++ b/web/app/models/build_summary.spec.ts
@@ -1,4 +1,4 @@
-import {BuildStatus} from '../common/constants';
+import {BuildStatus, FastlaneStatus} from '../common/constants';
 import {mockBuildSummaryResponse_success} from '../common/test_helpers/mock_build_data';
 
 import {BuildSummary} from './build_summary';
@@ -14,5 +14,28 @@ describe('Build Summary Model', () => {
     expect(build.shortSha).toBe('asdfsh');
     expect(build.date.getTime())
         .toBe(1522883518000);  // 2018-04-04 16:11:58 -0700
+  });
+
+  describe('#isFailure', () => {
+    const FAILED_STATUSES: FastlaneStatus[] =
+        ['failure', 'missing_fastfile', 'ci_problem'];
+
+    for (let status of FAILED_STATUSES) {
+      it(`should be true for status: ${status}`, () => {
+        const summaryResponse =
+            Object.assign({}, mockBuildSummaryResponse_success);
+        summaryResponse.status = status;
+
+        const build = new BuildSummary(summaryResponse);
+
+        expect(build.isFailure()).toBe(true);
+      });
+    }
+
+    it(`should be false for success status`, () => {
+      const build = new BuildSummary(mockBuildSummaryResponse_success);
+
+      expect(build.isFailure()).toBe(false);
+    });
   });
 });

--- a/web/app/models/build_summary.ts
+++ b/web/app/models/build_summary.ts
@@ -9,6 +9,7 @@ export interface BuildSummaryResponse {
   sha: string;
   link_to_sha: string;
   timestamp: string;
+  branch: string;
 }
 
 export class BuildSummary {
@@ -18,6 +19,7 @@ export class BuildSummary {
   readonly sha: string;
   readonly shortSha: string;
   readonly linkToSha: string;
+  readonly branch: string;
   readonly date: Date;
 
   constructor(buildSummary: BuildSummaryResponse) {
@@ -28,5 +30,6 @@ export class BuildSummary {
     this.shortSha = this.sha.slice(0, SHORT_SHA_LENGTH);
     this.status = fastlaneStatusToEnum(buildSummary.status);
     this.date = new Date(buildSummary.timestamp);
+    this.branch = buildSummary.branch;
   }
 }

--- a/web/app/models/build_summary.ts
+++ b/web/app/models/build_summary.ts
@@ -34,10 +34,11 @@ export class BuildSummary {
   }
 
   isFailure(): boolean {
-    return [
-      BuildStatus.FAILED,
-      BuildStatus.MISSING_FASTFILE,
-      BuildStatus.INTERNAL_ISSUE,
-    ].includes(this.status);
+    return new Set([
+             BuildStatus.FAILED,
+             BuildStatus.MISSING_FASTFILE,
+             BuildStatus.INTERNAL_ISSUE,
+           ])
+        .has(this.status);
   }
 }

--- a/web/app/models/build_summary.ts
+++ b/web/app/models/build_summary.ts
@@ -32,4 +32,12 @@ export class BuildSummary {
     this.date = new Date(buildSummary.timestamp);
     this.branch = buildSummary.branch;
   }
+
+  isFailure(): boolean {
+    return [
+      BuildStatus.FAILED,
+      BuildStatus.MISSING_FASTFILE,
+      BuildStatus.INTERNAL_ISSUE,
+    ].includes(this.status);
+  }
 }

--- a/web/app/models/project.spec.ts
+++ b/web/app/models/project.spec.ts
@@ -13,4 +13,16 @@ describe('Project Model', () => {
     expect(project.builds[0].status).toBe(BuildStatus.SUCCESS);
     expect(project.builds[1].status).toBe(BuildStatus.FAILED);
   });
+
+  it('should get last failed build', () => {
+    const project = new Project(mockProjectResponse);
+
+    expect(project.lastFailedBuild().number).toBe(1);
+  });
+
+  it('should get last successful build', () => {
+    const project = new Project(mockProjectResponse);
+
+    expect(project.lastSuccessfulBuild().number).toBe(2);
+  });
 });

--- a/web/app/models/project.ts
+++ b/web/app/models/project.ts
@@ -1,19 +1,37 @@
+import {BuildStatus} from '../common/constants';
+
 import {BuildSummary, BuildSummaryResponse} from './build_summary';
 
 export interface ProjectResponse {
   id: string;
   name: string;
+  lane: string;
+  repo_name: string;
   builds: BuildSummaryResponse[];
 }
 
 export class Project {
   readonly name: string;
   readonly id: string;
+  readonly repoName: string;
+  readonly lane: string;
   readonly builds: BuildSummary[];
 
   constructor(project: ProjectResponse) {
     this.name = project.name;
     this.id = project.id;
+    this.repoName = project.repo_name;
+    this.lane = project.lane;
     this.builds = project.builds.map((build) => new BuildSummary(build));
+  }
+
+  lastSuccessfulBuild(): BuildSummary {
+    return this.builds.find((build) => build.status === BuildStatus.SUCCESS);
+  }
+
+  lastFailedBuild(): BuildSummary {
+    return this.builds.find(
+        (build) => [BuildStatus.FAILED, BuildStatus.MISSING_FASTFILE].indexOf(
+                       build.status) > -1);
   }
 }

--- a/web/app/models/project.ts
+++ b/web/app/models/project.ts
@@ -25,13 +25,12 @@ export class Project {
     this.builds = project.builds.map((build) => new BuildSummary(build));
   }
 
-  lastSuccessfulBuild(): BuildSummary {
-    return this.builds.find((build) => build.status === BuildStatus.SUCCESS);
+  lastSuccessfulBuild(): BuildSummary|null {
+    return this.builds.find((build) => build.status === BuildStatus.SUCCESS) ||
+        null;
   }
 
-  lastFailedBuild(): BuildSummary {
-    return this.builds.find(
-        (build) => [BuildStatus.FAILED, BuildStatus.MISSING_FASTFILE].indexOf(
-                       build.status) > -1);
+  lastFailedBuild(): BuildSummary|null {
+    return this.builds.find((build) => build.isFailure()) || null;
   }
 }

--- a/web/app/models/project_summary.spec.ts
+++ b/web/app/models/project_summary.spec.ts
@@ -3,7 +3,7 @@ import {mockProjectSummaryResponse} from '../common/test_helpers/mock_project_da
 
 import {ProjectSummary} from './project_summary';
 
-describe('Project Model', () => {
+describe('Project Summary Model', () => {
   it('should convert project response successfully', () => {
     const project = new ProjectSummary(mockProjectSummaryResponse);
 

--- a/web/app/project/project.component.html
+++ b/web/app/project/project.component.html
@@ -2,8 +2,8 @@
 <div class="fci-project-container">
   <div class="fci-left-container">
     <div *ngIf="project" class="fci-project-header">{{project.name}}</div>
-    <div *ngIf="project" class="fci-build-table">
-      <mat-table #buildsTable [dataSource]="project.builds">
+    <div class="fci-build-table">
+      <mat-table #buildsTable [dataSource]="tableDataSource">
         <!-- Number Column -->
         <ng-container matColumnDef="number">
           <mat-header-cell *matHeaderCellDef>Build</mat-header-cell>
@@ -35,11 +35,10 @@
         <ng-container matColumnDef="sha">
           <mat-header-cell *matHeaderCellDef>Sha</mat-header-cell>
           <mat-cell *matCellDef="let build">
-            <a [attr.href]="build.linkToSha" target="_blank">
+            <a [attr.href]="build.linkToSha" target="_blank" (click)="$event.stopPropagation()">
               {{build.shortSha}}
             </a>
-            <button mat-button (click)="rebuild($event, build)">
-              <mat-icon>refresh</mat-icon>Rebuild</button>
+            <button mat-button (click)="rebuild($event, build)" [class.fci-button-visible]="build.isFailure()">Rebuild</button>
           </mat-cell>
         </ng-container>
 
@@ -53,7 +52,7 @@
   <div class="fci-right-container">
     <mat-card class="fci-project-details">
       <h3>Project Info</h3>
-      <mat-spinner *ngIf="!project" mode="indeterminate"></mat-spinner>
+      <mat-spinner *ngIf="!project" mode="indeterminate" class="fci-loading-spinner"></mat-spinner>
       <ng-container *ngIf="project">
         <h5>Repo</h5>
         <div>{{project.repoName}}</div>

--- a/web/app/project/project.component.html
+++ b/web/app/project/project.component.html
@@ -3,7 +3,7 @@
   <div class="fci-left-container">
     <div *ngIf="project" class="fci-project-header">{{project.name}}</div>
     <div *ngIf="project" class="fci-build-table">
-      <mat-table [dataSource]="project.builds">
+      <mat-table #buildsTable [dataSource]="project.builds">
         <!-- Number Column -->
         <ng-container matColumnDef="number">
           <mat-header-cell *matHeaderCellDef>Build</mat-header-cell>
@@ -38,13 +38,13 @@
             <a [attr.href]="build.linkToSha" target="_blank">
               {{build.shortSha}}
             </a>
-            <button mat-button>
+            <button mat-button (click)="rebuild($event, build)">
               <mat-icon>refresh</mat-icon>Rebuild</button>
           </mat-cell>
         </ng-container>
 
         <mat-header-row *matHeaderRowDef="DISPLAYED_COLUMNS"></mat-header-row>
-        <mat-row *matRowDef="let row; columns: DISPLAYED_COLUMNS;"></mat-row>
+        <mat-row *matRowDef="let row; columns: DISPLAYED_COLUMNS;let build;" [routerLink]="['/project', project.id, 'build', build.number]"></mat-row>
       </mat-table>
       <mat-progress-spinner mode="indeterminate" *ngIf="isLoading" class="fci-loading-spinner" diameter="30"></mat-progress-spinner>
       <!-- TODO: paginate this table -->

--- a/web/app/project/project.component.html
+++ b/web/app/project/project.component.html
@@ -1,39 +1,69 @@
 <fci-toolbar [breadcrumbs]="breadcrumbs"></fci-toolbar>
-
-<div fci-grid *ngIf="project">
-  <div fci-cell="12">
-    <mat-card class="fci-build-table">
+<div class="fci-project-container">
+  <div class="fci-left-container">
+    <div *ngIf="project" class="fci-project-header">{{project.name}}</div>
+    <div *ngIf="project" class="fci-build-table">
       <mat-table [dataSource]="project.builds">
         <!-- Number Column -->
         <ng-container matColumnDef="number">
-          <mat-header-cell *matHeaderCellDef> Build </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>Build</mat-header-cell>
           <mat-cell *matCellDef="let build">
             <fci-status-icon [status]="build.status"></fci-status-icon>
             <span>{{build.number}}</span>
           </mat-cell>
         </ng-container>
 
-        <!-- Date Column -->
-        <ng-container matColumnDef="date">
-          <mat-header-cell *matHeaderCellDef>Date</mat-header-cell>
-          <!-- TODO: Pipe this into a relative time pipe -->
+        <!-- Start Date Column -->
+        <ng-container matColumnDef="started">
+          <mat-header-cell *matHeaderCellDef>Started</mat-header-cell>
           <mat-cell *matCellDef="let build">{{build.date | amTimeAgo}}</mat-cell>
         </ng-container>
 
-        <!-- Lane Column -->
+        <!-- Duration Column -->
+        <ng-container matColumnDef="duration">
+          <mat-header-cell *matHeaderCellDef>Duration</mat-header-cell>
+          <mat-cell *matCellDef="let build">{{build.duration > -1 ? (build.duration| amDuration: 'seconds') : "&mdash;"}}</mat-cell>
+        </ng-container>
+
+        <!-- Branch Column -->
+        <ng-container matColumnDef="branch">
+          <mat-header-cell *matHeaderCellDef>Branch</mat-header-cell>
+          <mat-cell *matCellDef="let build">{{build.branch}}</mat-cell>
+        </ng-container>
+
+        <!-- SHA Column -->
         <ng-container matColumnDef="sha">
-          <mat-header-cell *matHeaderCellDef>Commit Sha</mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>Sha</mat-header-cell>
           <mat-cell *matCellDef="let build">
             <a [attr.href]="build.linkToSha" target="_blank">
               {{build.shortSha}}
             </a>
+            <button mat-button>
+              <mat-icon>refresh</mat-icon>Rebuild</button>
           </mat-cell>
         </ng-container>
 
         <mat-header-row *matHeaderRowDef="DISPLAYED_COLUMNS"></mat-header-row>
         <mat-row *matRowDef="let row; columns: DISPLAYED_COLUMNS;"></mat-row>
       </mat-table>
+      <mat-progress-spinner mode="indeterminate" *ngIf="isLoading" class="fci-loading-spinner" diameter="30"></mat-progress-spinner>
       <!-- TODO: paginate this table -->
+    </div>
+  </div>
+  <div class="fci-right-container">
+    <mat-card class="fci-project-details">
+      <h3>Project Info</h3>
+      <mat-spinner *ngIf="!project" mode="indeterminate"></mat-spinner>
+      <ng-container *ngIf="project">
+        <h5>Repo</h5>
+        <div>{{project.repoName}}</div>
+        <h5>Lane</h5>
+        <div>{{project.lane}}</div>
+        <h5>Last Successful Build</h5>
+        <div>{{project.lastSuccessfulBuild() ? project.lastSuccessfulBuild().number : "&mdash;"}}</div>
+        <h5>Last Failed Build</h5>
+        <div>{{project.lastFailedBuild() ? project.lastFailedBuild().number : "&mdash;"}}</div>
+      </ng-container>
     </mat-card>
   </div>
 </div>

--- a/web/app/project/project.component.scss
+++ b/web/app/project/project.component.scss
@@ -4,6 +4,9 @@ $TOOLBAR_HEIGHT:80px;
     padding: 24px 92px 0 92px;
     height: calc(100% - #{$TOOLBAR_HEIGHT});
     box-sizing: border-box;
+    .fci-loading-spinner {
+        margin: 32px auto;
+    }
     .fci-left-container {
         flex: 1;
         .fci-project-header {
@@ -25,8 +28,8 @@ $TOOLBAR_HEIGHT:80px;
                 padding: 0;
                 cursor: pointer;
                 &:hover {
-                    background-color: #F3E5F5;
-                    .mat-cell.mat-column-sha .mat-button {
+                    background-color: #d8d8d8;
+                    .mat-cell.mat-column-sha button {
                         visibility: visible;
                     }
                 }
@@ -46,20 +49,22 @@ $TOOLBAR_HEIGHT:80px;
                     font-weight: 500;
                 }
                 .mat-column-sha {
-                    a,
                     .mat-icon {
                         padding-right: 8px;
                     }
-                    .mat-button {
+                    a {
+                        padding-right: 30px;
+                    }
+                    button {
                         font-size: 14px;
                         visibility: hidden;
                         color: #6c6d6e;
                         text-transform: uppercase;
+                        &.fci-button-visible {
+                            visibility: visible;
+                        }
                     }
                 }
-            }
-            .fci-loading-spinner {
-                margin: 32px auto;
             }
         }
     }

--- a/web/app/project/project.component.scss
+++ b/web/app/project/project.component.scss
@@ -1,10 +1,82 @@
-.fci-build-table {
-    margin-top: 24px;
-    .mat-cell {
-        align-items: center;
-        display: flex;
-        .fci-status-icon {
-            margin-right: 8px;
+$TOOLBAR_HEIGHT:80px;
+.fci-project-container {
+    display: flex;
+    padding: 24px 92px 0 92px;
+    height: calc(100% - #{$TOOLBAR_HEIGHT});
+    box-sizing: border-box;
+    .fci-left-container {
+        flex: 1;
+        .fci-project-header {
+            font-size: 30px;
+            font-weight: 500;
+        }
+        .fci-build-table {
+            margin-top: 24px;
+            .mat-header-row {
+                font-weight: 500;
+                color: rgba(0, 0, 0, 0.54);
+                padding: 0 0 11px 0;
+                text-transform: uppercase;
+                font-size: 13px;
+                min-height: initial;
+            }
+            .mat-row {
+                height: 43px;
+                padding: 0;
+                &:hover .mat-cell.mat-column-sha .mat-button {
+                    visibility: visible;
+                }
+                .mat-cell {
+                    align-items: center;
+                    display: flex;
+                    font-size: 16px;
+                    padding-right: 8px;
+                    .fci-status-icon {
+                        margin-right: 8px;
+                        font-size: 20px;
+                        width: 20px;
+                        height: 20px;
+                    }
+                }
+                .mat-column-number {
+                    font-weight: 500;
+                }
+                .mat-column-sha {
+                    a,
+                    .mat-icon {
+                        padding-right: 8px;
+                    }
+                    .mat-button {
+                        font-size: 14px;
+                        visibility: hidden;
+                        color: #6c6d6e;
+                        text-transform: uppercase;
+                    }
+                }
+            }
+            .fci-loading-spinner {
+                margin: 32px auto;
+            }
+        }
+    }
+    .fci-right-container {
+        padding-left: 24px;
+        .fci-project-details {
+            font-family: 'Google Sans', sans-serif;
+            width: 296px;
+            font-size: 16px;
+            padding: 27px 51px 21px 51px;
+            box-sizing: border-box;
+            h3 {
+                font-weight: 500;
+                font-size: 18px;
+            }
+            h5 {
+                color: rgba(0, 0, 0, 0.54);
+                font-size: 13px;
+                margin-bottom: 0;
+                text-transform: uppercase;
+            }
         }
     }
 }

--- a/web/app/project/project.component.scss
+++ b/web/app/project/project.component.scss
@@ -23,8 +23,12 @@ $TOOLBAR_HEIGHT:80px;
             .mat-row {
                 height: 43px;
                 padding: 0;
-                &:hover .mat-cell.mat-column-sha .mat-button {
-                    visibility: visible;
+                cursor: pointer;
+                &:hover {
+                    background-color: #F3E5F5;
+                    .mat-cell.mat-column-sha .mat-button {
+                        visibility: visible;
+                    }
                 }
                 .mat-cell {
                     align-items: center;

--- a/web/app/project/project.component.spec.ts
+++ b/web/app/project/project.component.spec.ts
@@ -1,7 +1,9 @@
 import 'rxjs/add/operator/switchMap';
 
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatCardModule, MatTableModule} from '@angular/material';
+import {Location} from '@angular/common';
+import {DebugElement} from '@angular/core';
+import {async, ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
+import {MatCardModule, MatProgressSpinnerModule, MatTableModule} from '@angular/material';
 import {By} from '@angular/platform-browser';
 import {ActivatedRoute, convertToParamMap} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
@@ -11,10 +13,13 @@ import {Subject} from 'rxjs/Subject';
 
 import {CommonComponentsModule} from '../common/components/common-components.module';
 import {ToolbarModule} from '../common/components/toolbar/toolbar.module';
-import {mockProject} from '../common/test_helpers/mock_project_data';
+import {DummyComponent} from '../common/test_helpers/dummy.component';
+import {mockBuildSummary_success} from '../common/test_helpers/mock_build_data';
+import {getMockProject} from '../common/test_helpers/mock_project_data';
+import {BuildSummary} from '../models/build_summary';
 import {Project} from '../models/project';
-import {DataService} from '../services/data.service';
 import {SharedMaterialModule} from '../root/shared_material.module';
+import {DataService} from '../services/data.service';
 
 import {ProjectComponent} from './project.component';
 
@@ -23,24 +28,31 @@ describe('ProjectComponent', () => {
   let fixture: ComponentFixture<ProjectComponent>;
   let dataService: jasmine.SpyObj<Partial<DataService>>;
   let projectSubject: Subject<Project>;
+  let rebuildSummarySubject: Subject<BuildSummary>;
 
   beforeEach(async(() => {
     projectSubject = new Subject<Project>();
+    rebuildSummarySubject = new Subject<BuildSummary>();
     dataService = {
       getProject:
-          jasmine.createSpy().and.returnValue(projectSubject.asObservable())
+          jasmine.createSpy().and.returnValue(projectSubject.asObservable()),
+      rebuild: jasmine.createSpy().and.returnValue(
+          rebuildSummarySubject.asObservable())
     };
 
     TestBed
         .configureTestingModule({
           imports: [
-            CommonComponentsModule, MomentModule, ToolbarModule,
-            RouterTestingModule, MatCardModule, MatTableModule
-
+            CommonComponentsModule, MomentModule, ToolbarModule, MatCardModule,
+            MatTableModule, MatProgressSpinnerModule,
+            RouterTestingModule.withRoutes([
+              {
+                path: 'project/:projectId/build/:buildId',
+                component: DummyComponent
+              },
+            ])
           ],
-          declarations: [
-            ProjectComponent,
-          ],
+          declarations: [ProjectComponent, DummyComponent],
           providers: [
             {provide: DataService, useValue: dataService}, {
               provide: ActivatedRoute,
@@ -55,38 +67,248 @@ describe('ProjectComponent', () => {
     component = fixture.componentInstance;
   }));
 
-  it('should load project', () => {
-    expect(component.isLoading).toBe(true);
+  describe('Unit tests', () => {
+    it('should load project', () => {
+      expect(component.isLoading).toBe(true);
 
-    fixture.detectChanges();  // onInit()
-    expect(dataService.getProject).toHaveBeenCalledWith('123');
-    projectSubject.next(mockProject);  // Resolve observable
+      fixture.detectChanges();  // onInit()
+      expect(dataService.getProject).toHaveBeenCalledWith('123');
+      projectSubject.next(getMockProject());  // Resolve observable
 
-    expect(component.isLoading).toBe(false);
-    expect(component.project.id).toBe('12');
-    expect(component.project.name).toBe('the most coolest project');
-    expect(component.project.builds.length).toBe(2);
-    expect(component.project.builds[0].sha).toBe('asdfshzdggfdhdfh4');
+      expect(component.isLoading).toBe(false);
+      expect(component.project.id).toBe('12');
+      expect(component.project.name).toBe('the most coolest project');
+      expect(component.project.builds.length).toBe(2);
+      expect(component.project.builds[0].sha).toBe('asdfshzdggfdhdfh4');
+    });
+
+    it('should update breadcrumbs after loading project', () => {
+      fixture.detectChanges();  // onInit()
+      expect(component.breadcrumbs[1].hint).toBe('Project');
+      expect(component.breadcrumbs[1].label).toBeUndefined();
+
+      projectSubject.next(getMockProject());  // Resolve observable
+
+      expect(component.breadcrumbs[1].label).toBe('the most coolest project');
+    });
+
+    it('#rebuild should send rebuild request', () => {
+      fixture.detectChanges();                // onInit()
+      projectSubject.next(getMockProject());  // Resolve observable
+
+      component.rebuild(new Event('click'), getMockProject().builds[0]);
+      expect(dataService.rebuild).toHaveBeenCalledWith('12', 2);
+    });
+
+    it('#rebuild should add new Build Summary to table data', fakeAsync(() => {
+         fixture.detectChanges();                // onInit()
+         projectSubject.next(getMockProject());  // Resolve observable
+         flush();
+         fixture.detectChanges();
+         flush();
+
+         component.rebuild(new Event('click'), getMockProject().builds[0]);
+
+         expect(component.project.builds.length).toBe(2);
+         rebuildSummarySubject.next(mockBuildSummary_success);
+
+         expect(component.project.builds.length).toBe(3);
+       }));
   });
 
-  it('should update breadcrumbs after loading project', () => {
-    fixture.detectChanges();  // onInit()
-    expect(component.breadcrumbs[1].hint).toBe('Project');
-    expect(component.breadcrumbs[1].label).toBeUndefined();
+  describe('Shallow Tests', () => {
+    describe('Project not loaded', () => {
+      beforeEach(() => {
+        fixture.detectChanges();  // onInit()
+      });
 
-    projectSubject.next(mockProject);  // Resolve observable
+      it('should not show project title', () => {
+        expect(
+            fixture.debugElement.queryAll(By.css('.fci-project-header')).length)
+            .toBe(0);
+      });
 
-    expect(component.breadcrumbs[1].label).toBe('the most coolest project');
-  });
+      it('table should not show loading spinner', () => {
+        expect(fixture.debugElement
+                   .queryAll(By.css('.fci-build-table .fci-loading-spinner'))
+                   .length)
+            .toBe(1);
+      });
 
-  it('should have toolbar with breadcrumbs', () => {
-    fixture.detectChanges();  // onInit()
+      it('details card should not show loading spinner', () => {
+        expect(
+            fixture.debugElement
+                .queryAll(By.css('.fci-project-details .fci-loading-spinner'))
+                .length)
+            .toBe(1);
+      });
+    });
 
-    console.log(fixture.debugElement.query(By.css('.fci-crumb')));
-    // toolbar exists
-    expect(fixture.debugElement.queryAll(By.css('.fci-crumb')).length).toBe(2);
+    describe('Project loaded', () => {
+      beforeEach(fakeAsync(() => {
+        fixture.detectChanges();                // onInit()
+        projectSubject.next(getMockProject());  // Resolve observable
+        flush();
 
-    expect(component.breadcrumbs[0].label).toBe('Dashboard');
-    expect(component.breadcrumbs[0].url).toBe('/');
+        fixture.detectChanges();
+        flush();
+      }));
+
+      it('should have toolbar with breadcrumbs', () => {
+        // toolbar exists
+        expect(fixture.debugElement.queryAll(By.css('.fci-crumb')).length)
+            .toBe(2);
+
+        expect(component.breadcrumbs[0].label).toBe('Dashboard');
+        expect(component.breadcrumbs[0].url).toBe('/');
+      });
+
+      it('should have project title', () => {
+        expect(fixture.debugElement.query(By.css('.fci-project-header'))
+                   .nativeElement.innerText)
+            .toBe('the most coolest project');
+      });
+
+      describe('table', () => {
+        let rowEls: DebugElement[];
+        beforeEach(() => {
+          rowEls = fixture.debugElement.queryAll(By.css('.mat-row'));
+          expect(rowEls.length).toBe(2);
+        });
+
+        it('should not show loading spinner', () => {
+          expect(fixture.debugElement
+                     .queryAll(By.css('.fci-build-table .fci-loading-spinner'))
+                     .length)
+              .toBe(0);
+        });
+
+        it('should have status icon', () => {
+          expect(rowEls[0]
+                     .query(By.css('.mat-column-number .fci-status-icon'))
+                     .nativeElement.innerText)
+              .toBe('check_circle');
+          expect(rowEls[1]
+                     .query(By.css('.mat-column-number .fci-status-icon'))
+                     .nativeElement.innerText)
+              .toBe('cancel');
+        });
+
+        it('should have build number', () => {
+          expect(rowEls[0]
+                     .query(By.css('.mat-column-number span'))
+                     .nativeElement.innerText)
+              .toBe('2');
+          expect(rowEls[1]
+                     .query(By.css('.mat-column-number span'))
+                     .nativeElement.innerText)
+              .toBe('1');
+        });
+
+        it('should have duration', () => {
+          expect(rowEls[0]
+                     .query(By.css('.mat-column-duration'))
+                     .nativeElement.innerText)
+              .toBe('3 days');
+        });
+
+        it('should have branch', () => {
+          expect(rowEls[0]
+                     .query(By.css('.mat-column-branch'))
+                     .nativeElement.innerText)
+              .toBe('master');
+        });
+
+        it('should have sha link', () => {
+          expect(rowEls[0]
+                     .query(By.css('.mat-column-sha a'))
+                     .nativeElement.innerText)
+              .toBe('asdfsh');
+        });
+
+        it('should go to build when clicked', fakeAsync(() => {
+             const location = TestBed.get(Location);
+             rowEls[0].nativeElement.click();
+             tick();
+             expect(location.path()).toBe('/project/12/build/2');
+           }));
+
+        it('should not show rebuild button on successful builds', () => {
+          // First row is successful build
+          expect(rowEls[0]
+                     .queryAll(By.css('.mat-column-sha .fci-button-visible'))
+                     .length)
+              .toBe(0);
+        });
+
+        it('should show rebuild button on failed builds', () => {
+          // Second row is failed build
+          expect(rowEls[1]
+                     .queryAll(By.css('.mat-column-sha .fci-button-visible'))
+                     .length)
+              .toBe(1);
+        });
+
+        it('should rebuild when rebuild button is clicked', () => {
+          const buttonEl =
+              rowEls[1].query(By.css('.mat-column-sha .fci-button-visible'));
+
+          buttonEl.nativeElement.click();
+          expect(dataService.rebuild).toHaveBeenCalledWith('12', 1);
+        });
+
+        it('should add new row after rebuild is complete', () => {
+          const buttonEl =
+              rowEls[1].query(By.css('.mat-column-sha .fci-button-visible'));
+
+          buttonEl.nativeElement.click();
+          rebuildSummarySubject.next(mockBuildSummary_success);
+          fixture.detectChanges();
+
+          expect(fixture.debugElement.queryAll(By.css('.mat-row')).length)
+              .toBe(3);
+        });
+      });
+
+      describe('details card', () => {
+        let cardEl: DebugElement;
+        let headerEls: DebugElement[];
+        let contentsEls: DebugElement[];
+
+        beforeEach(() => {
+          cardEl = fixture.debugElement.query(By.css('.fci-project-details'));
+          headerEls = cardEl.queryAll(By.css('h5'));
+          contentsEls = cardEl.queryAll(By.css('div'));
+        });
+
+        it('should not show loading spinner', () => {
+          expect(cardEl.queryAll(By.css('.fci-loading-spinner')).length)
+              .toBe(0);
+        });
+
+        it('should show Repo name', () => {
+          expect(headerEls[0].nativeElement.innerText).toBe('REPO');
+          expect(contentsEls[0].nativeElement.innerText)
+              .toBe('fastlane/TacoRocat');
+        });
+
+        it('should show lane', () => {
+          expect(headerEls[1].nativeElement.innerText).toBe('LANE');
+          expect(contentsEls[1].nativeElement.innerText).toBe('ios test');
+        });
+
+        it('should show last successful build number', () => {
+          expect(headerEls[2].nativeElement.innerText)
+              .toBe('LAST SUCCESSFUL BUILD');
+          expect(contentsEls[2].nativeElement.innerText).toBe('2');
+        });
+
+        it('should show last failed build number', () => {
+          expect(headerEls[3].nativeElement.innerText)
+              .toBe('LAST FAILED BUILD');
+          expect(contentsEls[3].nativeElement.innerText).toBe('1');
+        });
+      });
+    });
   });
 });

--- a/web/app/project/project.component.ts
+++ b/web/app/project/project.component.ts
@@ -1,9 +1,12 @@
 import 'rxjs/add/operator/switchMap';
 
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {MatTable} from '@angular/material';
 import {ActivatedRoute, ParamMap} from '@angular/router';
 
 import {Breadcrumb} from '../common/components/toolbar/toolbar.component';
+import {Build} from '../models/build';
+import {BuildSummary} from '../models/build_summary';
 import {Project} from '../models/project';
 import {DataService} from '../services/data.service';
 
@@ -13,6 +16,7 @@ import {DataService} from '../services/data.service';
   styleUrls: ['./project.component.scss']
 })
 export class ProjectComponent implements OnInit {
+  @ViewChild('buildsTable') table: MatTable<BuildSummary>;
   readonly DISPLAYED_COLUMNS: string[] =
       ['number', 'started', 'duration', 'branch', 'sha'];
   isLoading = true;
@@ -33,6 +37,18 @@ export class ProjectComponent implements OnInit {
           this.project = project;
           this.updateBreadcrumbs(this.project.name);
           this.isLoading = false;
+        });
+  }
+
+  rebuild(event: Event, build: BuildSummary) {
+    // Make sure it doesn't trigger the row being clicked
+    event.stopPropagation();
+
+    this.dataService.rebuild(this.project.id, build.number)
+        .subscribe((newBuild) => {
+          this.project.builds.unshift(newBuild);
+          // Need to re-render rows now that new data is added.
+          this.table.renderRows();
         });
   }
 

--- a/web/app/project/project.component.ts
+++ b/web/app/project/project.component.ts
@@ -13,7 +13,8 @@ import {DataService} from '../services/data.service';
   styleUrls: ['./project.component.scss']
 })
 export class ProjectComponent implements OnInit {
-  readonly DISPLAYED_COLUMNS: string[] = ['number', 'date', 'sha'];
+  readonly DISPLAYED_COLUMNS: string[] =
+      ['number', 'started', 'duration', 'branch', 'sha'];
   isLoading = true;
   project: Project;
   readonly projectId: string;

--- a/web/app/project/project.component.ts
+++ b/web/app/project/project.component.ts
@@ -21,6 +21,7 @@ export class ProjectComponent implements OnInit {
       ['number', 'started', 'duration', 'branch', 'sha'];
   isLoading = true;
   project: Project;
+  tableDataSource: BuildSummary[];
   readonly projectId: string;
   readonly breadcrumbs: Breadcrumb[] =
       [{label: 'Dashboard', url: '/'}, {hint: 'Project'}];
@@ -35,6 +36,7 @@ export class ProjectComponent implements OnInit {
             (params: ParamMap) => this.dataService.getProject(params.get('id')))
         .subscribe((project) => {
           this.project = project;
+          this.tableDataSource = this.project.builds;
           this.updateBreadcrumbs(this.project.name);
           this.isLoading = false;
         });

--- a/web/app/project/project.module.ts
+++ b/web/app/project/project.module.ts
@@ -1,6 +1,6 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {MatCardModule, MatTableModule} from '@angular/material';
+import {MatButtonModule, MatCardModule, MatIconModule, MatProgressSpinnerModule, MatTableModule} from '@angular/material';
 import {RouterModule} from '@angular/router';
 import {MomentModule} from 'ngx-moment';
 
@@ -23,7 +23,8 @@ import {DataService} from '../services/data.service';
     /** Internal Imports */
     CommonComponentsModule, ToolbarModule,
     /** Angular Material Imports */
-    MatCardModule, MatTableModule,
+    MatCardModule, MatProgressSpinnerModule, MatTableModule, MatIconModule,
+    MatButtonModule,
     /** Third-Party Module Imports */
     MomentModule,  // For Date relative time pipes
   ],

--- a/web/app/project/project.module.ts
+++ b/web/app/project/project.module.ts
@@ -19,6 +19,7 @@ import {DataService} from '../services/data.service';
   ],
   imports: [
     /** Angular Library Imports */
+    RouterModule,  // For routerLink directive
     CommonModule,
     /** Internal Imports */
     CommonComponentsModule, ToolbarModule,

--- a/web/app/services/data.service.spec.ts
+++ b/web/app/services/data.service.spec.ts
@@ -4,11 +4,12 @@ import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Observable} from 'rxjs/Observable';
 
 import {BuildStatus} from '../common/constants';
-import {mockBuildResponse} from '../common/test_helpers/mock_build_data';
+import {mockBuildResponse, mockBuildSummary_success} from '../common/test_helpers/mock_build_data';
 import {mockLanesResponse} from '../common/test_helpers/mock_lane_data';
 import {mockProjectListResponse, mockProjectResponse, mockProjectSummaryResponse} from '../common/test_helpers/mock_project_data';
 import {mockRepositoryListResponse, mockRepositoryResponse} from '../common/test_helpers/mock_repository_data';
 import {Build} from '../models/build';
+import {BuildSummary} from '../models/build_summary';
 import {Lane} from '../models/lane';
 import {Project} from '../models/project';
 import {ProjectSummary} from '../models/project_summary';
@@ -90,6 +91,23 @@ describe('DataService', () => {
     });
   });
 
+  describe('#rebuild', () => {
+    it('should return response mapped to Build Summary model', () => {
+      let buildSummary: BuildSummary;
+      dataService.rebuild('some-id', 3).subscribe((buildRespone) => {
+        buildSummary = buildRespone;
+      });
+
+      const rebuildRequest =
+          mockHttp.expectOne('/data/projects/some-id/build/3/rebuild');
+      expect(rebuildRequest.request.method).toBe('POST');
+      rebuildRequest.flush(mockBuildSummary_success);
+
+      expect(buildSummary.number).toBe(2);
+      expect(buildSummary.sha).toBe('asdfshzdggfdhdfh4');
+    });
+  });
+
   describe('#getRepoLanes', () => {
     it('should return response mapped to Lane model', () => {
       let lanes: Lane[];
@@ -120,6 +138,7 @@ describe('DataService', () => {
 
       const projectsRequest = mockHttp.expectOne('/data/projects');
       expect(projectsRequest.request.body).toBe(COMMIT_TRIGGER_PROJECT_REQUEST);
+      expect(projectsRequest.request.method).toBe('POST');
       projectsRequest.flush(mockProjectSummaryResponse);
 
       expect(project.id).toBe('1');

--- a/web/app/services/data.service.ts
+++ b/web/app/services/data.service.ts
@@ -4,6 +4,7 @@ import {Observable} from 'rxjs/Observable';
 import {map} from 'rxjs/operators';
 
 import {Build, BuildResponse} from '../models/build';
+import {BuildSummary, BuildSummaryResponse} from '../models/build_summary';
 import {Lane, LaneResponse} from '../models/lane';
 import {Project, ProjectResponse} from '../models/project';
 import {ProjectSummary, ProjectSummaryResponse} from '../models/project_summary';
@@ -42,7 +43,14 @@ export class DataService {
   getBuild(projectId: string, buildNumber: number): Observable<Build> {
     const url = `${HOSTNAME}/projects/${projectId}/build/${buildNumber}`;
     return this.http.get<BuildResponse>(url).pipe(
-        map((project) => new Build(project)));
+        map((build) => new Build(build)));
+  }
+
+  rebuild(projectId: string, buildNumber: number): Observable<BuildSummary> {
+    const url =
+        `${HOSTNAME}/projects/${projectId}/build/${buildNumber}/rebuild`;
+    return this.http.post<BuildSummaryResponse>(url, {}).pipe(
+        map((build) => new BuildSummary(build)));
   }
 
   getRepoLanes(repoFullName: string, branch: string): Observable<Lane[]> {


### PR DESCRIPTION
Issue: #682 
- [x] Match mocks in styling
- [x] Rebuild Button that rebuilds and adds new build to list
- [x] Tests
- [ ] full repo name for the project. This is missing from the backend, won't be able to do this in this PR.
- [ ] Link to the repo.
- [ ] Successful/failed Build numbers link to their pages

There's a workaround to make `mat-table` behave like like a normal table and auto-resize to the largest cell item. I'll take a look into this at a later time. https://github.com/angular/material2/issues/6058#issuecomment-318612278

- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving


#### Screenshot
![image](https://user-images.githubusercontent.com/2754461/41599380-d1849ea8-7387-11e8-8bf2-205f96b9f688.png)
