### PR TITLE
Refactor: Add Jasmine Test helper for DOM Elements

### DIFF
--- a/web/app/build/build.component.spec.ts
+++ b/web/app/build/build.component.spec.ts
@@ -1,4 +1,4 @@
-import {DebugElement} from '@angular/core/src/debug/debug_node';
+import {DebugElement, getAllDebugNodes} from '@angular/core/src/debug/debug_node';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatCardModule, MatProgressSpinnerModule} from '@angular/material';
 import {By} from '@angular/platform-browser';
@@ -11,6 +11,7 @@ import {Subject} from 'rxjs/Subject';
 import {StatusIconModule} from '../common/components/status-icon/status-icon.module';
 import {ToolbarModule} from '../common/components/toolbar/toolbar.module';
 import {BuildStatus} from '../common/constants';
+import {expectElementNotToExist, expectElementToExist, getAllElements, getElement} from '../common/test_helpers/element_helper_functions';
 import {mockBuild, mockBuildResponse} from '../common/test_helpers/mock_build_data';
 import {Build, BuildLogLine} from '../models/build';
 import {BuildLogMessageEvent, BuildLogWebsocketService} from '../services/build-log-websocket.service';
@@ -21,6 +22,7 @@ import {BuildComponent} from './build.component';
 describe('BuildComponent', () => {
   let component: BuildComponent;
   let fixture: ComponentFixture<BuildComponent>;
+  let fixtureEl: DebugElement;
   let buildLogWebsocketService:
       jasmine.SpyObj<Partial<BuildLogWebsocketService>>;
   let dataService: jasmine.SpyObj<Partial<DataService>>;
@@ -67,6 +69,7 @@ describe('BuildComponent', () => {
         .compileComponents();
 
     fixture = TestBed.createComponent(BuildComponent);
+    fixtureEl = fixture.debugElement;
     component = fixture.componentInstance;
   });
 
@@ -118,8 +121,7 @@ describe('BuildComponent', () => {
       fixture.detectChanges();  // onInit()
 
       // toolbar exists
-      expect(fixture.debugElement.queryAll(By.css('.fci-crumb')).length)
-          .toBe(3);
+      expect(getAllElements(fixtureEl, '.fci-crumb').length).toBe(3);
 
       expect(component.breadcrumbs[0].label).toBe('Dashboard');
       expect(component.breadcrumbs[0].url).toBe('/');
@@ -171,8 +173,7 @@ describe('BuildComponent', () => {
     }));
 
     it('should show connecting while no logs is connecting', () => {
-      const logsEl =
-          fixture.debugElement.query(By.css('.fci-build-logs')).nativeElement;
+      const logsEl = getElement(fixtureEl, '.fci-build-logs').nativeElement;
       expect(component.logs.length).toBe(0);
       expect(logsEl.innerText).toBe('Connecting...');
 
@@ -187,23 +188,22 @@ describe('BuildComponent', () => {
       let headerEl: DebugElement;
 
       beforeEach(() => {
-        headerEl = fixture.debugElement.query(By.css('.fci-build-header'));
+        headerEl = getElement(fixtureEl, '.fci-build-header');
       });
 
       it('should show status icon after loading', () => {
-        expect(headerEl.queryAll(By.css('fci-status-icon')).length).toBe(0);
+        expectElementNotToExist(headerEl, 'fci-status-icon');
 
         buildSubject.next(mockBuild);
         fixture.detectChanges();
 
-        const iconsEl = headerEl.queryAll(By.css('fci-status-icon'));
+        const iconsEl = getAllElements(headerEl, 'fci-status-icon');
         expect(iconsEl.length).toBe(1);
         expect(iconsEl[0].nativeElement.innerText).toBe('warning');
       });
 
       it('should show build number in title after loading', () => {
-        const titleEl =
-            headerEl.query(By.css('.fci-build-title')).nativeElement;
+        const titleEl = getElement(headerEl, '.fci-build-title').nativeElement;
         expect(titleEl.innerText).toBe('Build');
 
         buildSubject.next(mockBuild);
@@ -213,14 +213,13 @@ describe('BuildComponent', () => {
       });
 
       it('should show build description after loading', () => {
-        expect(headerEl.queryAll(By.css('.fci-build-description')).length)
-            .toBe(0);
+        expectElementNotToExist(headerEl, '.fci-build-description');
 
         buildSubject.next(mockBuild);
         fixture.detectChanges();
 
         const descriptionsEl =
-            headerEl.queryAll(By.css('.fci-build-description'));
+            getAllElements(headerEl, '.fci-build-description');
         expect(descriptionsEl.length).toBe(1);
         expect(descriptionsEl[0].nativeElement.innerText)
             .toBe(
@@ -232,18 +231,16 @@ describe('BuildComponent', () => {
       let detailsEl: DebugElement;
 
       beforeEach(() => {
-        detailsEl = fixture.debugElement.query(By.css('.fci-build-details'));
+        detailsEl = getElement(fixtureEl, '.fci-build-details');
       });
 
       it('should show spinner while loading', () => {
-        expect(detailsEl.queryAll(By.css('.fci-loading-spinner')).length)
-            .toBe(1);
+        expectElementToExist(detailsEl, '.fci-loading-spinner');
 
         buildSubject.next(mockBuild);
         fixture.detectChanges();
 
-        expect(detailsEl.queryAll(By.css('.fci-loading-spinner')).length)
-            .toBe(0);
+        expectElementNotToExist(detailsEl, '.fci-loading-spinner');
       });
 
       describe('after build loaded', () => {
@@ -295,16 +292,16 @@ describe('BuildComponent', () => {
       let cardEl: DebugElement;
 
       beforeEach(() => {
-        cardEl = fixture.debugElement.query(By.css('.fci-artifacts'));
+        cardEl = getElement(fixtureEl, '.fci-artifacts');
       });
 
       it('should show spinner while loading', () => {
-        expect(cardEl.queryAll(By.css('.fci-loading-spinner')).length).toBe(1);
+        expectElementToExist(cardEl, '.fci-loading-spinner');
 
         buildSubject.next(mockBuild);
         fixture.detectChanges();
 
-        expect(cardEl.queryAll(By.css('.fci-loading-spinner')).length).toBe(0);
+        expectElementNotToExist(cardEl, '.fci-loading-spinner');
       });
 
       describe('after build loaded', () => {
@@ -314,7 +311,7 @@ describe('BuildComponent', () => {
         });
 
         it('should show artifacts', () => {
-          const artifactEls = cardEl.queryAll(By.css('div.fci-artifact'));
+          const artifactEls = getAllElements(cardEl, 'div.fci-artifact');
 
           expect(artifactEls.length).toBe(2);
           expect(artifactEls[0].nativeElement.innerText).toBe('fastlane.log');

--- a/web/app/build/build.component.spec.ts
+++ b/web/app/build/build.component.spec.ts
@@ -1,4 +1,4 @@
-import {DebugElement, getAllDebugNodes} from '@angular/core/src/debug/debug_node';
+import {DebugElement} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatCardModule, MatProgressSpinnerModule} from '@angular/material';
 import {By} from '@angular/platform-browser';

--- a/web/app/common/components/form-spinner/form-spinner.component.spec.ts
+++ b/web/app/common/components/form-spinner/form-spinner.component.spec.ts
@@ -2,6 +2,8 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatProgressSpinnerModule} from '@angular/material';
 import {By} from '@angular/platform-browser';
 
+import {expectElementToExist} from '../../test_helpers/element_helper_functions';
+
 import {FormSpinnerComponent} from './form-spinner.component';
 
 describe('FormSpinnerComponent', () => {
@@ -20,7 +22,6 @@ describe('FormSpinnerComponent', () => {
   });
 
   it('should show spinner and mask', () => {
-    expect(fixture.debugElement.queryAll(By.css('.mat-spinner')).length)
-        .toBe(1);
+    expectElementToExist(fixture.debugElement, '.mat-spinner');
   });
 });

--- a/web/app/common/components/status-icon/status-icon.component.spec.ts
+++ b/web/app/common/components/status-icon/status-icon.component.spec.ts
@@ -6,6 +6,7 @@ import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
 import {BuildStatus} from '../../constants';
+import {getElement, getElementText} from '../../test_helpers/element_helper_functions';
 
 import {StatusIconComponent} from './status-icon.component';
 
@@ -87,16 +88,16 @@ describe('StatusIconComponent', () => {
         component.status = status;
         fixture.detectChanges();
 
-        const icon = iconEl.query(By.css('.mat-icon')).nativeElement;
-        expect(icon.textContent.trim()).toBe(expectedIcon.iconString);
-        expect(icon.classList).toContain(expectedIcon.class);
+        const icon = getElement(iconEl, '.mat-icon');
+        expect(getElementText(icon)).toBe(expectedIcon.iconString);
+        expect(icon.nativeElement.classList).toContain(expectedIcon.class);
       });
 
       it('should have expected tooltip String', () => {
         component.status = status;
         fixture.detectChanges();
 
-        const icon = iconEl.query(By.css('.mat-icon'));
+        const icon = getElement(iconEl, '.mat-icon');
         const tooltipDir: MatTooltip =
             icon.injector.get<MatTooltip>(MatTooltip);
 

--- a/web/app/common/components/status-icon/status-icon.component.spec.ts
+++ b/web/app/common/components/status-icon/status-icon.component.spec.ts
@@ -1,4 +1,4 @@
-import {DebugElement} from '@angular/core/src/debug/debug_node';
+import {DebugElement} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatTooltip, MatTooltipModule} from '@angular/material';
 import {MatIconModule} from '@angular/material/icon';

--- a/web/app/common/components/toolbar/toolbar.component.spec.ts
+++ b/web/app/common/components/toolbar/toolbar.component.spec.ts
@@ -4,14 +4,17 @@ import {MatIconModule} from '@angular/material';
 import {By} from '@angular/platform-browser';
 import {RouterTestingModule} from '@angular/router/testing';
 
+import {getAllElements, getElement} from '../../test_helpers/element_helper_functions';
+
 import {ToolbarComponent} from './toolbar.component';
 
 describe('ToolbarComponent', () => {
   let component: ToolbarComponent;
   let fixture: ComponentFixture<ToolbarComponent>;
+  let fixtureEl: DebugElement;
 
   function getCrumbs(): DebugElement[] {
-    return fixture.debugElement.queryAll(By.css('.fci-crumb'));
+    return getAllElements(fixtureEl, '.fci-crumb');
   }
 
   function getFirstCrumb(): HTMLElement {
@@ -30,12 +33,13 @@ describe('ToolbarComponent', () => {
         .compileComponents();
 
     fixture = TestBed.createComponent(ToolbarComponent);
+    fixtureEl = fixture.debugElement;
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
   it('should show fastlane logo', () => {
-    const logosEl = fixture.debugElement.queryAll(By.css('.fci-fastlane-logo'));
+    const logosEl = getAllElements(fixtureEl, '.fci-fastlane-logo');
     expect(logosEl.length).toBe(1);
   });
 
@@ -73,7 +77,7 @@ describe('ToolbarComponent', () => {
     fixture.detectChanges();
 
     const crumbContainerEl =
-        fixture.debugElement.query(By.css('.fci-crumbtainer')).nativeElement;
+        getElement(fixtureEl, '.fci-crumbtainer').nativeElement;
     expect(crumbContainerEl.innerText)
         .toContain('parent\nchevron_right\nchild');
   });

--- a/web/app/common/test_helpers/element_helper_functions.ts
+++ b/web/app/common/test_helpers/element_helper_functions.ts
@@ -1,0 +1,48 @@
+import {DebugElement} from '@angular/core';
+import {By} from '@angular/platform-browser';
+
+function doesElementExist(context: DebugElement, selector: string): boolean {
+  return context.queryAll(By.css(selector)).length > 0;
+}
+
+export function getAllElements(
+    context: DebugElement, selector: string): DebugElement[] {
+  const els = context.queryAll(By.css(selector));
+  expect(els.length)
+      .toBeGreaterThan(0, `No Elements were found\nSelector: '${selector}'`);
+
+  return els;
+}
+
+export function getElement(
+    context: DebugElement, selector: string, index: number = 0): DebugElement {
+  const el = getAllElements(context, selector)[index];
+  expect(el).toBeDefined(`Element is undefined\nSelector: '${selector}'`);
+
+  return el;
+}
+
+export function getElementText(
+    context: DebugElement, selector?: string, index: number = 0): string {
+  const el =
+      (selector ? getElement(context, selector, index) : context).nativeElement;
+
+  return (el.innerText || el.textContent || '').trim();
+}
+
+export function expectElementToExist(context: DebugElement, selector: string) {
+  return expect(doesElementExist(context, selector))
+      .toBe(
+          true,
+          `An element was expected to exist, but was not found\nSelector: '${
+              selector}'`);
+}
+
+export function expectElementNotToExist(
+    context: DebugElement, selector: string) {
+  return expect(doesElementExist(context, selector))
+      .toBe(
+          false,
+          `An element was expected NOT to exist, but was found\nSelector: '${
+              selector}'`);
+}

--- a/web/app/dashboard/add-project-dialog/add-project-dialog.component.spec.ts
+++ b/web/app/dashboard/add-project-dialog/add-project-dialog.component.spec.ts
@@ -1,4 +1,5 @@
 import {CommonModule} from '@angular/common';
+import {DebugElement} from '@angular/core/src/debug/debug_node';
 import {async, ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule, MatDialogModule, MatDialogRef, MatIconModule, MatProgressSpinnerModule, MatSelectModule} from '@angular/material';
@@ -8,6 +9,8 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs/Subject';
 
 import {FormSpinnerModule} from '../../common/components/form-spinner/form-spinner.module';
+// tslint:disable-next-line:max-line-length
+import {expectElementNotToExist, expectElementToExist, getElement, getElementText} from '../../common/test_helpers/element_helper_functions';
 import {mockLanes, mockLanesResponse} from '../../common/test_helpers/mock_lane_data';
 import {mockProjectSummary} from '../../common/test_helpers/mock_project_data';
 import {mockRepositoryList} from '../../common/test_helpers/mock_repository_data';
@@ -21,6 +24,7 @@ import {AddProjectDialogComponent} from './add-project-dialog.component';
 describe('AddProjectDialogComponent', () => {
   let component: AddProjectDialogComponent;
   let fixture: ComponentFixture<AddProjectDialogComponent>;
+  let fixtureEl: DebugElement;
   let reposSubject: Subject<Repository[]>;
   let projectSubject: Subject<ProjectSummary>;
   let lanesSubject: Subject<Lane[]>;
@@ -64,28 +68,26 @@ describe('AddProjectDialogComponent', () => {
         .compileComponents();
 
     fixture = TestBed.createComponent(AddProjectDialogComponent);
+    fixtureEl = fixture.debugElement;
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    projectNameEl =
-        fixture.debugElement.query(By.css('input[placeholder="Project Name"]'))
-            .nativeElement;
-    repoSelectEl =
-        fixture.debugElement.query(By.css('.fci-repo-select')).nativeElement;
-    laneSelectEl =
-        fixture.debugElement.query(By.css('.fci-lane-select')).nativeElement;
+    projectNameEl = getElement(fixtureEl, 'input[placeholder="Project Name"]')
+                        .nativeElement;
+    repoSelectEl = getElement(fixtureEl, '.fci-repo-select').nativeElement;
+    laneSelectEl = getElement(fixtureEl, '.fci-lane-select').nativeElement;
     triggerSelectEl =
-        fixture.debugElement.query(By.css('.fci-trigger-select')).nativeElement;
+        getElement(fixtureEl, '.fci-trigger-select').nativeElement;
   }));
 
   it('Should close dialog when close button is clicked', () => {
-    fixture.debugElement.query(By.css('.mat-dialog-actions > .mat-button'))
+    getElement(fixtureEl, '.mat-dialog-actions > .mat-button')
         .nativeElement.click();
     expect(dialogRef.close).toHaveBeenCalled();
   });
 
   it('Should close dialog when X button is clicked', () => {
-    fixture.debugElement.query(By.css('.fci-dialog-icon-close-button'))
+    getElement(fixtureEl, '.fci-dialog-icon-close-button')
         .nativeElement.click();
     expect(dialogRef.close).toHaveBeenCalled();
   });
@@ -187,19 +189,13 @@ describe('AddProjectDialogComponent', () => {
 
     it('should show spinner when lanes are loading', () => {
       expect(component.isLoadingLanes).toBe(true);
-      let laneSpinnerEl =
-          fixture.debugElement.queryAll(By.css('.fci-lane-form .mat-spinner'));
-
-      expect(laneSpinnerEl.length).toBe(1);
+      expectElementToExist(fixtureEl, '.fci-lane-form .mat-spinner');
 
       lanesSubject.next(mockLanes);
       fixture.detectChanges();
 
-      laneSpinnerEl =
-          fixture.debugElement.queryAll(By.css('.fci-lane-form .mat-spinner'));
-
       expect(component.isLoadingLanes).toBe(false);
-      expect(laneSpinnerEl.length).toBe(0);
+      expectElementNotToExist(fixtureEl, '.fci-lane-form .mat-spinner');
     });
   });
 
@@ -228,44 +224,36 @@ describe('AddProjectDialogComponent', () => {
       component.form.patchValue({'trigger': 'nightly'});
       fixture.detectChanges();
 
-      expect(fixture.debugElement.queryAll(By.css('.fci-hour-select')).length)
-          .toBe(1);
-      expect(fixture.debugElement.queryAll(By.css('.fci-am-pm-select')).length)
-          .toBe(1);
+      expectElementToExist(fixtureEl, '.fci-hour-select');
+      expectElementToExist(fixtureEl, '.fci-am-pm-select');
     });
 
     it('should not show time selection when trigger is not nightly', () => {
       component.form.patchValue({'trigger': 'commit'});
       fixture.detectChanges();
 
-      expect(fixture.debugElement.queryAll(By.css('.fci-hour-select')).length)
-          .toBe(0);
-      expect(fixture.debugElement.queryAll(By.css('.fci-am-pm-select')).length)
-          .toBe(0);
+      expectElementNotToExist(fixtureEl, '.fci-hour-select');
+      expectElementNotToExist(fixtureEl, '.fci-am-pm-select');
     });
 
     it('should set nightly time correctly', async(() => {
          component.form.patchValue({'trigger': 'nightly'});
          fixture.detectChanges();
 
-         const hourEl: HTMLElement =
-             fixture.debugElement.query(By.css('.fci-hour-select'))
-                 .nativeElement;
-         const amPmEl: HTMLElement =
-             fixture.debugElement.query(By.css('.fci-am-pm-select'))
-                 .nativeElement;
+         const hourEl = getElement(fixtureEl, '.fci-hour-select');
+         const amPmEl = getElement(fixtureEl, '.fci-am-pm-select');
 
          // I think this is needed to load the hour/amPm select in ngIf block
          fixture.whenStable().then(() => {
            fixture.detectChanges();
-           expect(hourEl.textContent).toBe('12');
-           expect(amPmEl.textContent).toBe('AM');
+           expect(getElementText(hourEl)).toBe('12');
+           expect(getElementText(amPmEl)).toBe('AM');
 
            component.form.patchValue({'hour': 2, 'amPm': 'PM'});
            fixture.detectChanges();
 
-           expect(hourEl.textContent).toBe('2');
-           expect(amPmEl.textContent).toBe('PM');
+           expect(getElementText(hourEl)).toBe('2');
+           expect(getElementText(amPmEl)).toBe('PM');
          });
        }));
   });
@@ -346,21 +334,17 @@ describe('AddProjectDialogComponent', () => {
        });
 
     it('should show spinner while adding project', () => {
-      const spinnerEl = fixture.debugElement.query(By.css('.mat-spinner'));
-      expect(fixture.debugElement.queryAll(By.css('.mat-spinner')).length)
-          .toBe(0);
+      expectElementNotToExist(fixtureEl, '.mat-spinner');
 
       component.addProject();
       fixture.detectChanges();
 
-      expect(fixture.debugElement.queryAll(By.css('.mat-spinner')).length)
-          .toBe(1);
+      expectElementToExist(fixtureEl, '.mat-spinner');
 
       projectSubject.next(mockProjectSummary);
       fixture.detectChanges();
 
-      expect(fixture.debugElement.queryAll(By.css('.mat-spinner')).length)
-          .toBe(0);
+      expectElementNotToExist(fixtureEl, '.mat-spinner');
     });
 
     it('should close dialog on success', async(() => {

--- a/web/app/dashboard/add-project-dialog/add-project-dialog.component.spec.ts
+++ b/web/app/dashboard/add-project-dialog/add-project-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 import {CommonModule} from '@angular/common';
-import {DebugElement} from '@angular/core/src/debug/debug_node';
+import {DebugElement} from '@angular/core';
 import {async, ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule, MatDialogModule, MatDialogRef, MatIconModule, MatProgressSpinnerModule, MatSelectModule} from '@angular/material';

--- a/web/app/dashboard/dashboard.component.spec.ts
+++ b/web/app/dashboard/dashboard.component.spec.ts
@@ -1,6 +1,6 @@
 import 'rxjs/add/observable/of';
 
-import {DebugElement} from '@angular/core/src/debug/debug_node';
+import {DebugElement} from '@angular/core';
 import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {MatDialog, MatDialogModule} from '@angular/material';
 import {By} from '@angular/platform-browser';

--- a/web/app/dashboard/dashboard.component.spec.ts
+++ b/web/app/dashboard/dashboard.component.spec.ts
@@ -1,5 +1,6 @@
 import 'rxjs/add/observable/of';
 
+import {DebugElement} from '@angular/core/src/debug/debug_node';
 import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {MatDialog, MatDialogModule} from '@angular/material';
 import {By} from '@angular/platform-browser';
@@ -11,6 +12,7 @@ import {Subject} from 'rxjs/Subject';
 
 import {StatusIconModule} from '../common/components/status-icon/status-icon.module';
 import {BuildStatus} from '../common/constants';
+import {getAllElements, getElement, getElementText} from '../common/test_helpers/element_helper_functions';
 import {mockProjectSummary, mockProjectSummaryList} from '../common/test_helpers/mock_project_data';
 import {ProjectSummary} from '../models/project_summary';
 import {SharedMaterialModule} from '../root/shared_material.module';
@@ -21,6 +23,7 @@ import {DashboardComponent} from './dashboard.component';
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let fixture: ComponentFixture<DashboardComponent>;
+  let fixtureEl: DebugElement;
   let dataService: jasmine.SpyObj<Partial<DataService>>;
   let dialog: jasmine.SpyObj<Partial<MatDialog>>;
   let projectListSubject: Subject<ProjectSummary[]>;
@@ -62,6 +65,7 @@ describe('DashboardComponent', () => {
         .compileComponents();
 
     fixture = TestBed.createComponent(DashboardComponent);
+    fixtureEl = fixture.debugElement;
     component = fixture.componentInstance;
   });
 
@@ -89,21 +93,20 @@ describe('DashboardComponent', () => {
     });
 
     it('should add new project to project table', () => {
-      let tableRowsEl = fixture.debugElement.queryAll(By.css('.mat-row'));
+      let tableRowsEl = getAllElements(fixtureEl, '.mat-row');
       expect(tableRowsEl.length).toBe(4);
 
       component.openAddProjectDialog();
       projectAddedSubject.next(mockProjectSummary);
       fixture.detectChanges();
 
-      tableRowsEl = fixture.debugElement.queryAll(By.css('.mat-row'));
+      tableRowsEl = getAllElements(fixtureEl, '.mat-row');
       expect(tableRowsEl.length).toBe(5);
-      expect(tableRowsEl[4].nativeElement.innerText)
-          .toContain('the coolest project');
+      expect(getElementText(tableRowsEl[4])).toContain('the coolest project');
     });
 
     it('should open add project dialog when new project is clicked', () => {
-      fixture.debugElement.query(By.css('.fci-dashboard-welcome button'))
+      getElement(fixtureEl, '.fci-dashboard-welcome button')
           .nativeElement.click();
       expect(dialog.open).toHaveBeenCalled();
     });

--- a/web/app/login/login.component.spec.ts
+++ b/web/app/login/login.component.spec.ts
@@ -6,6 +6,7 @@ import {By} from '@angular/platform-browser';
 import {Router} from '@angular/router';
 import {Subject} from 'rxjs/Subject';
 
+import {expectElementNotToExist, expectElementToExist, getElement, getElementText} from '../common/test_helpers/element_helper_functions';
 import {mockLoginResponse} from '../common/test_helpers/mock_login_data';
 import {AuthService, LoginResponse} from '../services/auth.service';
 
@@ -13,12 +14,12 @@ import {LoginComponent} from './login.component';
 
 describe('LoginComponent', () => {
   let fixture: ComponentFixture<LoginComponent>;
+  let fixtureEl: DebugElement;
   let authService: jasmine.SpyObj<Partial<AuthService>>;
   let router: jasmine.SpyObj<Partial<Router>>;
   let loginButtonEl: DebugElement;
   let emailEl: DebugElement;
   let passwordEl: DebugElement;
-  let errorEl: DebugElement;
   let loginSubject: Subject<LoginResponse>;
 
   beforeEach(async(() => {
@@ -44,9 +45,10 @@ describe('LoginComponent', () => {
         .compileComponents();
 
     fixture = TestBed.createComponent(LoginComponent);
-    loginButtonEl = fixture.debugElement.query(By.css('button'));
-    emailEl = fixture.debugElement.query(By.css('input[type=email]'));
-    passwordEl = fixture.debugElement.query(By.css('input[type=password]'));
+    fixtureEl = fixture.debugElement;
+    loginButtonEl = getElement(fixtureEl, 'button');
+    emailEl = getElement(fixtureEl, 'input[type=email]');
+    passwordEl = getElement(fixtureEl, 'input[type=password]');
   }));
 
   describe('OnInit', () => {
@@ -124,23 +126,18 @@ describe('LoginComponent', () => {
     });
 
     it('should show an error message after a failed login attempt', () => {
-      function getFormErrorEl() {
-        return fixture.debugElement.query(By.css('.form-error'));
-      }
-
-      expect(getFormErrorEl()).toBeNull();
+      expectElementNotToExist(fixtureEl, '.form-error');
 
       loginButtonEl.triggerEventHandler('click', null);
       fixture.detectChanges();
 
-      expect(getFormErrorEl()).toBeNull();
+      expectElementNotToExist(fixtureEl, '.form-error');
 
       loginSubject.error(null);
       fixture.detectChanges();
 
-      errorEl = getFormErrorEl();
-      expect(errorEl).not.toBeNull();
-      expect(errorEl.nativeElement.textContent.trim())
+      expectElementToExist(fixtureEl, '.form-error');
+      expect(getElementText(fixtureEl, '.form-error'))
           .toBe('Could not log you in. Please try again.');
     });
   });

--- a/web/app/onboard/onboard.component.spec.ts
+++ b/web/app/onboard/onboard.component.spec.ts
@@ -1,4 +1,5 @@
 import {DOCUMENT} from '@angular/common';
+import {DebugElement} from '@angular/core/src/debug/debug_node';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule, MatIconModule, MatProgressSpinnerModule, MatStepperModule} from '@angular/material';
@@ -6,6 +7,7 @@ import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs/Subject';
 
+import {expectElementNotToExist, expectElementToExist, getElement, getElementText} from '../common/test_helpers/element_helper_functions';
 import {UserDetails} from '../common/types';
 import {DataService} from '../services/data.service';
 
@@ -17,6 +19,7 @@ const THIRY_NINE_CHAR_STRING: string = new Array(39 + 1).join('a');
 
 describe('OnboardComponent', () => {
   let fixture: ComponentFixture<OnboardComponent>;
+  let fixtureEl: DebugElement;
   let component: OnboardComponent;
   let dataService: jasmine.SpyObj<Partial<DataService>>;
   let userDetailsSubject: Subject<UserDetails>;
@@ -44,6 +47,7 @@ describe('OnboardComponent', () => {
         .compileComponents();
 
     fixture = TestBed.createComponent(OnboardComponent);
+    fixtureEl = fixture.debugElement;
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -94,16 +98,14 @@ describe('OnboardComponent', () => {
       component.botEmail = 'fake@email.com';
       fixture.detectChanges();
 
-      tokenInputEl = fixture.debugElement
-                         .query(By.css('input[formcontrolname="botToken"]'))
+      tokenInputEl = getElement(fixtureEl, 'input[formcontrolname="botToken"]')
                          .nativeElement;
     });
 
     for (const control_id of FORM_CONTROL_IDS) {
       it(`should have the ${control_id} control properly attached`, () => {
         const controlEl: HTMLInputElement =
-            fixture.debugElement
-                .query(By.css(`input[formcontrolname="${control_id}"]`))
+            getElement(fixtureEl, `input[formcontrolname="${control_id}"]`)
                 .nativeElement;
 
         controlEl.value = '10';
@@ -121,51 +123,34 @@ describe('OnboardComponent', () => {
 
     it('should show success check mark if bot email exists', () => {
       expect(component.botEmail).toBeDefined();
-      expect(fixture.debugElement
-                 .queryAll(By.css('.fci-input-status .fci-success-icon'))
-                 .length)
-          .toBe(1);
+      expectElementToExist(fixtureEl, '.fci-input-status .fci-success-icon');
     });
 
     it('should hide bot email and password if token changes', () => {
-      expect(fixture.debugElement
-                 .queryAll(By.css('input[formcontrolname="botPassword"]'))
-                 .length)
-          .toBe(1);
-      expect(fixture.debugElement.query(By.css('.fci-username'))
-                 .nativeElement.textContent)
-          .toBe('fake@email.com');
+      expectElementToExist(fixtureEl, 'input[formcontrolname="botPassword"]');
+      expect(getElementText(fixtureEl, '.fci-username')).toBe('fake@email.com');
 
       tokenInputEl.value = FORTY_CHAR_STRING;
       tokenInputEl.dispatchEvent(new Event('input'));
       fixture.detectChanges();
 
-      expect(fixture.debugElement
-                 .queryAll(By.css('input[formcontrolname="botPassword"]'))
-                 .length)
-          .toBe(0);
-      expect(fixture.debugElement.queryAll(By.css('.fci-username')).length)
-          .toBe(0);
+      expectElementNotToExist(
+          fixtureEl, 'input[formcontrolname="botPassword"]');
+      expectElementNotToExist(fixtureEl, '.fci-username');
     });
 
     it('should show spinner when looking for bot email', () => {
-      expect(fixture.debugElement
-                 .queryAll(By.css('.fci-input-status .mat-spinner'))
-                 .length)
-          .toBe(0);
+      expectElementNotToExist(fixtureEl, '.fci-input-status .mat-spinner');
       tokenInputEl.value = FORTY_CHAR_STRING;
       tokenInputEl.dispatchEvent(new Event('input'));
       fixture.detectChanges();
 
-      expect(fixture.debugElement
-                 .queryAll(By.css('.fci-input-status .mat-spinner'))
-                 .length)
-          .toBe(1);
+      expectElementToExist(fixtureEl, '.fci-input-status .mat-spinner');
     });
 
     it('should redirect to old onboarding when button is clicked', () => {
       spyOn(component, 'goToOldOnboarding');
-      fixture.debugElement.query(By.css('.fci-onboard-welcome button'))
+      getElement(fixtureEl, '.fci-onboard-welcome button')
           .nativeElement.click();
 
       expect(component.goToOldOnboarding).toHaveBeenCalled();

--- a/web/app/onboard/onboard.component.spec.ts
+++ b/web/app/onboard/onboard.component.spec.ts
@@ -1,5 +1,5 @@
 import {DOCUMENT} from '@angular/common';
-import {DebugElement} from '@angular/core/src/debug/debug_node';
+import {DebugElement} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule, MatIconModule, MatProgressSpinnerModule, MatStepperModule} from '@angular/material';

--- a/web/app/project/project.component.spec.ts
+++ b/web/app/project/project.component.spec.ts
@@ -14,6 +14,8 @@ import {Subject} from 'rxjs/Subject';
 import {StatusIconModule} from '../common/components/status-icon/status-icon.module';
 import {ToolbarModule} from '../common/components/toolbar/toolbar.module';
 import {DummyComponent} from '../common/test_helpers/dummy.component';
+// tslint:disable-next-line:max-line-length
+import {expectElementNotToExist, expectElementToExist, getAllElements, getElement, getElementText} from '../common/test_helpers/element_helper_functions';
 import {mockBuildSummary_success} from '../common/test_helpers/mock_build_data';
 import {getMockProject} from '../common/test_helpers/mock_project_data';
 import {BuildSummary} from '../models/build_summary';
@@ -26,6 +28,7 @@ import {ProjectComponent} from './project.component';
 describe('ProjectComponent', () => {
   let component: ProjectComponent;
   let fixture: ComponentFixture<ProjectComponent>;
+  let fixtureEl: DebugElement;
   let dataService: jasmine.SpyObj<Partial<DataService>>;
   let projectSubject: Subject<Project>;
   let rebuildSummarySubject: Subject<BuildSummary>;
@@ -64,6 +67,7 @@ describe('ProjectComponent', () => {
         .compileComponents();
 
     fixture = TestBed.createComponent(ProjectComponent);
+    fixtureEl = fixture.debugElement;
     component = fixture.componentInstance;
   }));
 
@@ -123,24 +127,17 @@ describe('ProjectComponent', () => {
       });
 
       it('should not show project title', () => {
-        expect(
-            fixture.debugElement.queryAll(By.css('.fci-project-header')).length)
-            .toBe(0);
+        expectElementNotToExist(fixtureEl, '.fci-project-header');
       });
 
       it('table should not show loading spinner', () => {
-        expect(fixture.debugElement
-                   .queryAll(By.css('.fci-build-table .fci-loading-spinner'))
-                   .length)
-            .toBe(1);
+        expectElementToExist(
+            fixtureEl, '.fci-build-table .fci-loading-spinner');
       });
 
       it('details card should not show loading spinner', () => {
-        expect(
-            fixture.debugElement
-                .queryAll(By.css('.fci-project-details .fci-loading-spinner'))
-                .length)
-            .toBe(1);
+        expectElementToExist(
+            fixtureEl, '.fci-project-details .fci-loading-spinner');
       });
     });
 
@@ -156,74 +153,57 @@ describe('ProjectComponent', () => {
 
       it('should have toolbar with breadcrumbs', () => {
         // toolbar exists
-        expect(fixture.debugElement.queryAll(By.css('.fci-crumb')).length)
-            .toBe(2);
+        expect(getAllElements(fixtureEl, '.fci-crumb').length).toBe(2);
 
         expect(component.breadcrumbs[0].label).toBe('Dashboard');
         expect(component.breadcrumbs[0].url).toBe('/');
       });
 
       it('should have project title', () => {
-        expect(fixture.debugElement.query(By.css('.fci-project-header'))
-                   .nativeElement.innerText)
+        expect(getElementText(fixtureEl, '.fci-project-header'))
             .toBe('the most coolest project');
       });
 
       describe('table', () => {
         let rowEls: DebugElement[];
         beforeEach(() => {
-          rowEls = fixture.debugElement.queryAll(By.css('.mat-row'));
+          rowEls = getAllElements(fixtureEl, '.mat-row');
           expect(rowEls.length).toBe(2);
         });
 
         it('should not show loading spinner', () => {
-          expect(fixture.debugElement
-                     .queryAll(By.css('.fci-build-table .fci-loading-spinner'))
-                     .length)
-              .toBe(0);
+          expectElementNotToExist(
+              fixtureEl, '.fci-build-table .fci-loading-spinner');
         });
 
         it('should have status icon', () => {
-          expect(rowEls[0]
-                     .query(By.css('.mat-column-number .fci-status-icon'))
-                     .nativeElement.innerText)
+          expect(
+              getElementText(rowEls[0], '.mat-column-number .fci-status-icon'))
               .toBe('check_circle');
-          expect(rowEls[1]
-                     .query(By.css('.mat-column-number .fci-status-icon'))
-                     .nativeElement.innerText)
+          expect(
+              getElementText(rowEls[1], '.mat-column-number .fci-status-icon'))
               .toBe('cancel');
         });
 
         it('should have build number', () => {
-          expect(rowEls[0]
-                     .query(By.css('.mat-column-number span'))
-                     .nativeElement.innerText)
+          expect(getElementText(rowEls[0], '.mat-column-number span'))
               .toBe('2');
-          expect(rowEls[1]
-                     .query(By.css('.mat-column-number span'))
-                     .nativeElement.innerText)
+          expect(getElementText(rowEls[1], '.mat-column-number span'))
               .toBe('1');
         });
 
         it('should have duration', () => {
-          expect(rowEls[0]
-                     .query(By.css('.mat-column-duration'))
-                     .nativeElement.innerText)
+          expect(getElementText(rowEls[0], '.mat-column-duration'))
               .toBe('3 days');
         });
 
         it('should have branch', () => {
-          expect(rowEls[0]
-                     .query(By.css('.mat-column-branch'))
-                     .nativeElement.innerText)
+          expect(getElementText(rowEls[0], '.mat-column-branch'))
               .toBe('master');
         });
 
         it('should have sha link', () => {
-          expect(rowEls[0]
-                     .query(By.css('.mat-column-sha a'))
-                     .nativeElement.innerText)
-              .toBe('asdfsh');
+          expect(getElementText(rowEls[0], '.mat-column-sha a')).toBe('asdfsh');
         });
 
         it('should go to build when clicked', fakeAsync(() => {
@@ -235,23 +215,19 @@ describe('ProjectComponent', () => {
 
         it('should not show rebuild button on successful builds', () => {
           // First row is successful build
-          expect(rowEls[0]
-                     .queryAll(By.css('.mat-column-sha .fci-button-visible'))
-                     .length)
-              .toBe(0);
+          expectElementNotToExist(
+              rowEls[0], '.mat-column-sha .fci-button-visible');
         });
 
         it('should show rebuild button on failed builds', () => {
           // Second row is failed build
-          expect(rowEls[1]
-                     .queryAll(By.css('.mat-column-sha .fci-button-visible'))
-                     .length)
-              .toBe(1);
+          expectElementToExist(
+              rowEls[1], '.mat-column-sha .fci-button-visible');
         });
 
         it('should rebuild when rebuild button is clicked', () => {
           const buttonEl =
-              rowEls[1].query(By.css('.mat-column-sha .fci-button-visible'));
+              getElement(rowEls[1], '.mat-column-sha .fci-button-visible');
 
           buttonEl.nativeElement.click();
           expect(dataService.rebuild).toHaveBeenCalledWith('12', 1);
@@ -259,14 +235,13 @@ describe('ProjectComponent', () => {
 
         it('should add new row after rebuild is complete', () => {
           const buttonEl =
-              rowEls[1].query(By.css('.mat-column-sha .fci-button-visible'));
+              getElement(rowEls[1], '.mat-column-sha .fci-button-visible');
 
           buttonEl.nativeElement.click();
           rebuildSummarySubject.next(mockBuildSummary_success);
           fixture.detectChanges();
 
-          expect(fixture.debugElement.queryAll(By.css('.mat-row')).length)
-              .toBe(3);
+          expect(getAllElements(fixtureEl, '.mat-row').length).toBe(3);
         });
       });
 
@@ -276,37 +251,33 @@ describe('ProjectComponent', () => {
         let contentsEls: DebugElement[];
 
         beforeEach(() => {
-          cardEl = fixture.debugElement.query(By.css('.fci-project-details'));
-          headerEls = cardEl.queryAll(By.css('h5'));
-          contentsEls = cardEl.queryAll(By.css('div'));
+          cardEl = getElement(fixtureEl, '.fci-project-details');
+          headerEls = getAllElements(cardEl, 'h5');
+          contentsEls = getAllElements(cardEl, 'div');
         });
 
         it('should not show loading spinner', () => {
-          expect(cardEl.queryAll(By.css('.fci-loading-spinner')).length)
-              .toBe(0);
+          expectElementNotToExist(cardEl, '.fci-loading-spinner');
         });
 
         it('should show Repo name', () => {
-          expect(headerEls[0].nativeElement.innerText).toBe('REPO');
-          expect(contentsEls[0].nativeElement.innerText)
-              .toBe('fastlane/TacoRocat');
+          expect(getElementText(headerEls[0])).toBe('REPO');
+          expect(getElementText(contentsEls[0])).toBe('fastlane/TacoRocat');
         });
 
         it('should show lane', () => {
-          expect(headerEls[1].nativeElement.innerText).toBe('LANE');
-          expect(contentsEls[1].nativeElement.innerText).toBe('ios test');
+          expect(getElementText(headerEls[1])).toBe('LANE');
+          expect(getElementText(contentsEls[1])).toBe('ios test');
         });
 
         it('should show last successful build number', () => {
-          expect(headerEls[2].nativeElement.innerText)
-              .toBe('LAST SUCCESSFUL BUILD');
-          expect(contentsEls[2].nativeElement.innerText).toBe('2');
+          expect(getElementText(headerEls[2])).toBe('LAST SUCCESSFUL BUILD');
+          expect(getElementText(contentsEls[2])).toBe('2');
         });
 
         it('should show last failed build number', () => {
-          expect(headerEls[3].nativeElement.innerText)
-              .toBe('LAST FAILED BUILD');
-          expect(contentsEls[3].nativeElement.innerText).toBe('1');
+          expect(getElementText(headerEls[3])).toBe('LAST FAILED BUILD');
+          expect(getElementText(contentsEls[3])).toBe('1');
         });
       });
     });

--- a/web/app/signup/signup.component.spec.ts
+++ b/web/app/signup/signup.component.spec.ts
@@ -6,6 +6,7 @@ import {By} from '@angular/platform-browser';
 import {Router} from '@angular/router';
 import {Subject} from 'rxjs/Subject';
 
+import {getElement, getElementText} from '../common/test_helpers/element_helper_functions';
 import {UserDetails} from '../common/types';
 import {AuthService} from '../services/auth.service';
 import {DataService} from '../services/data.service';
@@ -72,15 +73,15 @@ describe('SignupComponent', () => {
     beforeEach(() => {
       fixture.detectChanges();
       tokenEl =
-          fixture.debugElement.query(By.css('input[formcontrolname="token"]'))
+          getElement(fixture.debugElement, 'input[formcontrolname="token"]')
               .nativeElement;
     });
 
     for (const control_id of FORM_CONTROL_IDS) {
       it(`should have all the ${control_id} control properly attached`, () => {
         const controlEl: HTMLInputElement =
-            fixture.debugElement
-                .query(By.css(`input[formcontrolname="${control_id}"]`))
+            getElement(
+                fixture.debugElement, `input[formcontrolname="${control_id}"]`)
                 .nativeElement;
 
         controlEl.value = '10';
@@ -109,8 +110,7 @@ describe('SignupComponent', () => {
       userDetailsSubject.error({error: {message: 'ya done messed up'}});
       fixture.detectChanges();
 
-      expect(fixture.debugElement.query(By.css('.form-error'))
-                 .nativeElement.textContent)
+      expect(getElementText(fixture.debugElement, '.form-error'))
           .toBe('ya done messed up');
     });
   });


### PR DESCRIPTION
I think this should help readability in the tests by quite a bit

```
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```