### PR TITLE
fix issues with agent using wrong env during invocation

### DIFF
--- a/agent/client.rb
+++ b/agent/client.rb
@@ -6,8 +6,17 @@ module FastlaneCI
     ##
     # A sample client that can be used to make a request to the service.
     class Client
-      def initialize(host)
-        @stub = Proto::Agent::Stub.new("#{host}:#{PORT}", :this_channel_is_insecure)
+      ##
+      # the host that the client is connecting to
+      attr_reader :host
+
+      # the port that the client is connecting to
+      attr_reader :port
+
+      def initialize(host, port = PORT)
+        @host = host
+        @port = port
+        @stub = Proto::Agent::Stub.new("#{@host}:#{@port}", :this_channel_is_insecure)
       end
 
       def request_spawn(bin, *params, env: {})
@@ -16,12 +25,11 @@ module FastlaneCI
       end
 
       def request_run_fastlane(bin, *params, env: {})
-        command = Proto::Command.new(bin: bin, parameters: params, env: env)
+        command = Proto::Command.new(bin: bin, parameters: params.compact, env: env)
         @stub.run_fastlane(Proto::InvocationRequest.new(command: command))
       end
     end
   end
-  @file && @file.close
 end
 
 if $0 == __FILE__

--- a/spec/agent/invocation/recipes_spec.rb
+++ b/spec/agent/invocation/recipes_spec.rb
@@ -6,24 +6,41 @@ describe FastlaneCI::Agent::Recipes do
   class RecipesIncludingClass
     include FastlaneCI::Agent::Recipes
   end
+  subject { RecipesIncludingClass.new }
+
   before do
-    @recipes_including_class = RecipesIncludingClass.new
-    @recipes_including_class.output_queue = queue
+    subject.output_queue = queue
   end
 
   it "shell commands put the command, and stdout and stderr on the output queue" do
-    @recipes_including_class.sh("echo foo")
+    subject.sh("echo foo")
     expect(queue.pop).to eq("echo foo")
     expect(queue.pop).to eq("foo\n")
 
-    @recipes_including_class.sh("echo error 1>&2")
+    subject.sh("echo error 1>&2")
     expect(queue.pop).to eq("echo error 1>&2")
     expect(queue.pop).to eq("error\n")
   end
 
+  it "makes sure the bundler env is clean when shelling out" do
+    ENV["BUNDLER_GEMFILE"] = "/foo/bar/Gemfile"
+    subject.sh("env")
+
+    expect(queue.pop).to_not(include("BUNDLER_GEMFILE")) until queue.empty?
+  end
+
   it "raises an exception if a command exits non-zero" do
     expect do
-      @recipes_including_class.sh("false")
+      subject.sh("false")
     end.to raise_error(SystemCallError)
+  end
+
+  it "runs a command with the environment" do
+    command = FastlaneCI::Proto::Command.new(bin: "env", env: { "FASTLANE_CI_ARTIFACTS" => "/tmp/ci/artifacts" })
+    subject.run_fastlane(command)
+    rows = []
+    rows << queue.pop until queue.empty?
+
+    expect(rows).to include("FASTLANE_CI_ARTIFACTS=/tmp/ci/artifacts\n")
   end
 end


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build

This PR fixes some issues encountered by the agent running `bundle install`. It was inheriting the bundle env from the agent's Gemfile... *not* the Gemfile under test.

Using `Bundler.with_clean_env` fixes the issue. Also includes some small fixes and refactors.

This PR supersedes #1091