### PR TITLE
Helper to expect when an input is properly connected to the form control

### DIFF
--- a/web/app/common/test_helpers/element_helper_functions.ts
+++ b/web/app/common/test_helpers/element_helper_functions.ts
@@ -1,4 +1,6 @@
 import {DebugElement} from '@angular/core';
+import {ComponentFixture} from '@angular/core/testing';
+import {FormGroup} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 
 function doesElementExist(context: DebugElement, selector: string): boolean {
@@ -45,4 +47,23 @@ export function expectElementNotToExist(
           false,
           `An element was expected NOT to exist, but was found\nSelector: '${
               selector}'`);
+}
+
+export function expectInputControlToBeAttachedToForm(
+    fixture: ComponentFixture<any>, formControlName: string, form: FormGroup) {
+  const controlEl: HTMLInputElement =
+      getElement(
+          fixture.debugElement, `input[formcontrolname="${formControlName}"]`)
+          .nativeElement;
+
+  controlEl.value = '10';
+  controlEl.dispatchEvent(new Event('input'));
+  fixture.detectChanges();
+
+  expect(form.get(formControlName).value).toBe('10');
+
+  form.patchValue({[formControlName]: '12'});
+  fixture.detectChanges();
+
+  expect(controlEl.value).toBe('12');
 }

--- a/web/app/dashboard/add-project-dialog/add-project-dialog.component.spec.ts
+++ b/web/app/dashboard/add-project-dialog/add-project-dialog.component.spec.ts
@@ -10,7 +10,7 @@ import {Subject} from 'rxjs/Subject';
 
 import {FormSpinnerModule} from '../../common/components/form-spinner/form-spinner.module';
 // tslint:disable-next-line:max-line-length
-import {expectElementNotToExist, expectElementToExist, getElement, getElementText} from '../../common/test_helpers/element_helper_functions';
+import {expectElementNotToExist, expectElementToExist, expectInputControlToBeAttachedToForm, getElement, getElementText} from '../../common/test_helpers/element_helper_functions';
 import {mockLanes, mockLanesResponse} from '../../common/test_helpers/mock_lane_data';
 import {mockProjectSummary} from '../../common/test_helpers/mock_project_data';
 import {mockRepositoryList} from '../../common/test_helpers/mock_repository_data';
@@ -131,13 +131,8 @@ describe('AddProjectDialogComponent', () => {
          fixture.detectChanges();
 
          fixture.whenStable().then(() => {
-           expect(projectNameEl.value).toBe('ProjectX');
-
-           projectNameEl.value = 'ProjectY';
-           projectNameEl.dispatchEvent(new Event('input'));
-           fixture.detectChanges();
-
-           expect(component.form.get('name').value).toBe('ProjectY');
+           expectInputControlToBeAttachedToForm(
+               fixture, 'name', component.form);
          });
        }));
 

--- a/web/app/signup/signup.component.spec.ts
+++ b/web/app/signup/signup.component.spec.ts
@@ -6,7 +6,7 @@ import {By} from '@angular/platform-browser';
 import {Router} from '@angular/router';
 import {Subject} from 'rxjs/Subject';
 
-import {getElement, getElementText} from '../common/test_helpers/element_helper_functions';
+import {expectInputControlToBeAttachedToForm, getElement, getElementText} from '../common/test_helpers/element_helper_functions';
 import {UserDetails} from '../common/types';
 import {AuthService} from '../services/auth.service';
 import {DataService} from '../services/data.service';
@@ -68,32 +68,14 @@ describe('SignupComponent', () => {
   });
 
   describe('after OnInit', () => {
-    let tokenEl: HTMLInputElement;
-
     beforeEach(() => {
       fixture.detectChanges();
-      tokenEl =
-          getElement(fixture.debugElement, 'input[formcontrolname="token"]')
-              .nativeElement;
     });
 
     for (const control_id of FORM_CONTROL_IDS) {
       it(`should have all the ${control_id} control properly attached`, () => {
-        const controlEl: HTMLInputElement =
-            getElement(
-                fixture.debugElement, `input[formcontrolname="${control_id}"]`)
-                .nativeElement;
-
-        controlEl.value = '10';
-        controlEl.dispatchEvent(new Event('input'));
-        fixture.detectChanges();
-
-        expect(component.form.get(control_id).value).toBe('10');
-
-        component.form.patchValue({[control_id]: '12'});
-        fixture.detectChanges();
-
-        expect(controlEl.value).toBe('12');
+        expectInputControlToBeAttachedToForm(
+            fixture, control_id, component.form);
       });
     }
 


### PR DESCRIPTION
This is also gonna help test some of the onboarding forms i'm adding.

```
- [ ] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [x] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving
```