### PR TITLE
Get Build logs when build is complete

### DIFF
--- a/app/features-json/build_json_controller.rb
+++ b/app/features-json/build_json_controller.rb
@@ -10,15 +10,7 @@ module FastlaneCI
     use(FastlaneCI::BuildWebsocketBackend)
 
     get "#{HOME}/:build_number" do |project_id, build_number|
-      build = current_project.builds.find { |b| b.number == build_number.to_i }
-      if build.nil?
-        json_error!(
-          error_message: "Can't find build with ID #{build_number} for project #{project_id}",
-          error_key: "Build.Missing",
-          error_code: 404
-        )
-      end
-      build_view_model = BuildViewModel.new(build: build)
+      build_view_model = BuildViewModel.new(build: current_build)
 
       json(build_view_model)
     end
@@ -92,6 +84,42 @@ module FastlaneCI
       json(build_summary_view_model)
     end
 
+    get "#{HOME}/:build_number/logs" do |project_id, build_number|
+      # `current_build_runner` is only defined if the build was just run a while back
+      # if the server was restarted, we're gonna end here in this code block
+      build_log_artifact = current_build.artifacts.find do |current_artifact|
+        # We can improve the detection in the future, to actually mark an artifact as "default output"
+        current_artifact.type.include?("log") && current_artifact.reference.end_with?("fastlane.log")
+      end
+
+      if build_log_artifact
+        artifact_file_content = File.read(build_log_artifact.provider.retrieve!(artifact: build_log_artifact))
+      else
+        raise "Couldn't load previous output for build #{build_number}"
+      end
+      plain_artifact_file_content = convert_ansi_to_plain_text(artifact_file_content)
+      log_array = plain_artifact_file_content.split("\n").collect do |log_line|
+        {
+          message: log_line
+        }
+      end
+
+      return json(log_array)
+    end
+
+    def current_build
+      current_build = current_project.builds.find { |b| b.number == params[:build_number].to_i }
+      if current_build.nil?
+        json_error!(
+          error_message: "Can't find build with ID #{params[:build_number]} for project #{params[:project_id]}",
+          error_key: "Build.Missing",
+          error_code: 404
+        )
+      end
+
+      return current_build
+    end
+
     def current_project
       current_project = FastlaneCI::Services.project_service.project_by_id(params[:project_id])
       unless current_project
@@ -103,6 +131,11 @@ module FastlaneCI
       end
 
       return current_project
