### PR TITLE
add running status to the front-end and github_service

### DIFF
--- a/app/services/code_hosting/git_hub_service.rb
+++ b/app/services/code_hosting/git_hub_service.rb
@@ -216,7 +216,7 @@ module FastlaneCI
       case state
       when "success"
         "All green"
-      when "pending"
+      when "pending", "running"
         "Still running"
       when "installing_xcode"
         "Installing Xcode"
@@ -243,6 +243,7 @@ module FastlaneCI
         "error",
         "failure",
         "pending",
+        "running",
         "success",
         "ci_problem",
         "missing_fastfile",

--- a/web/app/common/components/status-icon/status-icon.component.spec.ts
+++ b/web/app/common/components/status-icon/status-icon.component.spec.ts
@@ -32,6 +32,13 @@ const EXPECTED_STATUSES = new Map<BuildStatus, ExpectedIcon>([
     }
   ],
   [
+    BuildStatus.RUNNING, {
+      iconString: 'directions_run',
+      class: 'fci-status-icon-running',
+      tooltipString: 'Running'
+    }
+  ],
+  [
     BuildStatus.FAILED, {
       iconString: 'cancel',
       class: 'fci-status-icon-failed',

--- a/web/app/common/components/status-icon/status-icon.component.ts
+++ b/web/app/common/components/status-icon/status-icon.component.ts
@@ -5,7 +5,7 @@ import {BuildStatus} from '../../constants';
 const FAILED_STATUSES: BuildStatus[] =
     [BuildStatus.FAILED, BuildStatus.MISSING_FASTFILE];
 
-const RUNNING_STATUSES: BuildStatus[] = [BuildStatus.INSTALLING_XCODE];
+const RUNNING_STATUSES: BuildStatus[] = [BuildStatus.INSTALLING_XCODE, BuildStatus.RUNNING];
 
 @Component({
   selector: 'fci-status-icon',
@@ -43,6 +43,8 @@ export class StatusIconComponent {
         return 'Internal CI Issue';
       case BuildStatus.PENDING:
         return 'Pending';
+      case BuildStatus.RUNNING:
+        return 'Running';
       default:
         throw new Error(`Unknown status type ${this.status}`);
     }

--- a/web/app/common/constants.ts
+++ b/web/app/common/constants.ts
@@ -2,6 +2,7 @@ export enum BuildStatus {
   SUCCESS = 'success',
   FAILED = 'failure',
   PENDING = 'pending',
+  RUNNING = 'running',
   MISSING_FASTFILE = 'missing_fastfile',
   INTERNAL_ISSUE = 'ci_problem',
   INSTALLING_XCODE = 'installing_xcode'
@@ -23,7 +24,7 @@ export function fastlaneStatusToEnum(status: FastlaneStatus): BuildStatus {
     case 'pending':
       return BuildStatus.PENDING;
     case 'running':
-      return BuildStatus.PENDING;
+      return BuildStatus.RUNNING;
     case 'missing_fastfile':
       return BuildStatus.MISSING_FASTFILE;
     case 'ci_problem':


### PR DESCRIPTION
- [x] I have run `rspec` and corrected all errors
- [x] I have run `rubocop` and corrected all errors
- [x] I have run `npm run test` and corrected all errors
- [x] I have tested this change locally and tried to launch the server as well as access a project, and with that at least one build

This PR handles some JS exceptions, as well as possibly a bug in the remote runner that prevents statuses being shown.