### PR TITLE
Add Initial Sign up page

### DIFF
--- a/app/features-json/setup_json_controller.rb
+++ b/app/features-json/setup_json_controller.rb
@@ -8,19 +8,5 @@ module FastlaneCI
     get "#{HOME}/configured", authenticate: false do
       return json(Services.onboarding_service.correct_setup?)
     end
-
-    get "#{HOME}/user_details" do
-      code_hosting_service = current_user_config_service.code_hosting_service(
-        provider_credential: Services.provider_credential
-      )
-
-      # For now we only support GitHub, it will be easy to support more in the future
-      json(
-        github: {
-          username: code_hosting_service.username,
-          email: code_hosting_service.email
-        }
-      )
-    end
   end
 end

--- a/app/features-json/setup_json_controller.rb
+++ b/app/features-json/setup_json_controller.rb
@@ -8,5 +8,19 @@ module FastlaneCI
     get "#{HOME}/configured", authenticate: false do
       return json(Services.onboarding_service.correct_setup?)
     end
+
+    get "#{HOME}/user_details" do
+      code_hosting_service = current_user_config_service.code_hosting_service(
+        provider_credential: Services.provider_credential
+      )
+
+      # For now we only support GitHub, it will be easy to support more in the future
+      json(
+        github: {
+          username: code_hosting_service.username,
+          email: code_hosting_service.email
+        }
+      )
+    end
   end
 end

--- a/web/app/common/types.ts
+++ b/web/app/common/types.ts
@@ -1,0 +1,9 @@
+import {HttpErrorResponse} from '@angular/common/http';
+
+export interface CiHttpErrorResponse extends HttpErrorResponse {
+  error: {key: string, message: string};
+}
+
+export interface UserDetails {
+  github: {email: string};
+}

--- a/web/app/root/routing.module.ts
+++ b/web/app/root/routing.module.ts
@@ -9,6 +9,8 @@ import {LoginComponent} from '../login/login.component';
 import {LoginModule} from '../login/login.module';
 import {ProjectComponent} from '../project/project.component';
 import {ProjectModule} from '../project/project.module';
