### PR TITLE
Include Roboto font and font-family fallback

### DIFF
--- a/web/app/dashboard/add-project-dialog/add-project-dialog.component.scss
+++ b/web/app/dashboard/add-project-dialog/add-project-dialog.component.scss
@@ -1,5 +1,5 @@
 .fci-dialog-form-section {
-    font-family: 'Roboto';
+    font-family: 'Roboto', sans-serif;
     padding-bottom: 16px;
     &:last-child {
         padding-bottom: 74px;

--- a/web/global/input.scss
+++ b/web/global/input.scss
@@ -1,7 +1,7 @@
 .fci-input-container {
     padding-bottom: 16px;
     label {
-        font-family: 'Roboto';
+        font-family: 'Roboto', sans-serif;
         color: rgba(0, 0, 0, 0.54);
         font-size: 13px;
         display: block;
@@ -48,7 +48,7 @@
         /** Font */
         color: rgba(0, 0, 0, 0.87);
         font-size: 16px;
-        font-family: 'Roboto';
+        font-family: 'Roboto', sans-serif;
         font-weight: 400;
         line-height: 24px;
         /** Inner text inherits content wrapping */

--- a/web/global/theme.scss
+++ b/web/global/theme.scss
@@ -1,7 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
 
 @import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
-@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500');
 
 // TODO: using theme functions to set the themes instead of overriding manually
 

--- a/web/global/theme.scss
+++ b/web/global/theme.scss
@@ -1,8 +1,10 @@
 /* You can add global styles to this file, and also import other style files */
 
 @import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
+@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500');
+
 // TODO: using theme functions to set the themes instead of overriding manually
-// TODO: Find out if Roboto is packaged in Angular Material
+
 body {
     margin: 0;
     font-family: 'Google Sans', sans-serif; // Default font-family

--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,9 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
 </head>
 
 <body>


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build
- [ ] If there is an existing issue, make sure to add `Fixes ...` as part of the PR body to reference the issue you're solving

Roboto does not seem to be included by default in Angular Material, as seen in the image below and [here](https://material.angular.io/guide/typography#usage).

![without-roboto](https://user-images.githubusercontent.com/2340997/43120417-647f833c-8f1a-11e8-8407-e9748fef81c4.png)

Included Roboto font from Google Fonts and properly set-up fallbacks if Google Fonts stopped working, resulting in:

![with-roboto](https://user-images.githubusercontent.com/2340997/43120511-be1928da-8f1a-11e8-8e13-89d13631dbef.png)



**Alternative** would be to remove all references to Roboto Font and just use the Google Sans font everywhere.





