### PR TITLE
Fix Angular CLI prod build errors

### DIFF
--- a/web/app/build/build.component.html
+++ b/web/app/build/build.component.html
@@ -7,10 +7,12 @@
       <span *ngIf="build && build.description" class="fci-build-description">{{build.description}}</span>
     </div>
     <div class="fci-build-logs">
-      <ng-container *ngIf="logs.length <= 0; else hasLogs">Connecting...</ng-container>
-      <ng-container #hasLogs *ngFor="let log of logs">
-        {{log.message}}
-        <br>
+      <ng-container *ngIf="logs.length <= 0">Connecting...</ng-container>
+      <ng-container *ngIf="logs.length > 0">
+        <ng-container *ngFor="let log of logs">
+          {{log.message}}
+          <br>
+        </ng-container>
       </ng-container>
     </div>
   </div>

--- a/web/app/common/test_helpers/dummy.module.ts
+++ b/web/app/common/test_helpers/dummy.module.ts
@@ -1,0 +1,6 @@
+import {NgModule} from '@angular/core';
+import {DummyComponent} from './dummy.component';
+
+@NgModule({declarations: [DummyComponent]})
+export class DummyModule {
+}


### PR DESCRIPTION
Prod build was failing for two reasons:
1. Apparently you need a module for every component, even if it's just used in a single test declaration.
1. `ngIfElse` usage throws an error. Not sure why this is the case, since it's totally a common use-case that Angular documents https://angular.io/api/common/NgIf#showing-an-alternative-template-using-else 