### PR TITLE
Fix server crash by updating `git` dependency with `bundle update git`.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GIT
 
 GIT
   remote: https://github.com/fastlane/ruby-git
-  revision: d595bf802aa9d95fdb62e1b5be03c05560bf85ed
+  revision: fcbf92632e47c8a4a57061877c839a805c07cd54
   specs:
     git (1.4.0)
 


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [ ] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving

