### PR TITLE
add Procfile for foreman

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec rake prod
+worker: bundle exec ruby agent/service.rb


### PR DESCRIPTION
Now that fastlane.ci requires multiple processes to run, we can take advantage of tools like https://github.com/ddollar/foreman to start or manage the services for us.

Not putting `foreman` in the Gemfile because @ddollar says so.
