### PR TITLE
Add initial onboarding stepper with link to old onboarding

### DIFF
--- a/web/app/onboard/onboard.component.html
+++ b/web/app/onboard/onboard.component.html
@@ -12,19 +12,28 @@
 <div fci-grid>
   <div fci-cell="12">
     <h6>NOT WORKING - CURRENTLY IN DEVELOPMENT</h6>
-    <mat-vertical-stepper>
-      <mat-step label="Set up your Encryption Key">
-        Encryption key input
-      </mat-step>
-      <mat-step label="Set Up your CI bot account">
-        CI bot account set up
-      </mat-step>
-      <mat-step label="Set up your CI account">
-        User CI account set up
-      </mat-step>
-      <mat-step label="Create private Repository for ci-config">
-        Repository setup
-      </mat-step>
-    </mat-vertical-stepper>
+    <form [formGroup]="form">
+      <mat-vertical-stepper>
+        <mat-step label="Set up your Encryption Key">
+          <p>
+            <b>fastlane.ci</b> uses an encryption key to encrypt your API tokens and passwords written out to the private
+            <b>fastlane.ci</b>
+            configuration repository generated at the end of onboarding.</p>
+          <div class="fci-input-container">
+            <label>CI encryption key</label>
+            <input formControlName="encryptionKey" placeholder="my-encryption-key" type="password">
+          </div>
+          <div>
+            <button mat-button mat-raised-button color="primary" matStepperNext>Next</button>
+          </div>
+        </mat-step>
+        <mat-step label="Set Up your CI bot account">
+          CI bot account set up
+        </mat-step>
+        <mat-step label="Create private Repository for ci-config">
+          Repository setup
+        </mat-step>
+      </mat-vertical-stepper>
+    </form>
   </div>
 </div>

--- a/web/app/onboard/onboard.component.html
+++ b/web/app/onboard/onboard.component.html
@@ -1,0 +1,30 @@
+<div class="fci-onboard-header">
+  <div fci-grid class="fci-onboard-welcome">
+    <div fci-cell="12">
+      <div class="fci-onboard-title">Welcome to fastlane.ci!</div>
+      <div class="fci-onboard-subtitle">
+        Open source, self-hosted, mobile-optimized CI powered by fastlane brought to you by the fastlane team.
+      </div>
+      <button mat-raised-button color="primary" (click)="goToOldOnboarding()">Old Onboarding</button>
+    </div>
+  </div>
+</div>
+<div fci-grid>
+  <div fci-cell="12">
+    <h6>NOT WORKING - CURRENTLY IN DEVELOPMENT</h6>
+    <mat-vertical-stepper>
+      <mat-step label="Set up your Encryption Key">
+        Encryption key input
+      </mat-step>
+      <mat-step label="Set Up your CI bot account">
+        CI bot account set up
+      </mat-step>
+      <mat-step label="Set up your CI account">
+        User CI account set up
+      </mat-step>
+      <mat-step label="Create private Repository for ci-config">
+        Repository setup
+      </mat-step>
+    </mat-vertical-stepper>
+  </div>
+</div>

--- a/web/app/onboard/onboard.component.scss
+++ b/web/app/onboard/onboard.component.scss
@@ -1,0 +1,24 @@
+@import "../../shared/layout";
+.fci-onboard-header {
+    background-color: #E1BEE7;
+    .fci-onboard-welcome {
+        padding: 75px 0 4px 0;
+        .fci-onboard-title {
+            font-family: 'Google Sans', sans-serif;
+            color: rgba(0, 0, 0, 0.87);
+            font-size: 32px;
+            font-weight: 500;
+            line-height: 40px;
+            margin-bottom: 12px;
+        }
+        .fci-onboard-subtitle {
+            color: rgba(0, 0, 0, 0.54);
+            font-size: 18px;
+            font-family: 'Google Sans', sans-serif;
+            line-height: 24px;
+        }
+        button {
+            margin-top: 25px;
+        }
+    }
+}

