### PR TITLE
Get User details in a stateless manner

### DIFF
--- a/app/features-json/repos_json_controller.rb
+++ b/app/features-json/repos_json_controller.rb
@@ -21,11 +21,11 @@ module FastlaneCI
 
     # Ex. "../repos/user_details?token=123456"
     get "#{HOME}/user_details", authenticate: false do
-      provider_credential = GitHubProviderCredential.new(api_token: params[:token])
-      github_service = GitHubService.new(provider_credential: provider_credential)
+      github_client = Octokit::Client.new(access_token: params[:token])
 
       begin
-        email = github_service.email
+        #  Note: This fails if the user.email scope is missing from token
+        email = github_client.emails.find(&:primary).email
       rescue Octokit::NotFound
         json_error!(
           error_message: "Provided API token needs user email scope",


### PR DESCRIPTION
Fixes: #1010

This allows us to make a request to Github without having to create any providers. Since this is a one time request without any persisted data.

```
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```