+    end
+
+    # convert .log files that include the color information as ANSI code to plain text
+    def convert_ansi_to_plain_text(data)
+      return data.gsub(/\e\[[0-9;]*m/, "")
     end
   end
 end

--- a/app/features-json/build_json_controller.rb
+++ b/app/features-json/build_json_controller.rb
@@ -95,8 +95,13 @@ module FastlaneCI
       if build_log_artifact
         artifact_file_content = File.read(build_log_artifact.provider.retrieve!(artifact: build_log_artifact))
       else
-        raise "Couldn't load previous output for build #{build_number}"
+        json_error!(
+          error_message: "Logs file missing for build #{build_number}",
+          error_key: "Build.LogsMissing",
+          error_code: 404
+        )
       end
+
       plain_artifact_file_content = convert_ansi_to_plain_text(artifact_file_content)
       log_array = plain_artifact_file_content.split("\n").collect do |log_line|
         {

--- a/app/features-json/build_json_controller.rb
+++ b/app/features-json/build_json_controller.rb
@@ -93,6 +93,7 @@ module FastlaneCI
       end
 
       if build_log_artifact
+        # TODO: This only works for local storage. Add External storage support (ex. Google Cloud Storage)
         artifact_file_content = File.read(build_log_artifact.provider.retrieve!(artifact: build_log_artifact))
       else
         json_error!(

--- a/web/app/build/build.component.scss
+++ b/web/app/build/build.component.scss
@@ -11,7 +11,7 @@ $TOOLBAR_HEIGHT:80px;
         .fci-build-logs {
             flex: 1;
             padding: 8px;
-            color: #859900;
+            color: #93a1a1;
             background-color: #073642;
             min-width: 926px;
         }

--- a/web/app/build/build.component.scss
+++ b/web/app/build/build.component.scss
@@ -20,6 +20,7 @@ $TOOLBAR_HEIGHT:80px;
             margin-bottom: 16px;
             display: flex;
             align-items: center;
+            flex-shrink: 0;
             fci-status-icon {
                 width: 24px;
                 height: 24px;

--- a/web/app/build/build.component.scss
+++ b/web/app/build/build.component.scss
@@ -13,7 +13,7 @@ $TOOLBAR_HEIGHT:80px;
             padding: 8px;
             color: #93a1a1;
             background-color: #073642;
-            font-family: 'Google Sans Monospace', sans-serif;
+            font-family: 'Google Sans Monospace', monospace;
             min-width: 926px;
         }
         .fci-build-header {

--- a/web/app/build/build.component.scss
+++ b/web/app/build/build.component.scss
@@ -13,6 +13,7 @@ $TOOLBAR_HEIGHT:80px;
             padding: 8px;
             color: #93a1a1;
             background-color: #073642;
+            font-family: 'Google Sans Monospace', sans-serif;
             min-width: 926px;
         }
         .fci-build-header {

--- a/web/app/models/build.spec.ts
+++ b/web/app/models/build.spec.ts
@@ -1,7 +1,14 @@
-import {BuildStatus} from '../common/constants';
+import {BuildStatus, FastlaneStatus} from '../common/constants';
 import {mockBuildResponse} from '../common/test_helpers/mock_build_data';
 
 import {Build} from './build';
+
+function getBuildWithStatus(status: FastlaneStatus): Build {
+  const buildResponse = Object.assign({}, mockBuildResponse);
+  buildResponse.status = status;
+
+  return new Build(buildResponse);
+}
 
 describe('Build Model', () => {
   it('should convert build response successfully', () => {
@@ -31,5 +38,23 @@ describe('Build Model', () => {
 
     // TODO: update this with real values once implemented on backend
     expect(build.parameters).toBe(null);
+  });
+
+  describe('#isComplete', () => {
+    const COMPLETE_STATUSES: FastlaneStatus[] =
+        ['failure', 'missing_fastfile', 'ci_problem', 'success'];
+    const RUNNING_STATUSES: FastlaneStatus[] = ['pending', 'installing_xcode'];
+
+    for (const status of COMPLETE_STATUSES) {
+      it(`should be true for status: ${status}`, () => {
+        expect(getBuildWithStatus(status).isComplete()).toBe(true);
+      });
+    }
+
+    for (const status of RUNNING_STATUSES) {
+      it(`should be false for status: ${status}`, () => {
+        expect(getBuildWithStatus(status).isComplete()).toBe(false);
+      });
+    }
   });
 });

--- a/web/app/models/build.ts
+++ b/web/app/models/build.ts
@@ -2,6 +2,14 @@ import {BuildStatus, FastlaneStatus, fastlaneStatusToEnum} from '../common/const
 import {Artifact} from './artifact';
 
 const SHORT_SHA_LENGTH = 6;
+const FINAL_STATES: Set<BuildStatus> = new Set([
+  BuildStatus.FAILED, BuildStatus.INTERNAL_ISSUE, BuildStatus.MISSING_FASTFILE,
+  BuildStatus.SUCCESS
+]);
+
+export interface BuildLogLine {
+  message: string;
+}
 
 export interface BuildArtifactResponse {
   id: string;
@@ -30,7 +38,7 @@ export interface BuildResponse {
 export class Build {
   readonly number: number;
   readonly projectId: string;
-  readonly status: FastlaneStatus;
+  readonly status: BuildStatus;
   readonly duration: number;
   readonly description: string;
   readonly trigger: string;
@@ -64,5 +72,9 @@ export class Build {
     this.status = fastlaneStatusToEnum(build.status);
     this.date = new Date(build.timestamp);
     this.artifacts = build.artifacts.map((artifact) => new Artifact(artifact));
+  }
+
+  isComplete(): boolean {
+    return FINAL_STATES.has(this.status);
   }
 }

--- a/web/app/services/data.service.spec.ts
+++ b/web/app/services/data.service.spec.ts
@@ -8,7 +8,7 @@ import {mockBuildResponse, mockBuildSummary_success} from '../common/test_helper
 import {mockLanesResponse} from '../common/test_helpers/mock_lane_data';
 import {mockProjectListResponse, mockProjectResponse, mockProjectSummaryResponse} from '../common/test_helpers/mock_project_data';
 import {mockRepositoryListResponse, mockRepositoryResponse} from '../common/test_helpers/mock_repository_data';
-import {Build} from '../models/build';
+import {Build, BuildLogLine} from '../models/build';
 import {BuildSummary} from '../models/build_summary';
 import {Lane} from '../models/lane';
 import {Project} from '../models/project';
@@ -88,6 +88,22 @@ describe('DataService', () => {
 
       expect(build.number).toBe(3);
       expect(build.sha).toBe('5903a0a7d2238846218c08ad9d5e278db7cf46c7');
+    });
+  });
+
+  describe('#getBuildLogs', () => {
+    it('should call correct URL and return data', () => {
+      let logs: BuildLogLine[];
+      dataService.getBuildLogs('some-id', 3).subscribe((logsResponse) => {
+        logs = logsResponse;
+      });
+
+      const logsRequest =
+          mockHttp.expectOne('/data/projects/some-id/build/3/logs');
+      logsRequest.flush([{message: 'message 1'}]);
+
+      expect(logs.length).toBe(1);
+      expect(logs[0].message).toBe('message 1');
     });
   });
 

--- a/web/app/services/data.service.ts
+++ b/web/app/services/data.service.ts
@@ -3,7 +3,7 @@ import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {map} from 'rxjs/operators';
 
-import {Build, BuildResponse} from '../models/build';
+import {Build, BuildLogLine, BuildResponse} from '../models/build';
 import {BuildSummary, BuildSummaryResponse} from '../models/build_summary';
 import {Lane, LaneResponse} from '../models/lane';
 import {Project, ProjectResponse} from '../models/project';
@@ -44,6 +44,12 @@ export class DataService {
     const url = `${HOSTNAME}/projects/${projectId}/build/${buildNumber}`;
     return this.http.get<BuildResponse>(url).pipe(
         map((build) => new Build(build)));
+  }
+
+  getBuildLogs(projectId: string, buildNumber: number):
+      Observable<BuildLogLine[]> {
+    const url = `${HOSTNAME}/projects/${projectId}/build/${buildNumber}/logs`;
+    return this.http.get<BuildLogLine[]>(url);
   }
 
   rebuild(projectId: string, buildNumber: number): Observable<BuildSummary> {


### PR DESCRIPTION
Issue: #709 

Probably want to make this a part of the websocket in the future. This PR should give us basic functionality to switch over to the web app in all situations 😄 

#### Screenshot
![image](https://user-images.githubusercontent.com/2754461/41993812-56128df4-7a01-11e8-9ed9-49055c6d8228.png)


```
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```