### PR TITLE
use Procfile for development as well

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec rake prod
+web: bundle exec rackup --host 0.0.0.0 --port 8080 --env production
 worker: bundle exec ruby agent/service.rb

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bundle exec rackup --host 0.0.0.0 --port 8080 --env development
+worker: bundle exec ruby agent/service.rb

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,15 @@
 task :dev do
-  sh "bundle exec rackup --host 0.0.0.0 --port 8080 --env development"
+  unless system("which foreman", out: File::NULL)
+    raise "`foreman` is now required for process management. `sudo gem install foreman`"
+  end
+  sh "foreman start -f Procfile.dev"
 end
 
 task :prod do
-  sh "bundle exec rackup --host 0.0.0.0 --port 8080 --env production"
+  unless system("which foreman", out: File::NULL)
+    raise "`foreman` is now required for process management. `sudo gem install foreman`"
+  end
+  sh "foreman start"
 end
 
 task :dev_bootstrap do

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
+# foreman is not included in the Gemfile, more context
+# https://github.com/ddollar/foreman/pull/678#issuecomment-398211757
+
 task :dev do
   unless system("which foreman", out: File::NULL)
     raise "`foreman` is now required for process management. `sudo gem install foreman`"


### PR DESCRIPTION
This PR adds a separate Procfile for development. The workflow `rake dev` is updated to do the right thing. This is required because now we have 2 processes required for usage.