### PR TITLE
Fixed error when trying to add a new project.

### DIFF
--- a/app/features-json/project_json_controller.rb
+++ b/app/features-json/project_json_controller.rb
@@ -78,7 +78,7 @@ module FastlaneCI
       # to the project details only when this task is finished.
       repo = GitRepo.new(
         git_config: repo_config,
-        provider_credential: provider_credential,
+        provider_credential: current_user_provider_credential,
         local_folder: project.local_repo_path,
         async_start: false,
         notification_service: FastlaneCI::Services.notification_service


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [ ] I have run `npm run test` and corrected all errors
- [ ] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving

`provider_credential` is not defined at this point. I believe it should be `current_user_provider_credential` instead.