+import {SignupComponent} from '../signup/signup.component';
+import {SignupModule} from '../signup/signup.module';
 
 const routes: Routes = [
   {path: '', redirectTo: '/dashboard', pathMatch: 'full'},
@@ -16,11 +18,12 @@ const routes: Routes = [
   {path: 'project/:id', component: ProjectComponent},
   {path: 'project/:projectId/build/:buildId', component: BuildComponent},
   {path: 'login', component: LoginComponent},
+  {path: 'signup', component: SignupComponent},
 ];
 
 @NgModule({
   imports: [
-    DashboardModule, ProjectModule, BuildModule, LoginModule,
+    DashboardModule, ProjectModule, BuildModule, LoginModule, SignupModule,
     RouterModule.forRoot(routes)
   ],
   exports: [RouterModule]

--- a/web/app/services/data.service.spec.ts
+++ b/web/app/services/data.service.spec.ts
@@ -8,6 +8,7 @@ import {mockBuildResponse, mockBuildSummary_success} from '../common/test_helper
 import {mockLanesResponse} from '../common/test_helpers/mock_lane_data';
 import {mockProjectListResponse, mockProjectResponse, mockProjectSummaryResponse} from '../common/test_helpers/mock_project_data';
 import {mockRepositoryListResponse, mockRepositoryResponse} from '../common/test_helpers/mock_repository_data';
+import {UserDetails} from '../common/types';
 import {Build, BuildLogLine} from '../models/build';
 import {BuildSummary} from '../models/build_summary';
 import {Lane} from '../models/lane';
@@ -141,6 +142,21 @@ describe('DataService', () => {
       expect(lanes[0].platform).toBe('ios');
       expect(lanes[1].name).toBe('beta');
       expect(lanes[1].platform).toBe('android');
+    });
+  });
+
+  describe('#getUserDetails', () => {
+    it('should return response mapped to UserDetails', () => {
+      let userDetails: UserDetails;
+      dataService.getUserDetails('some-token').subscribe((response) => {
+        userDetails = response;
+      });
+
+      const detailsRequest =
+          mockHttp.expectOne('/data/repos/user_details?token=some-token');
+      detailsRequest.flush({github: {email: 'wubalubadubdub@gmail.com'}});
+
+      expect(userDetails.github.email).toBe('wubalubadubdub@gmail.com');
     });
   });
 

--- a/web/app/services/data.service.ts
+++ b/web/app/services/data.service.ts
@@ -3,6 +3,7 @@ import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {map} from 'rxjs/operators';
 
+import {UserDetails} from '../common/types';
 import {Build, BuildLogLine, BuildResponse} from '../models/build';
 import {BuildSummary, BuildSummaryResponse} from '../models/build_summary';
 import {Lane, LaneResponse} from '../models/lane';
@@ -50,6 +51,12 @@ export class DataService {
       Observable<BuildLogLine[]> {
     const url = `${HOSTNAME}/projects/${projectId}/build/${buildNumber}/logs`;
     return this.http.get<BuildLogLine[]>(url);
+  }
+
+  getUserDetails(apiToken: string): Observable<UserDetails> {
+    const url =
+        `${HOSTNAME}/repos/user_details?token=${encodeURIComponent(apiToken)}`;
+    return this.http.get<UserDetails>(url);
   }
 
   rebuild(projectId: string, buildNumber: number): Observable<BuildSummary> {

--- a/web/app/signup/signup.component.html
+++ b/web/app/signup/signup.component.html
@@ -1,0 +1,18 @@
+<form [formGroup]="form" fci-grid class="fci-signup-container">
+  <div fci-cell="12">
+    <h6>NOT WORKING - CURRENTLY IN DEVELOPMENT</h6>
+    <div class="fci-input-container">
+      <label>Token</label>
+      <input formControlName="token" type="text">
+      <span *ngIf="email">Email: {{email}}</span>
+    </div>
+    <div class="fci-input-container">
+      <label>Password</label>
+      <input formControlName="password" type="password">
+    </div>
+
+    <button mat-raised-button color="primary" disabled>Signup</button>
+
+    <span *ngIf="error" class="form-error">{{error}}</span>
+  </div>
+</form>

--- a/web/app/signup/signup.component.scss
+++ b/web/app/signup/signup.component.scss
@@ -1,0 +1,13 @@
+.fci-signup-container {
+    margin-top: 72px;
+    .fci-input-container {
+        label {
+            display: block;
+            padding-bottom: 4px;
+        }
+    }
+
+    .form-error {
+        margin-left: 1rem;
+    }
+}

--- a/web/app/signup/signup.component.spec.ts
+++ b/web/app/signup/signup.component.spec.ts
@@ -1,0 +1,118 @@
+import {DebugElement} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material';
+import {By} from '@angular/platform-browser';
+import {Router} from '@angular/router';
+import {Subject} from 'rxjs/Subject';
+
+import {mockSignupResponse} from '../common/test_helpers/mock_login_data';
+import {UserDetails} from '../common/types';
+import {AuthService, SignupResponse} from '../services/auth.service';
+import {DataService} from '../services/data.service';
+
+import {SignupComponent} from './signup.component';
+
+const FORM_CONTROL_IDS: string[] = ['token', 'password'];
+
+describe('SignupComponent', () => {
+  let component: SignupComponent;
+  let fixture: ComponentFixture<SignupComponent>;
+  let authService: jasmine.SpyObj<Partial<AuthService>>;
+  let dataService: jasmine.SpyObj<Partial<DataService>>;
+  let userDetailsSubject: Subject<UserDetails>;
+  let router: jasmine.SpyObj<Partial<Router>>;
+
+  beforeEach(async(() => {
+    userDetailsSubject = new Subject<UserDetails>();
+    authService = {isLoggedIn: jasmine.createSpy().and.returnValue(false)};
+    dataService = {
+      getUserDetails:
+          jasmine.createSpy().and.returnValue(userDetailsSubject.asObservable())
+    };
+    router = {navigate: jasmine.createSpy()};
+
+    TestBed
+        .configureTestingModule({
+          declarations: [SignupComponent],
+          imports: [
+            MatButtonModule,
+            ReactiveFormsModule,
+          ],
+          providers: [
+            {provide: AuthService, useValue: authService},
+            {provide: DataService, useValue: dataService},
+            {provide: Router, useValue: router}
+          ]
+        })
+        .compileComponents();
+
+    fixture = TestBed.createComponent(SignupComponent);
+    component = fixture.componentInstance;
+  }));
+
+  describe('OnInit', () => {
+    it('should route to home page if already logged in', () => {
+      authService.isLoggedIn.and.returnValue(true);
+      fixture.detectChanges();
+
+      expect(router.navigate).toHaveBeenCalledWith(['/']);
+    });
+
+    it('should not route to home page if not logged in', () => {
+      authService.isLoggedIn.and.returnValue(false);
+      fixture.detectChanges();
+
+      expect(router.navigate).not.toHaveBeenCalledWith(['/']);
+    });
+  });
+
+  describe('after OnInit', () => {
+    let tokenEl: HTMLInputElement;
+
+    beforeEach(() => {
+      fixture.detectChanges();
+      tokenEl =
+          fixture.debugElement.query(By.css('input[formcontrolname="token"]'))
+              .nativeElement;
+    });
+
+    for (const control_id of FORM_CONTROL_IDS) {
+      it(`should have all the ${control_id} control properly attached`, () => {
+        const controlEl: HTMLInputElement =
+            fixture.debugElement
+                .query(By.css(`input[formcontrolname="${control_id}"]`))
+                .nativeElement;
+
+        controlEl.value = '10';
+        controlEl.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+
+        expect(component.form.get(control_id).value).toBe('10');
+
+        component.form.patchValue({[control_id]: '12'});
+        fixture.detectChanges();
+
+        expect(controlEl.value).toBe('12');
+      });
+    }
+
+    it('should get email associated with token', () => {
+      component.form.patchValue({'token': 'some-token'});
+      expect(dataService.getUserDetails).toHaveBeenCalledWith('some-token');
+
+      userDetailsSubject.next({github: {email: 'hans@solo.com'}});
+      expect(component.email).toBe('hans@solo.com');
+    });
+
+    it('should show error if getting email errors out', () => {
+      component.form.patchValue({'token': 'some-token'});
+      userDetailsSubject.error({error: {message: 'ya done messed up'}});
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.form-error'))
+                 .nativeElement.textContent)
+          .toBe('ya done messed up');
+    });
+  });
+});

--- a/web/app/signup/signup.component.spec.ts
+++ b/web/app/signup/signup.component.spec.ts
@@ -6,9 +6,8 @@ import {By} from '@angular/platform-browser';
 import {Router} from '@angular/router';
 import {Subject} from 'rxjs/Subject';
 
-import {mockSignupResponse} from '../common/test_helpers/mock_login_data';
 import {UserDetails} from '../common/types';
-import {AuthService, SignupResponse} from '../services/auth.service';
+import {AuthService} from '../services/auth.service';
 import {DataService} from '../services/data.service';
 
 import {SignupComponent} from './signup.component';

--- a/web/app/signup/signup.component.ts
+++ b/web/app/signup/signup.component.ts
@@ -1,0 +1,57 @@
+
+import {Component, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {Router} from '@angular/router';
+
+import {CiHttpErrorResponse} from '../common/types';
+import {AuthService} from '../services/auth.service';
+import {DataService} from '../services/data.service';
+
+function buildSignupForm(fb: FormBuilder): FormGroup {
+  return fb.group({
+    token: ['', Validators.required],
+    password: ['', Validators.required],
+  });
+}
+
+@Component({
+  selector: 'fci-login',
+  templateUrl: './signup.component.html',
+  styleUrls: ['./signup.component.scss']
+})
+export class SignupComponent implements OnInit {
+  email = '';
+  error: string;
+  readonly form: FormGroup;
+
+  constructor(
+      private readonly authService: AuthService,
+      private readonly dataService: DataService,
+      private readonly router: Router,
+      fb: FormBuilder,
+  ) {
+    this.form = buildSignupForm(fb);
+  }
+
+  ngOnInit() {
+    if (this.authService.isLoggedIn()) {
+      this.router.navigate(['/']);
+    }
+
+    this.form.get('token').valueChanges.subscribe((newToken) => {
+      this.getUserEmail(newToken);
+    });
+  }
+
+  private getUserEmail(token: string) {
+    delete this.error;
+
+    this.dataService.getUserDetails(token).subscribe(
+        (userDetails) => {
+          this.email = userDetails.github.email;
+        },
+        (response: CiHttpErrorResponse) => {
+          this.error = response.error.message;
+        });
+  }
+}

--- a/web/app/signup/signup.module.ts
+++ b/web/app/signup/signup.module.ts
@@ -1,0 +1,29 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {ReactiveFormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material';
+
+import {AuthService} from '../services/auth.service';
+import {DataService} from '../services/data.service';
+
+import {SignupComponent} from './signup.component';
+
+@NgModule({
+  declarations: [
+    SignupComponent,
+  ],
+  entryComponents: [
+    SignupComponent,
+  ],
+  imports: [
+    /** Angular Library Imports */
+    CommonModule, ReactiveFormsModule,
+    /** Internal Imports */
+    /** Angular Material Imports */
+    MatButtonModule,
+    /** Third-Party Module Imports */
+  ],
+  providers: [AuthService, DataService],
+})
+export class SignupModule {
+}


### PR DESCRIPTION
Issue: #1011

Initial sign up page. Very much still under development, but now we can see the user's email and use it as the email for login.

#### Screenshots
![image](https://user-images.githubusercontent.com/2754461/42117628-927537f8-7bb2-11e8-8c5f-098872f7d73d.png)

![image](https://user-images.githubusercontent.com/2754461/42117633-98860bea-7bb2-11e8-95f7-53f98e9cc7d7.png)


```
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```