### PR TITLE
Basic 404 handling

### DIFF
--- a/web/app/build/build.component.spec.ts
+++ b/web/app/build/build.component.spec.ts
@@ -1,5 +1,6 @@
-import {DebugElement} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {DebugElement, Component} from '@angular/core';
+import {Location} from '@angular/common';
+import {async, ComponentFixture, TestBed, tick, fakeAsync} from '@angular/core/testing';
 import {MatCardModule, MatProgressSpinnerModule} from '@angular/material';
 import {By} from '@angular/platform-browser';
 import {ActivatedRoute, convertToParamMap} from '@angular/router';
@@ -19,7 +20,13 @@ import {DataService} from '../services/data.service';
 
 import {BuildComponent} from './build.component';
 
+@Component({
+  template: ''
+})
+export class MockComponent { }
+
 describe('BuildComponent', () => {
+  let location: Location;
   let component: BuildComponent;
   let fixture: ComponentFixture<BuildComponent>;
   let fixtureEl: DebugElement;
@@ -47,10 +54,12 @@ describe('BuildComponent', () => {
 
     TestBed
         .configureTestingModule({
-          declarations: [BuildComponent],
+          declarations: [BuildComponent, MockComponent],
           imports: [
-            ToolbarModule, RouterTestingModule, StatusIconModule, MatCardModule,
-            MatProgressSpinnerModule, MomentModule
+            ToolbarModule, StatusIconModule, RouterTestingModule.withRoutes(
+              [{path: '404', component: MockComponent} ]
+            ),
+            MatCardModule, MatProgressSpinnerModule, MomentModule
           ],
           providers: [
             {
@@ -71,6 +80,8 @@ describe('BuildComponent', () => {
     fixture = TestBed.createComponent(BuildComponent);
     fixtureEl = fixture.debugElement;
     component = fixture.componentInstance;
+
+    location = TestBed.get(Location);
   });
 
   describe('unit tests', () => {
@@ -87,6 +98,16 @@ describe('BuildComponent', () => {
 
       expect(component.build).toBe(mockBuild);
     });
+
+    it('should redirect if build returns 404', fakeAsync(() => {
+      fixture.detectChanges();
+      expect(dataService.getBuild).toHaveBeenCalledWith('123', 3);
+
+      buildSubject.error({});
+      tick();
+
+      expect(location.path()).toBe('/404');
+    }));
 
     it('should update logs as they come in', () => {
       fixture.detectChanges();

--- a/web/app/build/build.component.spec.ts
+++ b/web/app/build/build.component.spec.ts
@@ -19,11 +19,7 @@ import {BuildLogMessageEvent, BuildLogWebsocketService} from '../services/build-
 import {DataService} from '../services/data.service';
 
 import {BuildComponent} from './build.component';
-
-@Component({
-  template: ''
-})
-export class MockComponent { }
+import {DummyComponent} from '../common/test_helpers/dummy.component';
 
 describe('BuildComponent', () => {
   let location: Location;
@@ -54,10 +50,10 @@ describe('BuildComponent', () => {
 
     TestBed
         .configureTestingModule({
-          declarations: [BuildComponent, MockComponent],
+          declarations: [BuildComponent, DummyComponent],
           imports: [
             ToolbarModule, StatusIconModule, RouterTestingModule.withRoutes(
-              [{path: '404', component: MockComponent} ]
+              [{path: '404', component: DummyComponent} ]
             ),
             MatCardModule, MatProgressSpinnerModule, MomentModule
           ],
@@ -84,7 +80,7 @@ describe('BuildComponent', () => {
     location = TestBed.get(Location);
   });
 
-  describe('unit tests', () => {
+  describe('Unit tests', () => {
     it('should start socket connection with correct project/build IDs', () => {
       fixture.detectChanges();
       expect(buildLogWebsocketService.connect).toHaveBeenCalledWith('123', 3);
@@ -99,7 +95,7 @@ describe('BuildComponent', () => {
       expect(component.build).toBe(mockBuild);
     });
 
-    it('should redirect if build returns 404', fakeAsync(() => {
+    it('should redirect if API returns an error', fakeAsync(() => {
       fixture.detectChanges();
       expect(dataService.getBuild).toHaveBeenCalledWith('123', 3);
 

--- a/web/app/build/build.component.ts
+++ b/web/app/build/build.component.ts
@@ -1,5 +1,5 @@
 import {Component, HostBinding, OnDestroy, OnInit} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {ParamMap} from '@angular/router/src/shared';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
@@ -30,6 +30,7 @@ export class BuildComponent implements OnInit, OnDestroy {
   constructor(
       private readonly dataService: DataService,
       private readonly buildLogSocketService: BuildLogWebsocketService,
+      private readonly router: Router,
       private readonly route: ActivatedRoute) {}
 
   ngOnDestroy(): void {
@@ -57,6 +58,9 @@ export class BuildComponent implements OnInit, OnDestroy {
             this.closeWebsocket();
           }
           this.updateBreadcrumbsLabels(build.projectId, build.number);
+        }, (error) => {
+          // @TODO check what type of error we get from api and act accordingly
+          this.router.navigate(['/404']);
         });
   }
 

--- a/web/app/project/project.component.spec.ts
+++ b/web/app/project/project.component.spec.ts
@@ -28,6 +28,7 @@ import {SettingsDialogComponent} from './settings-dialog/settings-dialog.compone
 import {SettingsDialogModule} from './settings-dialog/settings-dialog.modules';
 
 describe('ProjectComponent', () => {
+  let location: Location;
   let component: ProjectComponent;
   let fixture: ComponentFixture<ProjectComponent>;
   let fixtureEl: DebugElement;
@@ -57,6 +58,10 @@ describe('ProjectComponent', () => {
                 path: 'project/:projectId/build/:buildId',
                 component: DummyComponent
               },
+              {
+                path: '404',
+                component: DummyComponent
+              }
             ])
           ],
           declarations: [ProjectComponent, DummyComponent],
@@ -74,6 +79,8 @@ describe('ProjectComponent', () => {
     fixture = TestBed.createComponent(ProjectComponent);
     fixtureEl = fixture.debugElement;
     component = fixture.componentInstance;
+
+    location = TestBed.get(Location);
   }));
 
   describe('Unit tests', () => {
@@ -90,6 +97,16 @@ describe('ProjectComponent', () => {
       expect(component.project.builds.length).toBe(2);
       expect(component.project.builds[0].sha).toBe('asdfshzdggfdhdfh4');
     });
+
+    it('should redirect if API returns an error', fakeAsync(() => {
+      fixture.detectChanges();
+      expect(dataService.getProject).toHaveBeenCalledWith('123');
+
+      projectSubject.error({});
+      tick();
+
+      expect(location.path()).toBe('/404');
+    }));
 
     it('should update breadcrumbs after loading project', () => {
       fixture.detectChanges();  // onInit()
@@ -222,11 +239,10 @@ describe('ProjectComponent', () => {
         });
 
         it('should go to build when clicked', fakeAsync(() => {
-             const location = TestBed.get(Location);
-             rowEls[0].nativeElement.click();
-             tick();
-             expect(location.path()).toBe('/project/12/build/2');
-           }));
+          rowEls[0].nativeElement.click();
+          tick();
+          expect(location.path()).toBe('/project/12/build/2');
+        }));
 
         it('should not show rebuild button on successful builds', () => {
           // First row is successful build

--- a/web/app/project/project.component.ts
+++ b/web/app/project/project.component.ts
@@ -2,7 +2,7 @@ import 'rxjs/add/operator/switchMap';
 
 import {Component, OnInit, ViewChild} from '@angular/core';
 import {MatDialog, MatDialogConfig, MatTable} from '@angular/material';
-import {ActivatedRoute, ParamMap} from '@angular/router';
+import {ActivatedRoute, ParamMap, Router} from '@angular/router';
 
 import {Breadcrumb} from '../common/components/toolbar/toolbar.component';
 import {Build} from '../models/build';
@@ -30,6 +30,7 @@ export class ProjectComponent implements OnInit {
 
   constructor(
       private readonly dataService: DataService,
+      private readonly router: Router,
       private readonly route: ActivatedRoute,
       private readonly dialog: MatDialog) {}
 
@@ -42,6 +43,9 @@ export class ProjectComponent implements OnInit {
           this.tableDataSource = this.project.builds;
           this.updateBreadcrumbs(this.project.name);
           this.isLoading = false;
+        }, (error) => {
+          // @TODO check what type of error we get from api and act accordingly
+          this.router.navigate(['/404']);
         });
   }
 

--- a/web/app/root/routing.module.ts
+++ b/web/app/root/routing.module.ts
@@ -13,6 +13,8 @@ import {ProjectComponent} from '../project/project.component';
 import {ProjectModule} from '../project/project.module';
 import {SignupComponent} from '../signup/signup.component';
 import {SignupModule} from '../signup/signup.module';
+import {PageNotFoundComponent} from '../system/pagenotfound.component';
+import {SystemModule} from '../system/system.module';
 
 const routes: Routes = [
   {path: '', redirectTo: '/dashboard', pathMatch: 'full'},
@@ -22,11 +24,13 @@ const routes: Routes = [
   {path: 'login', component: LoginComponent},
   {path: 'signup', component: SignupComponent},
   {path: 'onboard', component: OnboardComponent},
+  {path: '404', component: PageNotFoundComponent},
+  {path: '**', redirectTo: '/404'}
 ];
 
 @NgModule({
   imports: [
-    DashboardModule, ProjectModule, BuildModule, LoginModule, SignupModule, OnboardModule,
+    DashboardModule, ProjectModule, BuildModule, LoginModule, SignupModule, OnboardModule, SystemModule,
     RouterModule.forRoot(routes)
   ],
   exports: [RouterModule]

--- a/web/app/system/pagenotfound.component.html
+++ b/web/app/system/pagenotfound.component.html
@@ -1,4 +1,4 @@
-<mat-card class="page-not-found">
+<mat-card class="fci-page-not-found">
     <h1>Uh oh</h1>
     <p>We couldn't find the page you were looking for.</p>
 

--- a/web/app/system/pagenotfound.component.html
+++ b/web/app/system/pagenotfound.component.html
@@ -1,0 +1,6 @@
+<mat-card class="page-not-found">
+    <h1>Uh oh</h1>
+    <p>We couldn't find the page you were looking for.</p>
+
+    <a href="/" mat-raised-button color="primary">Go to dashboard</a>
+</mat-card>

--- a/web/app/system/pagenotfound.component.scss
+++ b/web/app/system/pagenotfound.component.scss
@@ -1,0 +1,4 @@
+.page-not-found {
+    margin: 100px auto 0;
+    max-width: 450px;
+}

--- a/web/app/system/pagenotfound.component.scss
+++ b/web/app/system/pagenotfound.component.scss
@@ -1,4 +1,4 @@
-.page-not-found {
+.fci-page-not-found {
     margin: 100px auto 0;
     max-width: 450px;
 }

--- a/web/app/system/pagenotfound.component.ts
+++ b/web/app/system/pagenotfound.component.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'fci-page-not-found',
+  templateUrl: './pagenotfound.component.html',
+  styleUrls: ['./pagenotfound.component.scss']
+})
+export class PageNotFoundComponent {}

--- a/web/app/system/system.module.ts
+++ b/web/app/system/system.module.ts
@@ -1,0 +1,26 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {ReactiveFormsModule} from '@angular/forms';
+import {MatButtonModule, MatIconModule, MatCardModule} from '@angular/material';
+
+import {PageNotFoundComponent} from './pagenotfound.component';
+
+@NgModule({
+  declarations: [
+    PageNotFoundComponent,
+  ],
+  entryComponents: [
+    PageNotFoundComponent,
+  ],
+  imports: [
+    /** Angular Library Imports */
+    ReactiveFormsModule, CommonModule,
+    /** Internal Imports */
+    /** Angular Material Imports */
+    MatButtonModule, MatCardModule, MatIconModule
+    /** Third-Party Module Imports */
+  ],
+  providers: [],
+})
+export class SystemModule {
+}


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving

This PR _partially_ fixes #578 by adding a basic PageNotFound component and redirecting failing API calls on /project/_unknown-project-id_ and /project/1/build/_unknown-build-id_ towards it.

Run the project and try the following URL's:

- http://0.0.0.0:8080/unknown-url
- http://0.0.0.0:8080/project/unknown-project-id
- http://0.0.0.0:8080/project/ _find a existing project id_ /builds/unknown-build-id

These should redirect to /404 and show a simple dialog as in the image below.

This PR does not show errors or backtraces as @taquitos and @minuscorp mentioned in #578, as I'm not sure how to approach this (hence _partially fixes_). Hopefully this can work as a starting point and these requests can be implemented later on.

Also, the error handling on project-detail and build-detail pages could be improved (marked as TODO in this PR) by checking what kind of error gets returned (404, 500, etc.)

![image](https://user-images.githubusercontent.com/2340997/43079686-0d77f330-8e8e-11e8-8fb9-66365bc3d3a3.png)

