### PR TITLE
Remove test helpers folder from prod build

### DIFF
--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -8,6 +8,7 @@
   },
   "exclude": [
     "test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "app/common/test_helpers/*"
   ]
 }


### PR DESCRIPTION
Test helpers shouldn't be bloating the codespace

```
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```