### PR TITLE
[WIP] GitRepos get individual work queues

### DIFF
--- a/app/features-json/build_json_controller.rb
+++ b/app/features-json/build_json_controller.rb
@@ -78,7 +78,6 @@ module FastlaneCI
         sha: current_sha,
         github_service: FastlaneCI::GitHubService.new(provider_credential: current_user_provider_credential),
         notification_service: FastlaneCI::Services.notification_service,
-        work_queue: FastlaneCI::GitRepo.git_action_queue, # using the git repo queue because of https://github.com/ruby-git/ruby-git/issues/355
         trigger: project.find_triggers_of_type(trigger_type: :manual).first,
         git_fork_config: git_fork_config
       )

--- a/app/features/build_runner/build_runner.rb
+++ b/app/features/build_runner/build_runner.rb
@@ -58,7 +58,7 @@ module FastlaneCI
       sha:,
       github_service:,
       notification_service:,
-      work_queue:,
+      work_queue: nil,
       trigger:,
       git_fork_config:,
       local_build_folder: nil
@@ -86,8 +86,6 @@ module FastlaneCI
       # TODO: provider credential should determine what exact CodeHostingService gets instantiated
       @code_hosting_service = github_service
 
-      @work_queue = work_queue
-
       prepare_build_object(trigger: trigger)
 
       local_folder = @local_build_folder || File.join(project.local_repo_path, "builds", sha)
@@ -98,6 +96,8 @@ module FastlaneCI
         notification_service: notification_service,
         async_start: false
       )
+
+      @work_queue = @repo.git_action_queue
     end
 
     # Access the build number of that specific BuildRunner

--- a/app/features/project/project_controller.rb
+++ b/app/features/project/project_controller.rb
@@ -72,7 +72,6 @@ module FastlaneCI
         sha: current_sha,
         github_service: FastlaneCI::GitHubService.new(provider_credential: current_github_provider_credential),
         notification_service: FastlaneCI::Services.notification_service,
-        work_queue: FastlaneCI::GitRepo.git_action_queue, # using the git repo queue because of https://github.com/ruby-git/ruby-git/issues/355
         trigger: project.find_triggers_of_type(trigger_type: :manual).first,
         git_fork_config: git_fork_config,
         local_build_folder: checkout_folder

--- a/app/workers/github_worker_base.rb
+++ b/app/workers/github_worker_base.rb
@@ -72,7 +72,6 @@ module FastlaneCI
         sha: current_sha,
         github_service: github_service,
         notification_service: notification_service,
-        work_queue: FastlaneCI::GitRepo.git_action_queue, # using the git repo queue because of https://github.com/ruby-git/ruby-git/issues/355
         git_fork_config: git_fork_config,
         trigger: trigger
       )

--- a/launch.rb
+++ b/launch.rb
@@ -3,7 +3,6 @@ require "task_queue"
 require_relative "app/shared/logging_module"
 require_relative "app/shared/models/job_trigger"
 require_relative "app/shared/models/git_fork_config"
-require_relative "app/shared/models/git_repo" # for GitRepo.git_action_queue
 
 module FastlaneCI
   # Launch is responsible for spawning up the whole
@@ -266,7 +265,7 @@ module FastlaneCI
             github_service: github_service,
             notification_service: Services.notification_service,
             # using the git repo queue because of https://github.com/ruby-git/ruby-git/issues/355
-            work_queue: FastlaneCI::GitRepo.git_action_queue,
+            work_queue: nil,
             git_fork_config: git_fork_config,
             trigger: project.find_triggers_of_type(trigger_type: :commit).first
           )
@@ -318,8 +317,6 @@ module FastlaneCI
             sha: open_pr.current_sha,
             github_service: github_service,
             notification_service: Services.notification_service,
-            # using the git repo queue because of https://github.com/ruby-git/ruby-git/issues/355
-            work_queue: FastlaneCI::GitRepo.git_action_queue,
             git_fork_config: git_fork_config,
             trigger: project.find_triggers_of_type(trigger_type: :commit).first
           )


### PR DESCRIPTION
Now that we’ve made progress on https://github.com/ruby-git/ruby-git/pull/372
We can limit mutexes to be individual repo-scoped instead of 1 giant mutex for all.

- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving


