### PR TITLE
apparently github only gives us a few status options. map running to pending

### DIFF
--- a/app/services/code_hosting/git_hub_service.rb
+++ b/app/services/code_hosting/git_hub_service.rb
@@ -260,9 +260,10 @@ module FastlaneCI
       # to use the official GitHub terms
       #
       # All available states https://developer.github.com/v3/repos/statuses/
-      if state == "missing_fastfile" || state == "ci_problem"
+      case state
+      when "missing_fastfile", "ci_problem"
         state = "failure"
-      elsif state == "installing_xcode"
+      when "installing_xcode", "running"
         state = "pending"
       end
 


### PR DESCRIPTION
this PR maps `running` into `pending` on github's status: https://developer.github.com/v3/repos/statuses/
