### PR TITLE
Fix not building the right sha

### DIFF
--- a/app/features-json/build_json_controller.rb
+++ b/app/features-json/build_json_controller.rb
@@ -59,11 +59,8 @@ module FastlaneCI
         return
       end
 
-      branch_to_trigger = "master" # TODO: how/where do we get the default branch
-
       git_fork_config = GitForkConfig.new(
         sha: current_sha,
-        branch: branch_to_trigger,
         clone_url: project.repo_config.git_url
         # we don't need to pass a `ref`, as the sha and branch is all we need
       )


### PR DESCRIPTION
Seems like this was debug code, instead we want to trigger the specific sha we got as a parameter of the request.

From what I understand, we don't need to pass the branch anyway, as we have a sha, which basically is more precisely than a branch anyway

Taken from https://github.com/fastlane/ci/pull/1081