--- a/web/app/onboard/onboard.component.scss
+++ b/web/app/onboard/onboard.component.scss
@@ -22,3 +22,15 @@
         }
     }
 }
+
+.mat-stepper-vertical {
+    .fci-input-container {
+        padding-bottom: 24px;
+    }
+    p {
+        margin-top: 8px;
+        margin-bottom: 51px;
+        font-size: 14px;
+        color: #4a4a4a;
+    }
+}

--- a/web/app/onboard/onboard.component.spec.ts
+++ b/web/app/onboard/onboard.component.spec.ts
@@ -1,9 +1,13 @@
 import {DOCUMENT} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule, MatStepperModule} from '@angular/material';
 import {By} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
 import {OnboardComponent} from './onboard.component';
+
+const FORM_CONTROL_IDS: string[] = ['encryptionKey'];
 
 describe('OnboardComponent', () => {
   let fixture: ComponentFixture<OnboardComponent>;
@@ -15,7 +19,10 @@ describe('OnboardComponent', () => {
 
     TestBed
         .configureTestingModule({
-          imports: [MatStepperModule, MatButtonModule],
+          imports: [
+            MatStepperModule, BrowserAnimationsModule, MatButtonModule,
+            ReactiveFormsModule
+          ],
           declarations: [
             OnboardComponent,
           ],
@@ -24,7 +31,28 @@ describe('OnboardComponent', () => {
 
     fixture = TestBed.createComponent(OnboardComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
   });
+
+  for (const control_id of FORM_CONTROL_IDS) {
+    it(`should have the ${control_id} control properly attached`, () => {
+      const controlEl: HTMLInputElement =
+          fixture.debugElement
+              .query(By.css(`input[formcontrolname="${control_id}"]`))
+              .nativeElement;
+
+      controlEl.value = '10';
+      controlEl.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(component.form.get(control_id).value).toBe('10');
+
+      component.form.patchValue({[control_id]: '12'});
+      fixture.detectChanges();
+
+      expect(controlEl.value).toBe('12');
+    });
+  }
 
   it('should redirect to old onboarding when button is clicked', () => {
     spyOn(component, 'goToOldOnboarding');

--- a/web/app/onboard/onboard.component.spec.ts
+++ b/web/app/onboard/onboard.component.spec.ts
@@ -1,0 +1,36 @@
+import {DOCUMENT} from '@angular/common';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatButtonModule, MatStepperModule} from '@angular/material';
+import {By} from '@angular/platform-browser';
+
+import {OnboardComponent} from './onboard.component';
+
+describe('OnboardComponent', () => {
+  let fixture: ComponentFixture<OnboardComponent>;
+  let document: jasmine.SpyObj<any>;
+  let component: OnboardComponent;
+
+  beforeEach(() => {
+    document = {location: {origin: 'fake-host', href: 'fake-href'}};
+
+    TestBed
+        .configureTestingModule({
+          imports: [MatStepperModule, MatButtonModule],
+          declarations: [
+            OnboardComponent,
+          ],
+        })
+        .compileComponents();
+
+    fixture = TestBed.createComponent(OnboardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should redirect to old onboarding when button is clicked', () => {
+    spyOn(component, 'goToOldOnboarding');
+    fixture.debugElement.query(By.css('.fci-onboard-welcome button'))
+        .nativeElement.click();
+
+    expect(component.goToOldOnboarding).toHaveBeenCalled();
+  });
+});

--- a/web/app/onboard/onboard.component.ts
+++ b/web/app/onboard/onboard.component.ts
@@ -1,0 +1,17 @@
+import {DOCUMENT} from '@angular/common';
+import {Component, Inject} from '@angular/core';
+
+@Component({
+  selector: 'fci-onboard',
+  templateUrl: './onboard.component.html',
+  styleUrls: ['./onboard.component.scss']
+})
+
+export class OnboardComponent {
+  constructor(@Inject(DOCUMENT) private readonly document: any) {}
+
+  goToOldOnboarding() {
+    this.document.location.href =
+        `${this.document.location.origin}/onboarding_erb`;
+  }
+}

--- a/web/app/onboard/onboard.component.ts
+++ b/web/app/onboard/onboard.component.ts
@@ -1,14 +1,28 @@
 import {DOCUMENT} from '@angular/common';
 import {Component, Inject} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+
+
+function buildProjectForm(fb: FormBuilder): FormGroup {
+  return fb.group({
+    'encryptionKey': ['', Validators.required],
+  });
+}
 
 @Component({
   selector: 'fci-onboard',
   templateUrl: './onboard.component.html',
   styleUrls: ['./onboard.component.scss']
 })
-
 export class OnboardComponent {
-  constructor(@Inject(DOCUMENT) private readonly document: any) {}
+  readonly form: FormGroup;
+
+  constructor(
+      @Inject(DOCUMENT) private readonly document: any,
+      fb: FormBuilder,
+  ) {
+    this.form = buildProjectForm(fb);
+  }
 
   goToOldOnboarding() {
     this.document.location.href =

--- a/web/app/onboard/onboard.module.ts
+++ b/web/app/onboard/onboard.module.ts
@@ -1,0 +1,24 @@
+import {NgModule} from '@angular/core';
+import {MatButtonModule, MatStepperModule} from '@angular/material';
+
+import {OnboardComponent} from './onboard.component';
+
+
+@NgModule({
+  declarations: [
+    OnboardComponent,
+  ],
+  entryComponents: [
+    OnboardComponent,
+  ],
+  imports: [
+    /** Angular Library Imports */
+    /** Internal Imports */
+    /** Angular Material Imports */
+    MatButtonModule, MatStepperModule,
+    /** Third-Party Module Imports */
+  ],
+  providers: [],
+})
+export class OnboardModule {
+}

--- a/web/app/onboard/onboard.module.ts
+++ b/web/app/onboard/onboard.module.ts
@@ -1,4 +1,5 @@
 import {NgModule} from '@angular/core';
+import {ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule, MatStepperModule} from '@angular/material';
 
 import {OnboardComponent} from './onboard.component';
@@ -13,6 +14,7 @@ import {OnboardComponent} from './onboard.component';
   ],
   imports: [
     /** Angular Library Imports */
+    ReactiveFormsModule,
     /** Internal Imports */
     /** Angular Material Imports */
     MatButtonModule, MatStepperModule,

--- a/web/app/root/initialization.provider.spec.ts
+++ b/web/app/root/initialization.provider.spec.ts
@@ -1,51 +1,50 @@
-import {DOCUMENT} from '@angular/common';
 import {TestBed} from '@angular/core/testing';
+import {Router} from '@angular/router';
 import {Subject} from 'rxjs/Subject';
+
 import {DataService} from '../services/data.service';
+
 import {InitializationProvider} from './initialization.provider';
 
 describe('InitiliazationProvider', () => {
   let dataService: jasmine.SpyObj<Partial<DataService>>;
-  let document: jasmine.SpyObj<any>;
   let isConfiguredSubject: Subject<boolean>;
   let initializationProvider: InitializationProvider;
+  let router: jasmine.SpyObj<Partial<Router>>;
+
   beforeEach(() => {
     isConfiguredSubject = new Subject<boolean>();
     dataService = {
       isServerConfigured: jasmine.createSpy().and.returnValue(
           isConfiguredSubject.asObservable())
     };
-
-    document = {location: {origin: 'fake-host', href: 'fake-href'}};
+    router = {navigate: jasmine.createSpy()};
 
     TestBed.configureTestingModule({
       imports: [],
       providers: [
         {provide: DataService, useValue: dataService},
-        {provide: DOCUMENT, useValue: document}, InitializationProvider
+        {provide: Router, useValue: router}, InitializationProvider
       ]
     });
 
     initializationProvider = TestBed.get(InitializationProvider);
-    document = TestBed.get(DOCUMENT);
   });
 
   it('should redirect to onboarding erb page if the server is not configured',
      () => {
-       expect(document.location.href).toBe('fake-href');
        initializationProvider.initialize();
        isConfiguredSubject.next(false);
 
-       expect(document.location.href).toBe('fake-host/onboarding_erb');
+       expect(router.navigate).toHaveBeenCalledWith(['onboard']);
      });
 
 
   it('should not redirect to onboarding erb page if the server is configured',
      () => {
-       expect(document.location.href).toBe('fake-href');
        initializationProvider.initialize();
        isConfiguredSubject.next(true);
 
-       expect(document.location.href).toBe('fake-href');
+       expect(router.navigate).not.toHaveBeenCalledWith(['onboard']);
      });
 });

--- a/web/app/root/initialization.provider.ts
+++ b/web/app/root/initialization.provider.ts
@@ -1,15 +1,14 @@
 import 'rxjs/add/operator/map';
 
-import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable} from '@angular/core';
+import {Injectable, Injector} from '@angular/core';
+import {Router} from '@angular/router';
 
 import {DataService} from '../services/data.service';
 
 @Injectable()
 export class InitializationProvider {
   constructor(
-      @Inject(DOCUMENT) private document: any,
-      private readonly dataService: DataService) {}
+      private injector: Injector, private readonly dataService: DataService) {}
 
   /**
    * Load initial data and reroute to onboarding if the server is not
@@ -21,10 +20,20 @@ export class InitializationProvider {
     return this.dataService.isServerConfigured()
         .map((isConfigured) => {
           if (!isConfigured) {
-            this.document.location.href =
-                `${this.document.location.origin}/onboarding_erb`;
+            this.router.navigate(['onboard']);
           }
         })
         .toPromise();
+  }
+
+  /**
+   * This will return the Router dependency. It is required to inject this
+   * separately because the Router depends on Http and Http depends on the
+   * router. This creates a cyclical dependency when initializing the root
+   * module. More information can be found here:
+   * https://stackoverflow.com/questions/39767019/app-initializer-raises-cannot-instantiate-cyclic-dependency-applicationref-w
+   */
+  private get router(): Router {
+    return this.injector.get(Router);
   }
 }

--- a/web/app/root/routing.module.ts
+++ b/web/app/root/routing.module.ts
@@ -7,6 +7,8 @@ import {DashboardComponent} from '../dashboard/dashboard.component';
 import {DashboardModule} from '../dashboard/dashboard.module';
 import {LoginComponent} from '../login/login.component';
 import {LoginModule} from '../login/login.module';
+import {OnboardComponent} from '../onboard/onboard.component';
+import {OnboardModule} from '../onboard/onboard.module';
 import {ProjectComponent} from '../project/project.component';
 import {ProjectModule} from '../project/project.module';
 
@@ -16,11 +18,12 @@ const routes: Routes = [
   {path: 'project/:id', component: ProjectComponent},
   {path: 'project/:projectId/build/:buildId', component: BuildComponent},
   {path: 'login', component: LoginComponent},
+  {path: 'onboard', component: OnboardComponent},
 ];
 
 @NgModule({
   imports: [
-    DashboardModule, ProjectModule, BuildModule, LoginModule,
+    DashboardModule, ProjectModule, BuildModule, LoginModule, OnboardModule,
     RouterModule.forRoot(routes)
   ],
   exports: [RouterModule]

--- a/web/global/input.scss
+++ b/web/global/input.scss
@@ -1,5 +1,12 @@
 .fci-input-container {
     padding-bottom: 16px;
+    label {
+        font-family: 'Roboto';
+        color: rgba(0, 0, 0, 0.54);
+        font-size: 13px;
+        display: block;
+        padding-bottom: 8px;
+    }
     input {
         background-color: white;
         border: 0;


### PR DESCRIPTION
Issue: #784 

- [x] has stepper for onboarding
- [x] placeholders for all the onboarding inputs
- [x] routes to onboarding when server is not configured

#### Screenshot
![image](https://user-images.githubusercontent.com/2754461/42187333-8368c398-7e04-11e8-8039-f65bb42bc582.png)

```
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```