### PR TITLE
Proposal: Add running Build state

### DIFF
--- a/app/shared/models/build.rb
+++ b/app/shared/models/build.rb
@@ -11,6 +11,7 @@ module FastlaneCI
       :missing_fastfile,
       :failure,
       :installing_xcode,
+      :running,
       :ci_problem
     ]
 


### PR DESCRIPTION
I'm not sure what work is needed here, but we should have a differentiating state between `pending` and `running`.

```
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```