### PR TITLE
Create Settings Dialog component

### DIFF
--- a/web/app/project/project.component.html
+++ b/web/app/project/project.component.html
@@ -1,4 +1,8 @@
-<fci-toolbar [breadcrumbs]="breadcrumbs"></fci-toolbar>
+<fci-toolbar [breadcrumbs]="breadcrumbs">
+  <button class="fci-settings-button" fci-toolbar-right mat-icon-button (click)="openSettingsDialog()">
+    <mat-icon>settings</mat-icon>
+  </button>
+</fci-toolbar>
 <div class="fci-project-container">
   <div class="fci-left-container">
     <div *ngIf="project" class="fci-project-header">{{project.name}}</div>

--- a/web/app/project/project.component.scss
+++ b/web/app/project/project.component.scss
@@ -1,4 +1,9 @@
 $TOOLBAR_HEIGHT:80px;
+.fci-settings-button {
+    margin-right: 36px;
+    color: #ffffff
+}
+
 .fci-project-container {
     display: flex;
     padding: 24px 92px 0 92px;

--- a/web/app/project/project.component.spec.ts
+++ b/web/app/project/project.component.spec.ts
@@ -3,7 +3,7 @@ import 'rxjs/add/operator/switchMap';
 import {Location} from '@angular/common';
 import {DebugElement} from '@angular/core';
 import {async, ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
-import {MatCardModule, MatProgressSpinnerModule, MatTableModule} from '@angular/material';
+import {MatCardModule, MatDialog, MatIconModule, MatProgressSpinnerModule, MatTableModule} from '@angular/material';
 import {By} from '@angular/platform-browser';
 import {ActivatedRoute, convertToParamMap} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
@@ -22,6 +22,8 @@ import {SharedMaterialModule} from '../root/shared_material.module';
 import {DataService} from '../services/data.service';
 
 import {ProjectComponent} from './project.component';
+import {SettingsDialogComponent} from './settings-dialog/settings-dialog.component';
+import {SettingsDialogModule} from './settings-dialog/settings-dialog.modules';
 
 describe('ProjectComponent', () => {
   let component: ProjectComponent;
@@ -29,6 +31,7 @@ describe('ProjectComponent', () => {
   let dataService: jasmine.SpyObj<Partial<DataService>>;
   let projectSubject: Subject<Project>;
   let rebuildSummarySubject: Subject<BuildSummary>;
+  let dialog: jasmine.SpyObj<Partial<MatDialog>>;
 
   beforeEach(async(() => {
     projectSubject = new Subject<Project>();
@@ -39,13 +42,14 @@ describe('ProjectComponent', () => {
       rebuild: jasmine.createSpy().and.returnValue(
           rebuildSummarySubject.asObservable())
     };
+    dialog = {open: jasmine.createSpy()};
 
     TestBed
         .configureTestingModule({
           imports: [
             StatusIconModule, MomentModule, ToolbarModule, MatCardModule,
-            MatTableModule, MatProgressSpinnerModule,
-            RouterTestingModule.withRoutes([
+            MatTableModule, MatProgressSpinnerModule, SettingsDialogModule,
+            MatIconModule, RouterTestingModule.withRoutes([
               {
                 path: 'project/:projectId/build/:buildId',
                 component: DummyComponent
@@ -58,7 +62,8 @@ describe('ProjectComponent', () => {
               provide: ActivatedRoute,
               useValue:
                   {paramMap: Observable.of(convertToParamMap({id: '123'}))}
-            }
+            },
+            {provide: MatDialog, useValue: dialog}
           ],
         })
         .compileComponents();
@@ -141,6 +146,16 @@ describe('ProjectComponent', () => {
                 .queryAll(By.css('.fci-project-details .fci-loading-spinner'))
                 .length)
             .toBe(1);
+      });
+
+      it('should open settings dialog when settings gear is clicked', () => {
+        fixture.debugElement.query(By.css('.fci-settings-button'))
+            .nativeElement.click();
+        expect(dialog.open).toHaveBeenCalledWith(SettingsDialogComponent, {
+          panelClass: 'fci-dialog',
+          width: '1028px',
+          data: {project: this.project},
+        });
       });
     });
 

--- a/web/app/project/project.component.ts
+++ b/web/app/project/project.component.ts
@@ -1,7 +1,7 @@
 import 'rxjs/add/operator/switchMap';
 
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {MatTable} from '@angular/material';
+import {MatDialog, MatDialogConfig, MatTable} from '@angular/material';
 import {ActivatedRoute, ParamMap} from '@angular/router';
 
 import {Breadcrumb} from '../common/components/toolbar/toolbar.component';
@@ -9,6 +9,8 @@ import {Build} from '../models/build';
 import {BuildSummary} from '../models/build_summary';
 import {Project} from '../models/project';
 import {DataService} from '../services/data.service';
+
+import {SettingsDialogComponent, SettingsDialogData} from './settings-dialog/settings-dialog.component';
 
 @Component({
   selector: 'fci-project',
@@ -28,7 +30,8 @@ export class ProjectComponent implements OnInit {
 
   constructor(
       private readonly dataService: DataService,
-      private readonly route: ActivatedRoute) {}
+      private readonly route: ActivatedRoute,
+      private readonly dialog: MatDialog) {}
 
   ngOnInit() {
     this.route.paramMap
@@ -52,6 +55,16 @@ export class ProjectComponent implements OnInit {
           // Need to re-render rows now that new data is added.
           this.table.renderRows();
         });
+  }
+
+  openSettingsDialog() {
+    const dialogRef =
+        this.dialog.open<SettingsDialogComponent, SettingsDialogData>(
+            SettingsDialogComponent, {
+              panelClass: 'fci-dialog',
+              width: '1028px',
+              data: {project: this.project},
+            });
   }
 
   private updateBreadcrumbs(projectName: string) {

--- a/web/app/project/project.module.ts
+++ b/web/app/project/project.module.ts
@@ -9,6 +9,7 @@ import {ToolbarModule} from '../common/components/toolbar/toolbar.module';
 import {DashboardComponent} from '../dashboard/dashboard.component';
 import {ProjectComponent} from '../project/project.component';
 import {DataService} from '../services/data.service';
+import {SettingsDialogModule} from './settings-dialog/settings-dialog.modules';
 
 @NgModule({
   declarations: [
@@ -22,10 +23,10 @@ import {DataService} from '../services/data.service';
     RouterModule,  // For routerLink directive
     CommonModule,
     /** Internal Imports */
-    StatusIconModule, ToolbarModule,
+    StatusIconModule, ToolbarModule, SettingsDialogModule,
     /** Angular Material Imports */
     MatCardModule, MatProgressSpinnerModule, MatTableModule, MatIconModule,
-    MatButtonModule,
+    MatButtonModule, MatIconModule,
     /** Third-Party Module Imports */
     MomentModule,  // For Date relative time pipes
   ],

--- a/web/app/project/settings-dialog/settings-dialog.component.html
+++ b/web/app/project/settings-dialog/settings-dialog.component.html
@@ -1,0 +1,30 @@
+<fci-master-detail-card>
+  <!-- Master Content -->
+  <div fci-master>
+    <div class="fci-master-section-header">Project settings</div>
+    <div class="fci-master-section-label" *ngFor="let section of masterSections()" [class.fci-master-section-selected]="selectedSection === section"
+      (click)="selectSection(section)">
+      {{MASTER_SECTION_LABELS_MAP.get(section)}}
+    </div>
+  </div>
+  <!-- Detail Content -->
+  <div fci-detail class="fci-detail-container">
+    <ng-container [ngSwitch]="selectedSection">
+      <form *ngSwitchCase="MasterSection.GENERAL" [formGroup]="generalForm" class="fci-general-form">
+        <h3>General
+          <i>(not editable yet)</i>
+        </h3>
+        <mat-form-field>
+          <input matInput placeholder="Project name" formControlName="name">
+        </mat-form-field>
+        <mat-form-field>
+          <input matInput placeholder="Lane to run" formControlName="lane">
+        </mat-form-field>
+        <div class="fci-button-container">
+          <button mat-button (click)="closeDialog()" type="button">Close</button>
+          <button mat-raised-button color="primary" type="submit" [disabled]="!generalForm.valid">Done</button>
+        </div>
+      </form>
+    </ng-container>
+  </div>
+</fci-master-detail-card>

--- a/web/app/project/settings-dialog/settings-dialog.component.scss
+++ b/web/app/project/settings-dialog/settings-dialog.component.scss
@@ -1,0 +1,21 @@
+@import '../../common/components/master-detail-card/master-detail-card-shared-styles';
+.fci-detail-container {
+    h3 {
+        font-size: 20px;
+        color: rgba(0, 0, 0, 0.87);
+        font-weight: 500;
+        margin: 0 0 24px 0;
+    }
+    form {
+        display: flex;
+        flex-direction: column;
+        mat-form-field {
+            max-width: 300px;
+        }
+        .fci-button-container {
+            position: absolute;
+            right: 24px;
+            bottom: 24px;
+        }
+    }
+}

--- a/web/app/project/settings-dialog/settings-dialog.component.spec.ts
+++ b/web/app/project/settings-dialog/settings-dialog.component.spec.ts
@@ -1,0 +1,88 @@
+import {CommonModule} from '@angular/common';
+import {DebugElement} from '@angular/core/src/debug/debug_node';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ReactiveFormsModule} from '@angular/forms';
+import {MAT_DIALOG_DATA, MatButtonModule, MatDialogRef, MatInputModule} from '@angular/material';
+import {By} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {first} from 'rxjs/operators/first';
+
+import {MasterDetailCardModule} from '../../common/components/master-detail-card/master-detail-card.module';
+import {getMockProject} from '../../common/test_helpers/mock_project_data';
+
+import {SettingsDialogComponent} from './settings-dialog.component';
+
+describe('SettingsDialogComponent', () => {
+  let component: SettingsDialogComponent;
+  let dialogRef: jasmine.SpyObj<Partial<MatDialogRef<SettingsDialogComponent>>>;
+  let fixture: ComponentFixture<SettingsDialogComponent>;
+
+  function doesElementExist(selector: string): boolean {
+    return fixture.debugElement.queryAll(By.css(selector)).length > 0;
+  }
+
+  function getElement(selector: string, index: number = 0): DebugElement {
+    return fixture.debugElement.queryAll(By.css(selector))[index];
+  }
+
+  beforeEach(async(() => {
+    dialogRef = {close: jasmine.createSpy()};
+    TestBed
+        .configureTestingModule({
+          declarations: [SettingsDialogComponent],
+          imports: [
+            CommonModule, ReactiveFormsModule, MasterDetailCardModule,
+            MatInputModule, MatButtonModule, BrowserAnimationsModule
+          ],
+          providers: [
+            {provide: MAT_DIALOG_DATA, useValue: {project: getMockProject()}},
+            {provide: MatDialogRef, useValue: dialogRef}
+          ]
+        })
+        .compileComponents();
+
+    fixture = TestBed.createComponent(SettingsDialogComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  }));
+
+  describe('General Settings', () => {
+    it('Should close dialog when close button is clicked', () => {
+      getElement('.fci-button-container button[type="button"]')
+          .nativeElement.click();
+      expect(dialogRef.close).toHaveBeenCalled();
+    });
+
+    it('Should show general settings label as first label', () => {
+      const firstLabel = getElement('.fci-master-section-label', 0);
+      expect(firstLabel.nativeElement.innerText).toBe('General');
+    });
+
+    it('Should show General Settings content when section is clicked', () => {
+      // TODO: Change this to a different Section after adding Env vards
+      component.selectedSection = null;
+      fixture.detectChanges();
+
+      expect(doesElementExist('.fci-general-form')).toBe(false);
+      component.selectedSection = component.MasterSection.GENERAL;
+      fixture.detectChanges();
+
+      expect(doesElementExist('.fci-general-form')).toBe(true);
+    });
+
+    // TODO: Fill these tests out once feature as complete
+    it('Should submit changes when Done button is clicked', () => {});
+    it('Should have Project name properly bound to form', () => {});
+    it('Should have lane select properly bound to form', () => {});
+  });
+
+  describe('Environment Variables', () => {
+    // TODO: Complete these tests when a second section is added
+    it('Should add the selected section class when different section is clicked',
+       () => {});
+    it('Should show Environment Variables content when section is clicked',
+       () => {});
+    it('Should show Env vars label', () => {});
+  });
+});

--- a/web/app/project/settings-dialog/settings-dialog.component.ts
+++ b/web/app/project/settings-dialog/settings-dialog.component.ts
@@ -1,0 +1,55 @@
+import {Component, Inject} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {MAT_DIALOG_DATA, MatDialogConfig, MatDialogRef} from '@angular/material';
+
+import {Project} from '../../models/project';
+
+export interface SettingsDialogData {
+  project: Project;
+}
+
+enum MasterSection {
+  GENERAL
+}
+
+const MASTER_SECTION_LABELS_MAP: Map<MasterSection, string> =
+    new Map([[MasterSection.GENERAL, 'General']]);
+
+function buildGeneralForm(fb: FormBuilder, project: Project): FormGroup {
+  return fb.group({
+    'name': [{value: project.name, disabled: true}, Validators.required],
+    'lane': [{value: project.lane, disabled: true}, Validators.required],
+  });
+}
+
+@Component({
+  selector: 'fci-settings-dialog',
+  templateUrl: './settings-dialog.component.html',
+  styleUrls: ['./settings-dialog.component.scss']
+})
+export class SettingsDialogComponent {
+  selectedSection = MasterSection.GENERAL;
+  readonly generalForm: FormGroup;
+  readonly MasterSection = MasterSection;
+  readonly MASTER_SECTION_LABELS_MAP = MASTER_SECTION_LABELS_MAP;
+
+  constructor(
+      private readonly dialogRef: MatDialogRef<SettingsDialogComponent>,
+      @Inject(MAT_DIALOG_DATA) dialogData: SettingsDialogData,
+      fb: FormBuilder,
+  ) {
+    this.generalForm = buildGeneralForm(fb, dialogData.project);
+  }
+
+  closeDialog(): void {
+    this.dialogRef.close();
+  }
+
+  selectSection(section: MasterSection): void {
+    this.selectedSection = section;
+  }
+
+  masterSections(): MasterSection[] {
+    return Array.from(this.MASTER_SECTION_LABELS_MAP.keys());
+  }
+}

--- a/web/app/project/settings-dialog/settings-dialog.modules.ts
+++ b/web/app/project/settings-dialog/settings-dialog.modules.ts
@@ -1,0 +1,30 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {ReactiveFormsModule} from '@angular/forms';
+import {MatButtonModule, MatInputModule} from '@angular/material';
+
+import {MasterDetailCardModule} from '../../common/components/master-detail-card/master-detail-card.module';
+
+import {SettingsDialogComponent} from './settings-dialog.component';
+
+
+@NgModule({
+  declarations: [
+    SettingsDialogComponent,
+  ],
+  entryComponents: [
+    SettingsDialogComponent,
+  ],
+  imports: [
+    /** Angular Library Imports */
+    CommonModule, ReactiveFormsModule,
+    /** Internal Imports */
+    MasterDetailCardModule,
+    /** Angular Material Imports */
+    MatInputModule, MatButtonModule,
+    /** Third-Party Module Imports */
+  ],
+  providers: [],
+})
+export class SettingsDialogModule {
+}

--- a/web/global/dialog.scss
+++ b/web/global/dialog.scss
@@ -18,6 +18,10 @@
     }
 }
 
+.fci-dialog .mat-dialog-container {
+    padding: 0;
+}
+
 .mat-icon-button.fci-dialog-icon-close-button {
     position: absolute;
     right: 8px;


### PR DESCRIPTION
Issue: #1060 

This is the component implementation. It will be added to the Project details page in a separate PR. We need to change the project details data to include the full repo name and the full lane name (including the platform) for us to get the lanes. We also need an endpoint to update the project. So all the inputs are disabled for now.

Sneak Peek:
![image](https://user-images.githubusercontent.com/2754461/42403690-cbb5f37e-8137-11e8-881f-d8be145ae682.png)


```
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```