### PR TITLE
Stub `dot_keys` globally for all test suites.

### DIFF
--- a/spec/services/data_sources/json_user_data_source_spec.rb
+++ b/spec/services/data_sources/json_user_data_source_spec.rb
@@ -7,7 +7,6 @@ describe FastlaneCI::JSONUserDataSource do
     stub_file_io
     stub_git_repos
     stub_services
-    stub_environment_variables
   end
 
   let(:file_path) do

--- a/spec/services/dot_keys_variable_service_spec.rb
+++ b/spec/services/dot_keys_variable_service_spec.rb
@@ -11,7 +11,6 @@ describe FastlaneCI::DotKeysVariableService do
   end
 
   before(:each) do
-    stub_environment_variables
     allow(Dir).to receive(:home).and_return(fake_home_path)
   end
 
@@ -42,7 +41,7 @@ describe FastlaneCI::DotKeysVariableService do
 
   describe "#all_dot_variables_non_nil?" do
     it "returns `true` if all environment variables are non-`nil`, and non-'empty'" do
-      # Environment variables are set in the `stub_environment_variables` method
+      # Environment variables are set in the `stub_dot_keys` method called in the `spec_helper.rb` file
       expect(subject.all_dot_variables_non_nil?).to be(true)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,10 @@ RSpec.configure do |config|
   config.formatter = :documentation
   config.tty = true
   config.color = true
+
+  config.before(:each) do
+    stub_dot_keys
+  end
 end
 
 # Do not allow reading on STDIN on tests. This will block the test run.

--- a/spec/stub_helpers.rb
+++ b/spec/stub_helpers.rb
@@ -7,7 +7,7 @@ module StubHelpers
     allow(File).to receive(:write)
   end
 
-  def stub_environment_variables
+  def stub_dot_keys
     allow_any_instance_of(FastlaneCI::DotKeysVariables).to receive(:all).and_return(environment_variables)
     allow_any_instance_of(FastlaneCI::DotKeysVariables).to receive(:encryption_key).and_return("encryption_key")
     allow_any_instance_of(FastlaneCI::DotKeysVariables).to receive(:ci_user_password).and_return("ci_user_password")


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving

Fixes #1079. 