### PR TITLE
Remove dup dependency for web app tests

### DIFF
--- a/web/app/dashboard/dashboard.component.spec.ts
+++ b/web/app/dashboard/dashboard.component.spec.ts
@@ -15,7 +15,6 @@ import {mockProjectSummary, mockProjectSummaryList} from '../common/test_helpers
 import {ProjectSummary} from '../models/project_summary';
 import {SharedMaterialModule} from '../root/shared_material.module';
 import {DataService} from '../services/data.service';
-import {SharedMaterialModule} from '../root/shared_material.module';
 
 import {DashboardComponent} from './dashboard.component';
 
@@ -39,8 +38,7 @@ describe('DashboardComponent', () => {
 
     dialog = {
       open: jasmine.createSpy().and.returnValue({
-        componentInstance:
-            {projectAdded: projectAddedSubject.asObservable()}
+        componentInstance: {projectAdded: projectAddedSubject.asObservable()}
       })
     };
 


### PR DESCRIPTION
This is to fix the tests on master

- [ ] I have run `rspec` and corrected all errors
- [ ] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [ ] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
