### PR TITLE
Make Apple ID optional

### DIFF
--- a/app/services/xcode_manager_service.rb
+++ b/app/services/xcode_manager_service.rb
@@ -37,7 +37,8 @@ module FastlaneCI
         # Think about the user flow on how this would be shown, we probably want to check
         # for the existance of the Apple ID earlier, and then not even show the button,
         # or make the button redirect to the Apple ID login instead
-        raise "No registered Apple ID found with user #{user}, make sure to add your Apple account to fastlane.ci"
+        logger.error("No registered Apple ID found with user #{user}, make sure to add your Apple account to fastlane.ci")
+        return false
       end
       return true
     end

--- a/app/services/xcode_manager_service.rb
+++ b/app/services/xcode_manager_service.rb
@@ -37,7 +37,8 @@ module FastlaneCI
         # Think about the user flow on how this would be shown, we probably want to check
         # for the existance of the Apple ID earlier, and then not even show the button,
         # or make the button redirect to the Apple ID login instead
-        logger.error("No registered Apple ID found with user #{user}, make sure to add your Apple account to fastlane.ci")
+        logger.error("No registered Apple ID found with user #{user}, make sure to add your " \
+                     "Apple account to fastlane.ci")
         return false
       end
       return true

--- a/spec/services/xcode_manager_service_spec.rb
+++ b/spec/services/xcode_manager_service_spec.rb
@@ -53,14 +53,15 @@ describe FastlaneCI::XcodeManagerService do
   end
 
   describe "#use_apple_id" do
-    it "raises an exception if Apple ID isn't available" do
-      unavailable_apple_id = "someonewhodoesntexist@random.com"
-      expect do
-        xcode_manager_service.use_apple_id(user: unavailable_apple_id)
-      end.to raise_error("No registered Apple ID found with user #{unavailable_apple_id}, make sure to add your Apple account to fastlane.ci")
-    end
+    # TODO: enable test again once we decide on Apple ID flow
+    # it "raises an exception if Apple ID isn't available" do
+    #   unavailable_apple_id = "someonewhodoesntexist@random.com"
+    #   expect do
+    #     xcode_manager_service.use_apple_id(user: unavailable_apple_id)
+    #   end.to raise_error("No registered Apple ID found with user #{unavailable_apple_id}, make sure to add your Apple account to fastlane.ci")
+    # end
 
-    it "raises properly switches the Apple ID if it is available" do
+    it "properly switches the Apple ID if it is available" do
       xcode_manager_service.use_apple_id(user: secondary_apple_id_email)
       expect(xcode_manager_service.apple_id.user).to eq(secondary_apple_id_email)
     end


### PR DESCRIPTION
Until we decide how to handle CI systems that don't have an Apple ID, this should unblock everyone.

This will now cause an error if an installation is triggered (e.g. if you have an `.xcode-version` file)